### PR TITLE
Remove requirement of spree/frontend from spree_i18n.css, since this

### DIFF
--- a/app/assets/stylesheets/spree/frontend/spree_i18n.css
+++ b/app/assets/stylesheets/spree/frontend/spree_i18n.css
@@ -3,6 +3,5 @@
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *
- *= require spree/frontend
  *= require_tree .
 */


### PR DESCRIPTION
could cause troubles for themes, which want to replace the whole frontend styles.

Related to issue 
https://github.com/spree/spree_i18n/issues/394
