### PR TITLE
add :id to permitted params for nested attributes

### DIFF
--- a/app/controllers/spree/admin/taxons_controller_decorator.rb
+++ b/app/controllers/spree/admin/taxons_controller_decorator.rb
@@ -11,7 +11,7 @@ module Spree
         end
 
         def translations_attributes
-          [:locale, :name, :description, :permalink, :meta_description, :meta_keywords, :meta_title]
+          [:id, :locale, :name, :description, :permalink, :meta_description, :meta_keywords, :meta_title]
         end
     end
   end


### PR DESCRIPTION
fixes https://github.com/spree/spree_i18n/issues/312
Idea comes from: http://stackoverflow.com/questions/17515672/strong-parameters-for-nested-attributes-returns-unpermitted-parameters-when-em

This is fixing the problem but there are two omissions:
- a proper spec
- a look into the other controller decorators, the problem is probably existent there, too

I could really need help regarding the spec.
