### PR TITLE
config/locales/tr.yml: correct this_file_language

### DIFF
--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -522,7 +522,7 @@ tr:
       select_locale: Dil Seç
       show_only: Sadece Şunları Göster
       supported_locales: Desteklenen Diller
-      this_file_language: İngilizce (US)
+      this_file_language: Türkçe (TR)
       translations: Çeviriler
     icon: Simge
     image: Resim


### PR DESCRIPTION
this_file_language is translated literally and the phrase:
"İngilizce (US)" means "English (US)"
However this key should list the language of the current file which in
this case is Turkish.
