### PR TITLE
upgrade i18n_data gem to 0.5.1

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails-i18n', '~> 4.0.1'
   s.add_dependency 'spree_core', '~> 2.3.0.beta'
   s.add_dependency 'globalize', '~> 4.0.1'
-  s.add_dependency 'i18n_data', '~> 0.4.1'
+  s.add_dependency 'i18n_data', '~> 0.5.1'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-rails', '~> 2.14'


### PR DESCRIPTION
i18n_data gem 0.5.1 fix some translation of countries. Please use latest gem.
relate to https://github.com/spree/spree_i18n/commit/1bec159f2586186608dda00c0bbb243f2c4f1c05
