### PR TITLE
Fix misleading confirm translation (de)

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -689,7 +689,7 @@ de:
     canceled: Abgebrochen
     cart: Warenkorb
     complete: Abgeschlossen
-    confirm: Bestätigt
+    confirm: Bestätigen
     delivery: Versand
     payment: Bezahlung
     resumed: "wieder aufgenommen"


### PR DESCRIPTION
In german "Bestätigt" means "confirmed" and that is VERY misleading for customers because in the confirmation step of an order they think it is already confirmed and therefore do not submit their order. "Bestätigen" means "confirm" or "confirming".
