### PR TITLE
fix id replacement on taxon translations link

### DIFF
--- a/app/assets/javascripts/admin/taxon_tree_menu.js.coffee
+++ b/app/assets/javascripts/admin/taxon_tree_menu.js.coffee
@@ -13,7 +13,7 @@ root.taxon_tree_menu = (obj, context) ->
 
   translation_base_path = admin_base_url.path().replace(/taxons/, "translations")
   translation_base_path = translation_base_path.replace(/taxonomies/, "taxons")
-  translation_base_path = translation_base_path.replace(/\d/, id)
+  translation_base_path = translation_base_path.replace(/\d+/, id)
   translation_url.setPath(translation_base_path);
 
   create:


### PR DESCRIPTION
Fix the translations context menu link for taxons. Current implementation only replaces the first digit of the base url and will break for taxonomies with IDs greater than 9.
