### PR TITLE
fix ZH_TW country_mappings

### DIFF
--- a/config/initializers/country_names.rb
+++ b/config/initializers/country_names.rb
@@ -44,7 +44,7 @@ module I18nData
       "ES-MX" => "es",
       "PT-BR" => "pt",
       "SL-SI" => "sl",
-      "ZH-TW" => "zh_CN",
+      "ZH-TW" => "zh_TW",
       "ZH-CN" => "zh_CN",
       "ZH" => "zh_CN",
       "BN" => "bn_IN",


### PR DESCRIPTION
We people in Taiwan use Traditional Chinese, not Simplified Chinese.