### PR TITLE
Add translations for :taxonomies and :taxon in tabs for russian locale

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -326,6 +326,8 @@ ru:
         option_types: Товарные опции
         properties: Свойства
         prototypes: Прототипы
+        taxonomies: Таксономии
+        taxons: Таксоны
     administration: Администрирование
     agree_to_privacy_policy: Согласиться с Политикой Конфиденциальности
     agree_to_terms_of_service: Согласиться с Уловиями обслуживания


### PR DESCRIPTION
Spree edge now have two additional tabs `taxonomies` and `taxons`:

``` erb
<% content_for :sub_menu do %>
  <ul id="sub_nav" data-hook="admin_product_sub_tabs" class="inline-menu">
    <%= tab :products, :match_path => '/products' %>
    <%= tab :option_types, :match_path => '/option_types' %>
    <%= tab :properties %>
    <%= tab :prototypes %>
    <%= tab :taxonomies %>
    <%= tab :taxons %>
  </ul>
<% end %>

I've added russian localization for them.
```
