### PR TITLE
Soft-delete product translations

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -7,6 +7,27 @@ module Spree
 
     include SpreeI18n::Translatable
 
+    translation_class.class_eval do
+      # Paranoia soft-deletes the associated records only if they are paranoid themselves.
+      acts_as_paranoid
+
+      # Paranoid sets the default scope and Globalize rewrites all query methods.
+      # Therefore we prefer to unset the default_scopes over injecting 'unscope'
+      # in every Globalize query method.
+      self.default_scopes = []
+
+      # Punch slug on every translation to allow reuse of original
+      after_destroy :punch_slug
+
+      def punch_slug
+        update(slug: "#{Time.now.to_i}_#{slug}")
+      end
+    end
+
+    # Don't punch slug on original product as it prevents bulk deletion.
+    # Also we don't need it, as it is translated.
+    def punch_slug; end
+
     # Allow to filter products through their translations, too
     def self.like_any(fields, values)
       translations = Spree::Product::Translation.arel_table

--- a/db/migrate/20150224152415_add_deleted_at_to_translation_tables.rb
+++ b/db/migrate/20150224152415_add_deleted_at_to_translation_tables.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToTranslationTables < ActiveRecord::Migration
+  def change
+    add_column :spree_product_translations, :deleted_at, :datetime
+    add_index :spree_product_translations, :deleted_at
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -47,5 +47,23 @@ module Spree
         end
       end
     end
+
+    context "soft-deletion" do
+      subject do
+        product.destroy
+        product.reload
+      end
+
+      it "keeps the translation on deletion" do
+        subject
+        expect(product.translations).not_to be_empty
+      end
+
+      it "changes the slug on the translation to allow reuse of original slug" do
+        expect do
+          subject
+        end.to change { product.slug }
+      end
+    end
   end
 end


### PR DESCRIPTION
Spree::Product acts_as_paranoid and therefore get's only soft-deleted on destroy. However the translations get destroyed "for real" by the after_destroy hook and the soft-deleted product ends up without the translated attributes (Globalize 5 doesn't update the original column).

This commit makes the product translations paranoid as well and makes sure, that the original slug may be reused.