### PR TITLE
Globalize 5.x compatibility

### DIFF
--- a/db/migrate/20150217095648_remove_null_constraints_from_spree_tables.rb
+++ b/db/migrate/20150217095648_remove_null_constraints_from_spree_tables.rb
@@ -1,0 +1,13 @@
+class RemoveNullConstraintsFromSpreeTables < ActiveRecord::Migration
+  def up
+    change_column :spree_properties, :presentation, :string, null: true
+    change_column :spree_taxonomies, :name,         :string, null: true
+    change_column :spree_taxons,     :name,         :string, null: true
+  end
+
+  def down
+    change_column :spree_properties, :presentation, :string, null: false
+    change_column :spree_taxonomies, :name,         :string, null: false
+    change_column :spree_taxons,     :name,         :string, null: false
+  end
+end


### PR DESCRIPTION
This removes the null constraints on some spree tables (see f46c26b78cb453cf0b01259d4b01a57fac0eab82) since globalize removed the updating of the original column.