### PR TITLE
Add en-NZ

### DIFF
--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -1,6 +1,6 @@
 ---
 en-NZ:
-  a_copy_of_all_mail_will_be_sent_to_the_following_addresses: A copy of all mail be sent to the following addresses
+  a_copy_of_all_mail_will_be_sent_to_the_following_addresses: "A copy of all mail be sent to the following addresses"
   abbreviation: Abbreviation
   access_denied: "Access Denied"
   account: Account
@@ -13,21 +13,21 @@ en-NZ:
     listing: Listing
     new: New
     update: Update
-  active: "Active"
+  active: Active
   activerecord:
     attributes:
       spree/address:
         address1: Address
         address2: "Address (contd.)"
-        city: Town / City
-        country: "Country"
+        city: "Town / City"
+        country: Country
         first_name_begins_with: "First Name Begins With"
         firstname: "First Name"
         last_name_begins_with: "Last Name Begins With"
         lastname: "Last Name"
         phone: Phone
-        state: "Region"
-        zipcode: "Postcode"
+        state: Region
+        zipcode: Postcode
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -51,13 +51,13 @@ en-NZ:
       spree/order:
         checkout_complete: "Checkout Complete"
         completed_at: "Completed At"
-        created_at: Order Date
-        email: Customer E-Mail
+        created_at: "Order Date"
+        email: "Customer E-Mail"
         ip_address: "IP Address"
         item_total: "Item Total"
         number: Number
-        payment_state: Payment State
-        shipment_state: Shipment State
+        payment_state: "Payment State"
+        shipment_state: "Shipment State"
         special_instructions: "Special Instructions"
         state: State
         total: Total
@@ -92,12 +92,12 @@ en-NZ:
         advertise: Advertise
         code: Code
         description: Description
-        event_name: Event Name
-        expires_at: Expires At
+        event_name: "Event Name"
+        expires_at: "Expires At"
         name: Name
         path: Path
-        starts_at: Starts At
-        usage_limit: Usage Limit
+        starts_at: "Starts At"
+        usage_limit: "Usage Limit"
       spree/property:
         name: Name
         presentation: Presentation
@@ -115,7 +115,7 @@ en-NZ:
         name: Name
       spree/tax_rate:
         amount: Rate
-        included_in_price: Included in Price
+        included_in_price: "Included in Price"
       spree/taxon:
         name: Name
         permalink: Permalink
@@ -124,7 +124,7 @@ en-NZ:
         name: Name
       spree/user:
         email: Email
-        password: "Password"
+        password: Password
         password_confirmation: "Password Confirmation"
       spree/variant:
         cost_price: "Cost Price"
@@ -142,8 +142,8 @@ en-NZ:
         one: Address
         other: Addresses
       spree/cheque_payment:
-        one: Cheque Payment
-        other: Cheque Payments
+        one: "Cheque Payment"
+        other: "Cheque Payments"
       spree/country:
         one: Country
         other: Countries
@@ -178,8 +178,8 @@ en-NZ:
         one: Prototype
         other: Prototypes
       spree/return_authorization:
-        one: Return Authorization
-        other: Return Authorizations
+        one: "Return Authorization"
+        other: "Return Authorizations"
       spree/role:
         one: Roles
         other: Roles
@@ -214,7 +214,7 @@ en-NZ:
         one: Zone
         other: Zones
   add: Add
-  add_action_of_type: Add action of type
+  add_action_of_type: "Add action of type"
   add_category: "Add Category"
   add_country: "Add Country"
   add_new_header: "Add New Header"
@@ -224,39 +224,39 @@ en-NZ:
   add_option_value: "Add Option Value"
   add_product: "Add Product"
   add_product_properties: "Add Product Properties"
-  add_rule_of_type: Add rule of type
+  add_rule_of_type: "Add rule of type"
   add_scope: "Add a scope"
   add_state: "Add Region"
   add_to_cart: "Add To Cart"
   add_zone: "Add Zone"
-  additional_item: Additional Item Cost
+  additional_item: "Additional Item Cost"
   address: Address
   address_information: "Address Information"
   adjustment: Adjustment
-  adjustment_total: Adjustment Total
+  adjustment_total: "Adjustment Total"
   adjustments: Adjustments
   admin:
     mail_methods:
-      send_testmail: 'Send Testmail'
+      send_testmail: "Send Testmail"
       testmail:
-        delivery_error: 'Testmail delivery error'
-        delivery_success: 'Testmail sent successfully'
-        error: 'Testmail error: %{e}'
+        delivery_error: "Testmail delivery error"
+        delivery_success: "Testmail sent successfully"
+        error: "Testmail error: %{e}"
   administration: Administration
-  all: "All"
-  all_departments: All departments
+  all: All
+  all_departments: "All departments"
   allow_backorders: "Allow Backorders"
-  allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
-  allow_ssl_in_production: Allow SSL to be used in production mode
-  allow_ssl_in_staging: Allow SSL to be used in staging mode
+  allow_ssl_in_development_and_test: "Allow SSL to be used when in development and test modes"
+  allow_ssl_in_production: "Allow SSL to be used in production mode"
+  allow_ssl_in_staging: "Allow SSL to be used in staging mode"
   allowed_ssl_in_production_mode: "SSL will %{not} be used in production"
