### PR TITLE
changing this dependency so it works with Rails 3.2

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails-i18n', '~> 0.7.3'
   s.add_dependency 'spree_core', '~> 2.0.4'
+  s.add_dependency 'globalize3', '~> 0.3.0'
 
   s.add_development_dependency 'rspec-rails', '~> 2.13'
   s.add_development_dependency 'sqlite3', '~> 1.3.7'


### PR DESCRIPTION
@radar please take a look.
## Gemfile

gem 'rails', '3.2.14'
gem 'spree'
## gem 'spree_i18n', github: 'yakko/spree_i18n'

after changing this file, the error below no longer shows.

I hope this commit is beneficial to other people in the international spree community who need this gem.
## Bundle output

deployer@debian:~/host/apps/demo_store$ bundle
Fetching git://github.com/spree/spree_i18n.git
remote: Counting objects: 4533, done.
remote: Compressing objects: 100% (2368/2368), done.
remote: Total 4533 (delta 2138), reused 3810 (delta 1496)
Receiving objects: 100% (4533/4533), 5.06 MiB | 66 KiB/s, done.
Resolving deltas: 100% (2138/2138), done.
Fetching gem metadata from https://rubygems.org/.......
Fetching gem metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "spree_core":
  In snapshot (Gemfile.lock):
    spree_core (2.0.4)

  In Gemfile:
    spree_i18n (>= 0) ruby depends on
      spree_core (~> 2.1.0.beta) ruby

Running `bundle update` will rebuild your snapshot from scratch, using only
## the gems in your Gemfile, which may resolve the conflict.
