### PR TITLE
Changing format for date_picker so you dont get errors while editing

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -463,7 +463,7 @@ es:
     date_completed: Fecha completada
     date_picker:
       first_day: 1
-      format: ! '%d%m%Y'
+      format: ! '%d/%m/%Y'
       js_format: dd/mm/yy
     date_range: Rango de fechas
     default: Por defecto


### PR DESCRIPTION
Changed format for date_picker so you dont get errors while editingroduct. Now its format: ! '%d/%m/%Y' as it should be
