### PR TITLE
DE: Fix date_picker format

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1076,14 +1076,16 @@ de:
   special_instructions: "Spezielle Anweisungen"
   spree: 
     date_picker:
-      format: 'yy/mm/dd'
+      format: ! '%Y/%m/%d'
+      js_format: 'yy/mm/dd'
     date: Datum
     time: Zeit
   spree/order: 
     coupon_code: "Aktions-Code"
     date: Datum
     date_picker: 
-      format: 'yy/mm/dd'
+      format: ! '%Y/%m/%d'
+      js_format: 'yy/mm/dd'
     time: Zeit
   spree_alert_checking: "Überprüfe auf Spree Sicherheits- und Veröffentlichungshinweise"
   spree_alert_not_checking: "Überprüfe nicht auf Spree Sicherheits- und Veröffentlichungshinweise"


### PR DESCRIPTION
With the old value, the content of the date picker input field is always (!) just the template 'yy/mm/dd' and never the actual value (if already present). As a result, the product availablity date is resetted on every form submit and products are simply not available anymore.