-  already_registered: Already Registered?
-  alt_text: Alternative Text
-  alternative_phone: Alternative Phone
+  already_registered: "Already Registered?"
+  alt_text: "Alternative Text"
+  alternative_phone: "Alternative Phone"
   amount: Amount
-  analytics_trackers: Analytics Trackers
+  analytics_trackers: "Analytics Trackers"
   and: and
-  apply: "Apply"
+  apply: Apply
   are_you_sure: "Are you sure"
   are_you_sure_category: "Are you sure you want to delete this category?"
   are_you_sure_delete: "Are you sure you want to delete this record?"
@@ -270,12 +270,12 @@ en-NZ:
   attachment_styles: "Paperclip Styles"
   authorization_failure: "Authorization Failure"
   authorized: Authorized
-  availability: "Availability"
+  availability: Availability
   available_on: "Available On"
   available_taxons: "Available Taxons"
-  awaiting_return: Awaiting Return
+  awaiting_return: "Awaiting Return"
   back: Back
-  back_end: Back End
+  back_end: "Back End"
   back_to_store: "Go Back To Store"
   backordered: Backordered
   backordering_is_allowed: "Backordering %{not} allowed"
@@ -287,29 +287,29 @@ en-NZ:
   calculator: Calculator
   calculator_settings_warning: "If you are changing the calculator type, you must save first before you can edit the calculator settings"
   cancel: cancel
-  cancel_my_account: Cancel my account
-  cancel_my_account_description: "Unhappy?"
+  cancel_my_account: "Cancel my account"
+  cancel_my_account_description: Unhappy?
   canceled: Canceled
-  cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
-  cannot_create_returns: Cannot create returns as this order has no shipped units.
+  cannot_create_payment_without_payment_methods: "You cannot create a payment for an order without any payment methods defined."
+  cannot_create_returns: "Cannot create returns as this order has no shipped units."
   cannot_perform_operation: "Cannot perform requested operation"
   capture: Capture
   card_code: "Card Code"
   card_details: "Card details"
   card_number: "Card Number"
-  card_type_is: Card type is
+  card_type_is: "Card type is"
   cart: Cart
   categories: Categories
   category: Category
   change: Change
   change_language: "Change Language"
   change_my_password: "Change my password"
-  charge_total: Charge Total
+  charge_total: "Charge Total"
   charged: Charged
   charges: Charges
   checkout: Checkout
   cheque: Cheque
-  city: Town / City
+  city: "Town / City"
   clone: Clone
   code: Code
   combine: Combine
@@ -324,23 +324,23 @@ en-NZ:
   confirm_password: "Password Confirmation"
   continue: Continue
   continue_shopping: "Continue shopping"
-  copy_all_mails_to: Copy All Mails To
+  copy_all_mails_to: "Copy All Mails To"
   cost_price: "Cost Price"
   count_of_reduced_by: "count of '%{name}' reduced by %{count}"
   country: Country
   country_based: "Country Based"
   coupon: Coupon
-  coupon_code: Coupon code
+  coupon_code: "Coupon code"
   create: Create
   create_a_new_account: "Create a new account"
-  create_user_account: Create User Account
+  create_user_account: "Create User Account"
   created_successfully: "Created Successfully"
   credit: Credit
   credit_card: "Credit Card"
   credit_card_capture_complete: "Credit Card Was Captured"
   credit_card_payment: "Credit Card Payment"
   credit_owed: "Credit Owed"
-  credit_total: Credit Total
+  credit_total: "Credit Total"
   creditcard: Creditcard
   creditcards: Creditcards
   credits: Credits
@@ -349,15 +349,15 @@ en-NZ:
   customer_details: "Customer Details"
   customer_details_updated: "The customer's details have been updated."
   customer_search: "Customer Search"
-  date_created: Date created
+  date_created: "Date created"
   date_range: "Date Range"
   debit: Debit
   default: Default
-  default_meta_description: Default Meta Description
-  default_meta_keywords: Default Meta Keywords
-  default_seo_title: Default Seo Title
-  default_tax: Default Tax
-  default_tax_zone: Default Tax Zone
+  default_meta_description: "Default Meta Description"
+  default_meta_keywords: "Default Meta Keywords"
+  default_seo_title: "Default Seo Title"
+  default_tax: "Default Tax"
+  default_tax_zone: "Default Tax Zone"
   delete: Delete
   delivery: Delivery
   depth: Depth
@@ -370,15 +370,15 @@ en-NZ:
   display: Display
   edit: Edit
   edit_general_settings: "Edit General Settings"
-  editing_billing_integration: Editing Billing Integration
+  editing_billing_integration: "Editing Billing Integration"
   editing_category: "Editing Category"
-  editing_mail_method: Editing Mail Method
+  editing_mail_method: "Editing Mail Method"
   editing_option_type: "Editing Option Type"
   editing_option_types: "Editing Option Types"
-  editing_payment_method: Editing Payment Method
+  editing_payment_method: "Editing Payment Method"
   editing_product: "Editing Product"
   editing_product_group: "Editing Product Group"
-  editing_promotion: Editing Promotion
+  editing_promotion: "Editing Promotion"
   editing_property: "Editing Property"
   editing_prototype: "Editing Prototype"
   editing_shipping_category: "Editing Shipping Category"
@@ -386,23 +386,23 @@ en-NZ:
   editing_state: "Editing Region"
   editing_tax_category: "Editing Tax Category"
   editing_tax_rate: "Editing Tax Rate"
