### PR TITLE
">= 1.1.0.rc2" Doesn't work with spree 1.1.0

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency('spree',  '>= 1.1.0.rc2')
+  s.add_dependency('spree',  '~> 1.1.0')
   s.add_dependency('i18n', '~> 0.5')
   s.add_development_dependency "rails", ">= 3.0.0"
   s.add_development_dependency "rspec-rails", ">= 2.7.0"


### PR DESCRIPTION
```
Could not find gem 'spree (>= 1.1.0.rc2) ruby', which is required by gem 'spree_i18n (>= 0) ruby', in any of the sources.
```
