### PR TITLE
we should duplicate the translation also

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -12,7 +12,7 @@ module Spree
 
     def duplicate_translations(old_product)
       old_product.translations.each do |translation|
-        self.translations << translation
+        self.translations << translation.dup
       end
     end
   end


### PR DESCRIPTION
otherwise we remove it from old product and add it to new one. (old product will miss all translations)