-  editing_tracker: Editing Tracker
+  editing_tracker: "Editing Tracker"
   editing_user: "Editing User"
   editing_zone: "Editing Zone"
   email: Email
   email_address: "Email Address"
   email_server_settings_description: "Set email server settings."
-  empty: "Empty"
+  empty: Empty
   empty_cart: "Empty Cart"
   enable_login_via_login_password: "Use standard email/password"
   enable_login_via_openid: "Use OpenID instead"
-  enable_mail_delivery: Enable Mail Delivery
+  enable_mail_delivery: "Enable Mail Delivery"
   ending_in: "Ending in"
-  enter_at_least_five_letters: Enter at least five letters of customer name
-  enter_exactly_as_shown_on_card: Please enter exactly as shown on the card
+  enter_at_least_five_letters: "Enter at least five letters of customer name"
+  enter_exactly_as_shown_on_card: "Please enter exactly as shown on the card"
   enter_password_to_confirm: "(we need your current password to confirm your changes)"
-  enter_token: Enter Token
-  environment: "Environment"
+  enter_token: "Enter Token"
+  environment: Environment
   error: error
   error_user_destroy_with_orders: "Users with completed orders may not be deleted"
   errors:
@@ -417,39 +417,40 @@ en-NZ:
   events:
     spree:
       cart:
-        add: 'Add to cart'
+        add: "Add to cart"
       checkout:
-        coupon_code_added: Coupon code added
+        coupon_code_added: "Coupon code added"
       content:
-        visited: Visit static content page
+        visited: "Visit static content page"
       order:
         contents_changed: "Order contents changed"
       page_view: "Static page viewed"
       user:
-        signup: 'User signup'
+        signup: "User signup"
   existing_customer: "Existing Customer"
-  expiration: "Expiration"
+  expiration: Expiration
   expiration_month: "Expiration Month"
   expiration_year: "Expiration Year"
   expiry: Expiry
   extension: Extension
   extensions: Extensions
+  false: "No"
   filename: Filename
   final_confirmation: "Final Confirmation"
   finalize: Finalize
-  finalized_payments: Finalized Payments
-  first_item: First Item Cost
+  finalized_payments: "Finalized Payments"
+  first_item: "First Item Cost"
   first_name: "First Name"
   first_name_begins_with: "First Name Begins With"
-  flat_percent: Flat Percent
+  flat_percent: "Flat Percent"
   flat_rate_amount: Amount
   flat_rate_per_item: "Flat Rate (per item)"
   flat_rate_per_order: "Flat Rate (per order)"
   flexible_rate: "Flexible Rate"
   forgot_password: "Forgot Password?"
-  free_shipping: Free Delivery
-  from_state: From State
-  front_end: Front End
+  free_shipping: "Free Delivery"
+  from_state: "From State"
+  front_end: "Front End"
   full_name: "Full Name"
   gateway: Gateway
   gateway_config_unavailable: "Gateway unavailable for environment"
@@ -457,23 +458,23 @@ en-NZ:
   gateway_error: "Gateway Error"
   gateway_setting_description: "Select a payment gateway and configure its settings."
   gateway_settings_warning: "If you are changing the gateway type, you must save first before you can edit the gateway settings"
-  general: "General"
+  general: General
   general_settings: "General Settings"
   general_settings_description: "Configure general Spree settings."
   google_analytics: "Google Analytics"
-  google_analytics_active: "Active"
+  google_analytics_active: Active
   google_analytics_create: "Create New Google Analytics Account"
   google_analytics_id: "Analytics ID"
   google_analytics_new: "New Google Analytics Account"
   google_analytics_setting_description: "Manage Google Analytics ID"
-  guest_checkout: Guest Checkout
-  guest_user_account: Checkout as a Guest
-  has_no_shipped_units: has no shipped units
+  guest_checkout: "Guest Checkout"
+  guest_user_account: "Checkout as a Guest"
+  has_no_shipped_units: "has no shipped units"
   height: Height
   hello_user: "Hello User"
   history: History
-  home: "Home"
-  icon: "Icon"
+  home: Home
+  icon: Icon
   icons_by: "Icons by"
   image: Image
   image_settings: "Image Settings"
@@ -482,35 +483,35 @@ en-NZ:
   images: Images
   images_for: "Images for"
   in_progress: "In Progress"
-  include_in_shipment: Include in Shipment
-  included_in_other_shipment: Included in another Shipment
-  included_in_price: Included in Price
-  included_in_this_shipment: Included in this Shipment
+  include_in_shipment: "Include in Shipment"
+  included_in_other_shipment: "Included in another Shipment"
+  included_in_price: "Included in Price"
+  included_in_this_shipment: "Included in this Shipment"
   included_price_validation: "cannot be selected unless you have set a Default Tax Zone"
   instructions_to_reset_password: "Fill out the form below and instructions to reset your password will be emailed to you:"
   insufficient_stock: "Insufficient stock available, only %{on_hand} remaining"
   integration_settings_warning: "If you are changing the billing integration, you must save first before you can edit the integration settings"
-  intercept_email_address: Intercept Email Address
+  intercept_email_address: "Intercept Email Address"
   intercept_email_instructions: "Override email recipient and replace with this address."
   invalid_search: "Invalid search criteria."
   inventory: Inventory
   inventory_adjustment: "Inventory Adjustment"
   inventory_setting_description: "Inventory Configuration, Backordering, Zero-Stock Display"
   inventory_settings: "Inventory Settings"
