### PR TITLE
Adding date picker format translation to german locale

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1028,6 +1028,8 @@ de:
   spree: 
     date: Datum
     time: Uhrzeit
+    date_picker:
+      format: 'dd.mm.yy'
   spree_alert_checking: "Überprüfe auf Spree Sicherheits- und Veröffentlichungshinweise"
   spree_alert_not_checking: "Überprüfe nicht auf Spree Sicherheits- und Veröffentlichungshinweise"
   spree_gateway_error_flash_for_checkout: "Es gab Probleme mit Ihren Zahlungsinformationen. Bitte überprüfen Sie Ihre Angaben und probieren Sie es erneut."


### PR DESCRIPTION
If you merge my pull request for localizing the datepicker (https://github.com/spree/spree/pull/1457), then this is the german translation for it.
