### PR TITLE
Fixing #54 undefined method `read_file` for main:Object.

### DIFF
--- a/lib/tasks/i18n.rake
+++ b/lib/tasks/i18n.rake
@@ -89,7 +89,7 @@ namespace :spree_i18n do
   end
 
   def get_translation_keys(gem_name)
-    (dummy_comments, words) = read_file(File.dirname(__FILE__) + "/../../default/#{gem_name}.yml", "en")
+    (dummy_comments, words) = Spree::I18nUtils.read_file(File.dirname(__FILE__) + "/../../default/#{gem_name}.yml", "en")
       words
   end
 


### PR DESCRIPTION
readfile should be called in context of its module
Spree:I18nUtils.read_file