-  is_not_available_to_shipment_address: is not available to delivery address
-  issue_number: Issue Number
+  is_not_available_to_shipment_address: "is not available to delivery address"
+  issue_number: "Issue Number"
   item: Item
   item_description: "Item Description"
   item_total: "Item Total"
   item_total_rule:
     operators:
-      gt: greater than
-      gte: greater than or equal to
+      gt: "greater than"
+      gte: "greater than or equal to"
   landing_page_rule:
     path: Path
   last_name: "Last Name"
   last_name_begins_with: "Last Name Begins With"
-  learn_more: Learn More
+  learn_more: "Learn More"
   leave_blank_to_not_change: "(leave blank if you don't want to change it)"
   list: List
   listing_categories: "Listing Categories"
@@ -521,7 +522,7 @@ en-NZ:
   listing_reports: "Listing Reports"
   listing_tax_categories: "Listing Tax Categories"
   listing_users: "Listing Users"
-  live: "Live"
+  live: Live
   loading: Loading
   locale_changed: "Locale Changed"
   logged_in_as: "Logged in as"
@@ -532,51 +533,51 @@ en-NZ:
   login_failed: "Login authentication failed."
   login_name: Login
   logout: Logout
-  look_for_similar_items: Look for similar items
-  maestro_or_solo_cards: Maestro/Solo cards
+  look_for_similar_items: "Look for similar items"
+  maestro_or_solo_cards: "Maestro/Solo cards"
   mail_delivery_enabled: "Mail delivery is enabled"
   mail_delivery_not_enabled: "Mail delivery is not enabled"
-  mail_methods: Mail Methods
-  mail_server_preferences: Mail Server Preferences
-  make_refund: Make refund
+  mail_methods: "Mail Methods"
+  mail_server_preferences: "Mail Server Preferences"
+  make_refund: "Make refund"
   mark_shipped: "Mark Shipped"
   master_price: "Master Price"
   match_choices:
-    all: "All"
-    none: "None"
-    one: "One"
+    all: All
+    none: None
+    one: One
   match_rule: "Products That Must Match:"
-  max_items: Max Items
+  max_items: "Max Items"
   meta_description: "Meta Description"
   meta_keywords: "Meta Keywords"
-  metadata: "Metadata"
+  metadata: Metadata
   minimal_amount: "Minimal Amount"
   missing_required_information: "Missing Required Information"
-  month: "Month"
+  month: Month
   my_account: "My Account"
   my_orders: "My Orders"
   name: Name
   name_or_sku: "Name or SKU (enter at least first 4 characters of product name)"
   new: New
   new_adjustment: "New Adjustment"
-  new_billing_integration: New Billing Integration
+  new_billing_integration: "New Billing Integration"
   new_category: "New category"
   new_customer: "New Customer"
-  new_group: New Group
+  new_group: "New Group"
   new_image: "New Image"
-  new_mail_method: New Mail Method
+  new_mail_method: "New Mail Method"
   new_option_type: "New Option Type"
   new_option_value: "New Option Value"
   new_order: "New Order"
   new_order_completed: "New Order Completed"
   new_payment: "New Payment"
-  new_payment_method: New Payment Method
+  new_payment_method: "New Payment Method"
   new_product: "New Product"
-  new_product_group: New Product Group
-  new_promotion: New Promotion
+  new_product_group: "New Product Group"
+  new_promotion: "New Promotion"
   new_property: "New Property"
   new_prototype: "New Prototype"
-  new_return_authorization: New Return Authorization
+  new_return_authorization: "New Return Authorization"
   new_shipment: "New Shipment"
   new_shipping_category: "New Shipping Category"
   new_shipping_method: "New Delivery Method"
@@ -585,17 +586,16 @@ en-NZ:
   new_tax_rate: "New Tax Rate"
   new_taxon: "New Taxon"
   new_taxonomy: "New Taxonomy"
-  new_tracker: New Tracker
+  new_tracker: "New Tracker"
   new_user: "New User"
   new_variant: "New Variant"
   new_zone: "New Zone"
   next: Next
-  no: "No"
   no_items_in_cart: ""
   no_match_found: "No Match Found"
   no_products_found: "No products found"
   no_results: "No results"
-  no_rules_added: No rules added
+  no_rules_added: "No rules added"
   no_user_found: "No user was found with that email address"
   none: None
   none_available: "None Available"
@@ -632,15 +632,15 @@ en-NZ:
       subject: "Cancellation of Order"
     confirm_email:
       subject: "Order Confirmation"
-  order_not_in_system: That order number is not valid on this site.
+  order_not_in_system: "That order number is not valid on this site."
   order_number: Order
   order_operation_authorize: Authorize
   order_processed_but_following_items_are_out_of_stock: "Your order has been processed, but following items are out of stock:"
   order_processed_successfully: "Your order has been processed successfully"
-  order_state: # keys correspond to Checkout state names:
+  order_state:
     address: address
     adjustments: adjustments
-    awaiting_return: awaiting return
+    awaiting_return: "awaiting return"
     canceled: canceled
     cart: cart
     complete: complete
