### PR TITLE
Add newline for append_file arguments in add_javascripts (install)

### DIFF
--- a/lib/generators/spree_i18n/install/install_generator.rb
+++ b/lib/generators/spree_i18n/install/install_generator.rb
@@ -4,8 +4,8 @@ module SpreeI18n
       class_option :auto_run_migrations, :type => :boolean, :default => true
 
       def add_javascripts
-        append_file "app/assets/javascripts/admin/all.js", "//= require admin/spree_i18n"
-        append_file "app/assets/javascripts/store/all.js", "//= require store/spree_i18n"
+        append_file "app/assets/javascripts/admin/all.js", "//= require admin/spree_i18n\n"
+        append_file "app/assets/javascripts/store/all.js", "//= require store/spree_i18n\n"
       end
 
       def add_stylesheets


### PR DESCRIPTION
Using append_file without a new line in add_javascripts() causes the
file `all.js' to be saved without a new line at the end and making the
next (different) plugin install fail to write valid data to this file.
For example after installing spree_reviews which appends jquery.rating
to all.js the diff looks like:

   -//= require store/spree_i18n
   \ No newline at end of file
   +//= require store/spree_i18n//= require jquery.rating

Added '\n' suffix for the string arguments of append_file to fix.

Signed-off-by: Ali Polatel ali.polatel@ozguryazilim.com.tr
