### PR TITLE
'on_hand' doesn't mean 'receiving day' in ja locale

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -88,7 +88,7 @@ ja:
         description: "説明"
         master_price: "値段"
         name: "商品名"
-        on_hand: "入荷日"
+        on_hand: "入荷数"
         shipping_category: "配達区間"
         tax_category: "税区"
       product_group: 
@@ -591,7 +591,7 @@ ja:
     product_not_deleted: "商品を削除することが出来ませんでした"
     variant_deleted: "種類を削除しました"
     variant_not_deleted: "種類を削除することが出来ませんでした"
-  on_hand: "入荷日"
+  on_hand: "入荷数"
   operation: Operation
   option_type: "オプションタイプ"
   option_types: "オプションタイプ"


### PR DESCRIPTION
In ja locale, 'on_hand' is translated into '入荷日'.
'入荷日' means 'Receiving day'.

'on_hand' means 'the number of stock', isn't it?
So, I translated it into '入荷数'.

I'm not a pro-translator. Please discuss it.
