### PR TITLE
fix wrong translation

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -207,7 +207,7 @@ ru:
       spree/shipping_method:
         one: Cпособ доставки
         many: Cпособов доставки
-        other: Cпособа доставки
+        other: Cпособы доставки
       spree/state:
         one: Область/Регион
         many: Областей/Регионов


### PR DESCRIPTION
using there: https://github.com/spree/spree/blob/b66ea0229646062acb7b6f89ac2447f5ffc862fb/backend/app/views/spree/admin/shipping_methods/index.html.erb#L48
and who can understand:
was: "Способа доставки не найдены"
now: "Способы доставки не найдены"
