### PR TITLE
Fix broken sk.yml

### DIFF
--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -654,7 +654,7 @@ sk:
   option_values: "Hodnoty opcií"
   options: Opcie
   or: alebo
-  or_over_price: %{price} alebo viac
+  or_over_price: "%{price} alebo viac"
   order: Objednávka
   order_adjustments: "Order adjustments"
   order_confirmation_note: ""


### PR DESCRIPTION
The last commit contains a broken entry in sk locale. Could you fix please? Thank you.

irb(main):009:0> y = YAML.load_file('/home/bitnami/.bundler/ruby/1.9.1/spree_i18n-17cd16372e77/lib/spree_i18n/../../config/locales/sk.broken')
Psych::SyntaxError: (/home/bitnami/.bundler/ruby/1.9.1/spree_i18n-17cd16372e77/lib/spree_i18n/../../config/locales/sk.broken): found character that cannot start any token while scanning for the next token at line 657 column 18
        from /opt/bitnami/ruby/lib/ruby/1.9.1/psych.rb:203:in `parse'
        from /opt/bitnami/ruby/lib/ruby/1.9.1/psych.rb:203:in`parse_stream'
        from /opt/bitnami/ruby/lib/ruby/1.9.1/psych.rb:151:in `parse'
        from /opt/bitnami/ruby/lib/ruby/1.9.1/psych.rb:127:in`load'
        from /opt/bitnami/ruby/lib/ruby/1.9.1/psych.rb:297:in `block in load_file'
        from /opt/bitnami/ruby/lib/ruby/1.9.1/psych.rb:297:in`open'
        from /opt/bitnami/ruby/lib/ruby/1.9.1/psych.rb:297:in `load_file'
        from (irb):9
        from /opt/bitnami/ruby/bin/irb:12:in`<main>'
