### PR TITLE
Rename Japanese translation to  ja.yml

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,5 @@
 ---
-jp: 
+ja: 
   'no': "No"
   'yes': "Yes"
   5_biggest_spenders: "5 Biggest Spenders"


### PR DESCRIPTION
Hi,

I was just wondering why the Japanese translation has the filename jp.yml when ja is the iso language code.

Correct me if I'm wrong but the locales should use the language iso first, then the country iso? like language-COUNTRY

I understand that this would break anyone already using this... but i though it was worth discussing as it would make it more compatible.

This was messing up a lot of other I18n gems I'm using...(I18nData etc)