@@ -650,22 +650,22 @@ en-NZ:
     resumed: resumed
     returned: returned
     skrill: skrill
-  order_summary: Order Summary
+  order_summary: "Order Summary"
   order_sure_want_to: "Are you sure you want to %{event} this order?"
   order_total: "Order Total"
   order_total_message: "The total amount charged to your card will be"
   order_updated: "Order Updated"
   orders: Orders
-  other_payment_options: Other Payment Options
+  other_payment_options: "Other Payment Options"
   out_of_stock: "Out of Stock"
   over_paid: "Over Paid"
   overview: Overview
-  page_only_viewable_when_logged_in: You attempted to visit a page which can only be viewed when you are logged in
-  page_only_viewable_when_logged_out: You attempted to visit a page which can only be viewed when you are logged out
+  page_only_viewable_when_logged_in: "You attempted to visit a page which can only be viewed when you are logged in"
+  page_only_viewable_when_logged_out: "You attempted to visit a page which can only be viewed when you are logged out"
   pagination:
-    next_page: "next page &raquo;"
-    previous_page: "&laquo; previous page"
-    truncate: "&hellip;"
+    next_page: "next page »"
+    previous_page: "« previous page"
+    truncate: "…"
   paid: Paid
   parent_category: "Parent Category"
   password: Password
@@ -676,32 +676,32 @@ en-NZ:
   path: Path
   pay: pay
   payment: Payment
-  payment_actions: "Actions"
+  payment_actions: Actions
   payment_gateway: "Payment Gateway"
   payment_information: "Payment Information"
-  payment_method: Payment Method
-  payment_methods: Payment Methods
-  payment_methods_setting_description: Configure methods customers can use to pay
+  payment_method: "Payment Method"
+  payment_methods: "Payment Methods"
+  payment_methods_setting_description: "Configure methods customers can use to pay"
   payment_processing_failed: "Payment could not be processed, please check the details you entered"
   payment_processor_choose_banner_text: "If you need help choosing a payment processor, please visit"
   payment_processor_choose_link: "our payments page"
-  payment_state: Payment State
+  payment_state: "Payment State"
   payment_states:
-    balance_due: balance due
+    balance_due: "balance due"
     checkout: checkout
     completed: completed
-    credit_owed: credit owed
+    credit_owed: "credit owed"
     failed: failed
     paid: paid
     pending: pending
     processing: processing
     void: void
-  payment_updated: Payment Updated
+  payment_updated: "Payment Updated"
   payments: Payments
-  pending_payments: Pending Payments
+  pending_payments: "Pending Payments"
   permalink: Permalink
   phone: Phone
-  place_order: Place Order
+  place_order: "Place Order"
   please_create_user: "Please create a user account"
   please_define_payment_methods: "Please define some payment methods first."
   powered_by: "Powered by"
@@ -709,8 +709,8 @@ en-NZ:
   preview: Preview
   previous: Previous
   price: Price
-  price_range: Price Range
-  price_sack: Price Sack
+  price_range: "Price Range"
+  price_sack: "Price Sack"
   problem_authorizing_card: "Problem authorizing credit card"
   problem_capturing_card: "Problem capturing credit card"
   problems_processing_order: "We had problems processing your order"
@@ -718,19 +718,19 @@ en-NZ:
   process: Process
   product: Product
   product_details: "Product Details"
-  product_group: Product Group
-  product_group_invalid: Product Group has invalid scopes
-  product_groups: Product Groups
-  product_has_no_description: This product has no description
+  product_group: "Product Group"
+  product_group_invalid: "Product Group has invalid scopes"
+  product_groups: "Product Groups"
+  product_has_no_description: "This product has no description"
   product_properties: "Product Properties"
   product_rule:
-    choose_products: Choose products
+    choose_products: "Choose products"
     label: "Order must contain %{select} of these products"
     match_all: all
-    match_any: at least one
+    match_any: "at least one"
     product_source:
-      group: From product group
-      manual: Manually choose
+      group: "From product group"
+      manual: "Manually choose"
   product_scopes:
     groups:
       price:
@@ -747,165 +747,165 @@ en-NZ:
         name: Values
     scopes:
       ascend_by_name:
-        name: Ascend by product name
+        name: "Ascend by product name"
       ascend_by_updated_at:
-        name: Ascend by actualization date
+        name: "Ascend by actualization date"
       descend_by_name:
-        name: Descend by product name
+        name: "Descend by product name"
       descend_by_updated_at:
-        name: Descend by actualization date
+        name: "Descend by actualization date"
       in_name:
         args:
           words: Words
         description: "(separated by space or comma)"
         name: "Product name have following"
-        sentence: product name contain <em>%s</em>
+        sentence: "product name contain <em>%s</em>"
       in_name_or_description:
         args:
           words: Words
         description: "(separated by space or comma)"
         name: "Product name or description have following"
-        sentence: name or description contain <em>%s</em>
+        sentence: "name or description contain <em>%s</em>"
       in_name_or_keywords:
         args:
           words: Words
         description: "(separated by space or comma)"
         name: "Product name or meta keywords have following"
-        sentence: name or keywords contain <em>%s</em>
+        sentence: "name or keywords contain <em>%s</em>"
       in_taxons:
         args:
-          "taxon_names": "Taxon names"
+          taxon_names: "Taxon names"
         description: "Taxon names have to be separated by comma or space(eg. adidas,shoes)"
         name: "In taxons and all their descendants"
