### PR TITLE
2 1 stable

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'rails-i18n', '>= 0.7.4'
+  s.add_dependency 'rails-i18n', '>= 0.7.3'
   s.add_dependency 'spree_core', '~> 2.1.0'
   s.add_dependency 'globalize', '~> 4.0.0'
 


### PR DESCRIPTION
Depending on rails-i18n '~> 0.7.3' will cause version conflict new gems since october 2013.

Please update to atleast '>= 0.7.3'
