### PR TITLE
Update pt-BR.yml

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1094,6 +1094,7 @@ pt-BR:
     update: Atualizar
     updating: Atualizando
     usage_limit: Limite de uso
+    use_app_default: Usar Padrão da Aplicação
     use_billing_address: Usar endereço de cobrança
     use_new_cc: Usar um novo cartão
     use_s3: Usar Amazon S3 para imagens


### PR DESCRIPTION
When creating a payment method on the admin area, there's a field that specifies the auto capture method of the payment.

There are three options, and the 'use_app_default' one was not translated.
