### PR TITLE
Work around for issues when using nl-NL as locale

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,5 +1,5 @@
 ---
-nl-NL: 
+nl: 
   'no': "No"
   'yes': "Yes"
   5_biggest_spenders: "5 Biggest Spenders"


### PR DESCRIPTION
On rails-i18n there is only 1 locale for nl, "nl". There is no separation made between nl-NL and nl-BE.
A [PR](https://github.com/svenfuchs/rails-i18n/pull/258) by @radar to create this division has been declined.

This is a workaround. 
