### PR TITLE
Rename cs-CZ.yml to cs.yml

### DIFF
--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,5 +1,5 @@
 ---
-cs-CZ: 
+cs: 
   a_copy_of_all_mail_will_be_sent_to_the_following_addresses: "Zasílat kopii každého odeslaného emailu na další adresu"
   abbreviation: Zkratka
   access_denied: "Přístup zakázan (Access Denied)"


### PR DESCRIPTION
Rails use for Czech cs.yml and devise using same filename. I think that this name is better because then you can use gem for devise or rails i18n.
Is this change possible ?