-        sentence: in <em>%s</em> and all their descendants
+        sentence: "in <em>%s</em> and all their descendants"
       master_price_gte:
         args:
           amount: Amount
         description: ""
         name: "Master price greater or equal to"
-        sentence: price greater or equal to <em>%.2f</em>
+        sentence: "price greater or equal to <em>%.2f</em>"
       master_price_lte:
         args:
           amount: Amount
         description: ""
         name: "Master price lesser or equal to"
-        sentence: price less or equal to <em>%.2f</em>
+        sentence: "price less or equal to <em>%.2f</em>"
       price_between:
         args:
           high: High
           low: Low
         description: ""
         name: "Price between"
-        sentence: price between <em>%.2f</em> and <em>%.2f</em>
+        sentence: "price between <em>%.2f</em> and <em>%.2f</em>"
       taxons_name_eq:
         args:
           taxon_name: "Taxon name"
         description: "In specific taxon - without descendants"
         name: "In Taxon(without descendants)"
-        sentence: in <em>%s</em>
+        sentence: "in <em>%s</em>"
       with:
         args:
           value: Value
         description: "Selects all products that have at least one variant that have specified value as either option or property (eg. red)"
-        name: With value
-        sentence: with value <em>%s</em>
+        name: "With value"
+        sentence: "with value <em>%s</em>"
       with_ids:
         args:
           ids: IDs
         description: "Select specific products"
-        name: Products with IDs
-        sentence: with IDs <em>%s</em>
+        name: "Products with IDs"
+        sentence: "with IDs <em>%s</em>"
       with_option:
         args:
           option: Option
         description: "Selects all products that have specified option(eg. color)"
         name: "With option"
-        sentence: with option <em>%s</em>
+        sentence: "with option <em>%s</em>"
       with_option_value:
         args:
           option: Option
           value: Value
         description: "Selects all products that have at least one variant with specified option and value(eg. color:red)"
         name: "With option and value"
-        sentence: with option <em>%s</em> and value <em>%s</em>
+        sentence: "with option <em>%s</em> and value <em>%s</em>"
       with_property:
         args:
           property: Property
         description: "Selects all products that have specified property(eg. weight)"
         name: "With property"
-        sentence: with property <em>%s</em>
+        sentence: "with property <em>%s</em>"
       with_property_value:
         args:
           property: Property
           value: Value
         description: "Selects all products that have at least one variant with specified property and value(eg. weight:10kg)"
         name: "With property value"
-        sentence: with property <em>%s</em> and value <em>%s</em>
+        sentence: "with property <em>%s</em> and value <em>%s</em>"
   products: Products
   products_with_zero_inventory_display: "Products with a zero inventory will %{not} be displayed"
   promotion: Promotion
-  promotion_action: Promotion Action
+  promotion_action: "Promotion Action"
   promotion_action_types:
     create_adjustment:
-      description: Creates a promotion credit adjustment on the order
-      name: Create adjustment
+      description: "Creates a promotion credit adjustment on the order"
+      name: "Create adjustment"
     create_line_items:
-      description: Populates the cart with the specified variants and quantities
-      name: Create line items
+      description: "Populates the cart with the specified variants and quantities"
+      name: "Create line items"
     give_store_credit:
-      description: Gives the user store credit of the amount specified
-      name: Give store credit
+      description: "Gives the user store credit of the amount specified"
+      name: "Give store credit"
   promotion_actions: Actions
   promotion_form:
     match_policies:
-      all: Match all of these rules
-      any: Match any of these rules
-  promotion_not_found: The coupon code you entered doesn't exist. Please try again.
-  promotion_rule: Promotion Rule
+      all: "Match all of these rules"
+      any: "Match any of these rules"
+  promotion_not_found: "The coupon code you entered doesn't exist. Please try again."
+  promotion_rule: "Promotion Rule"
   promotion_rule_types:
     first_order:
       description: "Must be the customer's first order"
-      name: First order
+      name: "First order"
     item_total:
-      description: Order total meets these criteria
-      name: Item total
+      description: "Order total meets these criteria"
+      name: "Item total"
     landing_page:
-      description: Customer must have visited the specified page
-      name: Landing Page
+      description: "Customer must have visited the specified page"
+      name: "Landing Page"
     product:
-      description: Order includes specified product(s)
+      description: "Order includes specified product(s)"
       name: Product(s)
     user:
-      description: Available only to the specified users
+      description: "Available only to the specified users"
       name: User
     user_logged_in:
-      description: Available only to logged in users
-      name: User Logged In
+      description: "Available only to logged in users"
+      name: "User Logged In"
   promotions: Promotions
-  promotions_description: Manage offers and coupons with promotions
+  promotions_description: "Manage offers and coupons with promotions"
   properties: Properties
   property: Property
   prototype: Prototype
   prototypes: Prototypes
-  provider: "Provider"
+  provider: Provider
   provider_settings_warning: "If you are changing the provider type, you must save first before you can edit the provider settings"
   qty: Qty
-  quantity_returned: Quantity Returned
-  quantity_shipped: Quantity Shipped
-  range: "Range"
+  quantity_returned: "Quantity Returned"
+  quantity_shipped: "Quantity Shipped"
+  range: Range
   rate: Rate
   reason: Reason
   recalculate_order_total: "Recalculate order total"
   receive: receive
   received: Received
   refund: Refund
