### PR TITLE
Change locale names to follow Rails i18n.

### DIFF
--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -1,4 +1,4 @@
-nb-NO:
+nb:
   activerecord:
     attributes:
       spree/address:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,4 +1,4 @@
-pt-PT:
+pt:
   activerecord:
     attributes:
       spree/address:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,4 +1,4 @@
-sv-SE:
+sv:
   activerecord:
     attributes:
       spree/address:


### PR DESCRIPTION
Think the locales are maintained now on locale app but do a pull request anyway.

Changed filenames of 3 locales so they follow [Rails i18n](https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale) in an ISO style to avoid fallback confusion. This is similar to 9d7a60d so I did not change locale for Czech.
