### PR TITLE
Added translation for month_name for italian

### DIFF
--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -377,7 +377,7 @@ it:
   cut: Cut
   date:
     month_names: [~, gennaio, febbraio, marzo, aprile, maggio, giugno, luglio, agosto, settembre, ottobre, novembre, dicembre]
-    format:
+    formats:
       default: '%d/%m/%Y'
   date_completed: Date Completamento
   date_created: "Data creazione"


### PR DESCRIPTION
I added the missing translation for month_names and the date format for :it
