### PR TITLE
Add rails-i18n as a gem dependency (fixes #191)

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('spree_core',  '>= 1.1')
   s.add_dependency('i18n', '~> 0.5')
-  s.add_dependency('rails_i18n')
+  s.add_dependency('rails-i18n')
 
   s.add_development_dependency "rails", ">= 3.0.0"
   s.add_development_dependency "rspec-rails", ">= 2.7.0"


### PR DESCRIPTION
This should also be applied to branch **1-3-stable** and **master** I guess.
