### PR TITLE
Added "price_range" translation & update login/logout messages for french

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -671,6 +671,7 @@ fr:
   preview: Aperçu
   previous: Précédent
   price: Prix
+  price_range: "Prix"
   price_bucket: Price Bucket # Prix du seau ?
   price_with_vat_included: "%{price} (TTC)"
   problem_authorizing_card: "Problème d'autorisation de votre carte de crédit"


### PR DESCRIPTION
Added "price_range" translation.

And update login/logout messages : there is 2 types of login/logout messages that were not the same but I think they should :

``` yaml
logged_in_succesfully: "Connexion réussie"
[...]
you_have_been_logged_out: "Vous avez été déconnecté"
```

and

``` yaml
devise
    user_sessions:
      signed_in: "Connexion réussie."
      signed_out: "Vous avez été déconnecté."
```

I am pretty sure the firsts are simply deprecated, they were not found in spree source except in en.yml.
