### PR TITLE
translation missing: fr.date.month_names

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -379,7 +379,7 @@ fr:
   date_created: Date de création
   date_range: "Sélection de dates"
   date:
-      month_names: [~, janvier, février, mars, avril, mai, juin, juiller, aôut, septembre, octobre, novemvre, decembre]
+      month_names: [~, janvier, février, mars, avril, mai, juin, juiller, aôut, septembre, octobre, novembre, decembre]
       formats:
             default: '%d-%m-%Y'
   debit: Débit


### PR DESCRIPTION
added translation missing fr 

dat_month_names