-  register: Register as a New User
-  register_or_guest: Checkout as Guest or Register
+  register: "Register as a New User"
+  register_or_guest: "Checkout as Guest or Register"
   registration: Registration
   remember_me: "Remember me"
   remove: Remove
   reports: Reports
-  required_for_solo_and_maestro: Required for Solo and Maestro cards.
+  required_for_solo_and_maestro: "Required for Solo and Maestro cards."
   resend: Resend
   resend_confirmation_instructions: "Resend confirmation instructions"
   resend_unlock_instructions: "Resend unlock instructions"
@@ -916,21 +916,21 @@ en-NZ:
     successfully_removed: "Successfully removed!"
     successfully_updated: "Successfully updated!"
   response_code: "Response Code"
-  resume: "resume"
+  resume: resume
   resumed: Resumed
   return: return
-  return_authorization: Return Authorization
-  return_authorization_updated: Return authorization updated
-  return_authorizations: Return Authorizations
-  return_quantity: Return Quantity
+  return_authorization: "Return Authorization"
+  return_authorization_updated: "Return authorization updated"
+  return_authorizations: "Return Authorizations"
+  return_quantity: "Return Quantity"
   returned: Returned
-  rma_credit: RMA Credit
-  rma_number: RMA Number
-  rma_value: RMA Value
+  rma_credit: "RMA Credit"
+  rma_number: "RMA Number"
+  rma_value: "RMA Value"
   roles: Roles
   rules: Rules
   s3_access_key: "Access Key"
-  s3_bucket: "Bucket"
+  s3_bucket: Bucket
   s3_headers: "S3 Headers"
   s3_not_used_for_product_images: "S3 is not being used for product images"
   s3_secret: "Secret Key"
@@ -938,50 +938,50 @@ en-NZ:
   sales_tax: "Sales Tax"
   sales_total: "Sales Total"
   sales_total_description: "Sales Total For All Orders"
-  save_and_continue: Save and Continue
-  save_preferences: Save Preferences
+  save_and_continue: "Save and Continue"
+  save_preferences: "Save Preferences"
   scope: Scope
   scopes: Scopes
   search: Search
   search_results: "Search results for '%{keywords}'"
   searching: Searching
-  secure_connection_type: Secure Connection Type
-  secure_creditcard: Secure Creditcard
+  secure_connection_type: "Secure Connection Type"
+  secure_creditcard: "Secure Creditcard"
   select: Select
   select_from_prototype: "Select From Prototype"
   select_preferred_shipping_option: "Select preferred delivery option"
-  send_copy_of_all_mails_to: Send Copy of All Mails To
-  send_copy_of_orders_mails_to: Send Copy of Order Mails To
-  send_mails_as: Send Mails As
+  send_copy_of_all_mails_to: "Send Copy of All Mails To"
+  send_copy_of_orders_mails_to: "Send Copy of Order Mails To"
+  send_mails_as: "Send Mails As"
   send_me_reset_password_instructions: "Send me reset password instructions"
-  send_order_mails_as: Send Order Mails As
+  send_order_mails_as: "Send Order Mails As"
   server: Server
   server_error: "The server returned an error"
   settings: Settings
   ship: ship
   ship_address: "Delivery Address"
   shipment: Shipment
-  shipment_details: Shipment Details
+  shipment_details: "Shipment Details"
   shipment_inc_vat: "Shipment including GST"
   shipment_mailer:
     shipped_email:
       subject: "Shipment Notification"
   shipment_number: "Shipment #"
-  shipment_state: Shipment State
+  shipment_state: "Shipment State"
   shipment_states:
     backorder: backorder
     partial: partial
     pending: pending
     ready: ready
     shipped: shipped
-  shipment_updated: Shipment Updated
-  shipments: "Shipments"
+  shipment_updated: "Shipment Updated"
+  shipments: Shipments
   shipped: Shipped
   shipping: Delivery
   shipping_address: "Delivery Address"
   shipping_categories: "Shipping Categories"
   shipping_categories_description: "Manage shipping categories to identify which products can be shipped via which method"
-  shipping_category: Shipping Category
+  shipping_category: "Shipping Category"
   shipping_category_choose: "Shipping Category"
   shipping_cost: Cost
   shipping_error: "Delivery Error"
@@ -1005,20 +1005,20 @@ en-NZ:
   site_url: "Site URL"
   sku: SKU
   smtp: SMTP
-  smtp_authentication_type: SMTP Authentication Type
-  smtp_domain: SMTP Domain
-  smtp_mail_host: SMTP Mail Host
-  smtp_password: SMTP Password
-  smtp_port: SMTP Port
+  smtp_authentication_type: "SMTP Authentication Type"
+  smtp_domain: "SMTP Domain"
+  smtp_mail_host: "SMTP Mail Host"
+  smtp_password: "SMTP Password"
+  smtp_port: "SMTP Port"
   smtp_send_all_emails_as_from_following_address: "Send all mails as from the following address."
   smtp_send_copy_to_this_addresses: "Sends a copy of all outgoing mails to this address. For multiple addresses, separate with commas."
-  smtp_username: SMTP Username
+  smtp_username: "SMTP Username"
   sold: Sold
   sort_ordering: "Sort ordering"
   special_instructions: "Special Instructions"
