### PR TITLE
Fix tooltips.

### DIFF
--- a/app/overrides/spree/admin/option_types/index/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/index/add_translation.html.erb.deface
@@ -1,3 +1,3 @@
 <!-- insert_bottom 'td.actions' -->
 <%= link_to '', admin_translations_path('option_types', option_type.id),
-        class: 'icon_link with-tip icon-flag no-text' %>
+        class: 'icon_link with-tip icon-flag no-text', title: Spree.t(:translations) %>

--- a/app/overrides/spree/admin/promotions/index/add_translation_link.html.erb.deface
+++ b/app/overrides/spree/admin/promotions/index/add_translation_link.html.erb.deface
@@ -1,3 +1,3 @@
 <!-- insert_bottom 'td.actions' -->
 <%= link_to '', admin_translations_path('promotions', promotion.id),
-        class: 'icon_link with-tip icon-flag no-text' %>
+        class: 'icon_link with-tip icon-flag no-text', title: Spree.t(:translations) %>

--- a/app/overrides/spree/admin/properties/index/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/properties/index/add_translation.html.erb.deface
@@ -1,3 +1,3 @@
 <!-- insert_bottom 'td.actions' -->
 <%= link_to '', admin_translations_path('properties', property.id),
-        class: 'icon_link with-tip icon-flag no-text' %>
+        class: 'icon_link with-tip icon-flag no-text', title: Spree.t(:translations) %>

--- a/app/overrides/spree/admin/taxonomies/_list/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/taxonomies/_list/add_translations.html.erb.deface
@@ -1,3 +1,3 @@
 <!-- insert_bottom 'td.actions' -->
 <%= link_to '', admin_translations_path('taxonomies', taxonomy.id),
-        class: 'icon_link with-tip icon-flag no-text' %>
+        class: 'icon_link with-tip icon-flag no-text', title: Spree.t(:translations) %>


### PR DESCRIPTION
Tooltips in admin do not show any rollover text, here is the tiny fix for this.
