### PR TITLE
Update ru.yml

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1034,7 +1034,7 @@ ru:
     store: В магазин
     street_address: Адрес
     street_address_2: Адрес (строка 2)
-    subtotal: Подытог
+    subtotal: Подитог
     subtract: Вычет
     successfully_created: ! '%{resource} был успешно создан!'
     successfully_removed: ! '%{resource} был успешно удален!'


### PR DESCRIPTION
There are two different ways to translate "subtotal" into Russian. We need to use one of them, not both two: "Подитог" (proposed) xor "Подытог".

В 2х случаях употребляется "Подитог", в одном - "Подытог".
Нужно определиться, как переводить. Предлагается вариант "Подитог".
