### PR TITLE
Copied the missing key from the core

### DIFF
--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -739,6 +739,7 @@ en-GB:
     order_number: Order
     order_populator:
       out_of_stock: ! '%{item} is out of stock.'
+      selected_quantity_not_available: ! 'Selected quantity of %{item} is not available.'
       please_enter_reasonable_quantity: Please enter a reasonable quantity.
     order_processed_successfully: Your order has been processed successfully
     order_state:


### PR DESCRIPTION
This key is defined like this in the core, but it's missing from the spree_i18n. This is my attempt to make the string translatable in the Localeapp.

https://github.com/spree/spree/blob/master/core/config/locales/en.yml#L777