-  spree:
+  spree: ~
   spree/order:
-    coupon_code: Coupon Code
+    coupon_code: "Coupon Code"
     date: Date
     time: Time
   spree_alert_checking: "Check for Spree security and release alerts"
@@ -1032,7 +1032,7 @@ en-NZ:
   ssl_will_not_be_used_in_production_mode: "SSL will not be used in production mode"
   ssl_will_not_be_used_in_staging_mode: "SSL will not be used in staging mode"
   start: Start
-  start_date: Valid from
+  start_date: "Valid from"
   state: Region
   state_based: "Region Based"
   state_setting_description: "Administer the list of states/provinces/regions associated with each country."
@@ -1053,13 +1053,13 @@ en-NZ:
   tax_categories_setting_description: "Set up tax categories to identify which products should be taxable."
   tax_category: "Tax Category"
   tax_rates: "Tax Rates"
-  tax_rates_description: Tax rates setup and configuration.
+  tax_rates_description: "Tax rates setup and configuration."
   tax_settings: "Tax Settings"
-  tax_settings_description: Basic tax settings.
+  tax_settings_description: "Basic tax settings."
   tax_total: "Tax Total"
   tax_type: "Tax Type"
   taxon: Taxon
-  taxon_edit: Edit Taxon
+  taxon_edit: "Edit Taxon"
   taxonomies: Taxonomies
   taxonomies_setting_description: "Create and manage taxonomies"
   taxonomy: Taxonomy
@@ -1067,17 +1067,17 @@ en-NZ:
   taxonomy_tree_error: "The requested change has not been accepted and the tree has been returned to its previous state, please try again."
   taxonomy_tree_instruction: "* Right click a child in the tree to access the menu for adding, deleting or sorting a child."
   taxons: Taxons
-  test: "Test"
+  test: Test
   test_mailer:
     test_email:
-      greeting: 'Congratulations!'
-      message: 'If you have received this email, then your email settings are correct.'
-      subject: 'Testmail'
-  test_mode: Test Mode
+      greeting: Congratulations!
+      message: "If you have received this email, then your email settings are correct."
+      subject: Testmail
+  test_mode: "Test Mode"
   thank_you_for_your_order: "Thank you for your business.  Please print out a copy of this confirmation page for your records."
   there_were_problems_with_the_following_fields: "There were problems with the following fields"
   this_file_language: "English (New Zealand)"
-  thumbnail: "Thumbnail"
+  thumbnail: Thumbnail
   to_add_variants_you_must_first_define: "To add variants, you must first define"
   to_state: "To State"
   total: Total
@@ -1085,9 +1085,10 @@ en-NZ:
   transaction: Transaction
   transactions: Transactions
   tree: Tree
+  true: "Yes"
   try_again: "Try Again"
   type: Type
-  type_to_search: Type to search
+  type_to_search: "Type to search"
   unable_ship_method: "Unable to generate delivery methods due to a server error."
   unable_to_authorize_credit_card: "Unable to Authorize Credit Card"
   unable_to_capture_credit_card: "Unable to Capture Credit Card"
@@ -1095,24 +1096,24 @@ en-NZ:
   unable_to_save_order: "Unable to Save Order"
   under_paid: "Under Paid"
   under_price: "Under %{price}"
-  unrecognized_card_type: Unrecognized card type
+  unrecognized_card_type: "Unrecognized card type"
   update: Update
   update_password: "Update my password and log me in"
   updated_successfully: "Updated Successfully"
   updating: Updating
-  usage_limit: Usage Limit
-  use_as_shipping_address: Use as Delivery Address
-  use_billing_address: Use Billing Address
+  usage_limit: "Usage Limit"
+  use_as_shipping_address: "Use as Delivery Address"
+  use_billing_address: "Use Billing Address"
   use_different_shipping_address: "Use Different Delivery Address"
   use_new_cc: "Use a new card"
   use_s3: "Use Amazon S3 For Images"
   user: User
-  user_account: User Account
+  user_account: "User Account"
   user_created_successfully: "User created successfully"
   user_rule:
-    choose_users: Choose users
+    choose_users: "Choose users"
   users: Users
-  validate_on_profile_create: Validate on profile create
+  validate_on_profile_create: "Validate on profile create"
   validation:
     cannot_be_greater_than_available_stock: "cannot be greater than available stock."
     cannot_be_less_than_shipped_units: "cannot be less than the number of shipped units."
@@ -1123,7 +1124,7 @@ en-NZ:
   value: Value
   variant: Variant
   variants: Variants
-  vat: "GST"
+  vat: GST
   version: Version
   view_shipping_options: "View delivery options"
   void: Void
@@ -1134,8 +1135,7 @@ en-NZ:
   what_is_this: "What's This?"
   whats_this: "What's this"
   width: Width
-  year: "Year"
-  yes: "Yes"
+  year: Year
   you_have_been_logged_out: "You have been logged out."
   you_have_no_orders_yet: "You have no orders yet."
   your_cart_is_empty: "Your cart is empty"


### PR DESCRIPTION
This is a hybrid of en-GB, en-AU and en.

Differences:

GST instead of VAT
Region instead of state
Cart instead of basket
Delivery instead of shipping
Postcode instead of ZIP code or Post code

I've added 1 commit to bring it up to what's in master here, and another to bring it up to what's in spree core v1.1.0.rc1
