### PR TITLE
Let ransack know about translations

### DIFF
--- a/app/models/spree_i18n/translatable.rb
+++ b/app/models/spree_i18n/translatable.rb
@@ -4,5 +4,22 @@ module SpreeI18n
     included do
       accepts_nested_attributes_for :translations
     end
+
+    class_methods do
+      def ransack(params = {}, options = {})
+        names = params.keys
+
+        names.each do |n|
+          translated_attribute_names.each do |t|
+            if n.to_s.starts_with? t.to_s
+              params[:"translations_#{n}"] = params[n]
+              params.delete n
+            end
+          end
+        end
+
+        super(params, options)
+      end
+    end
   end
 end

--- a/app/models/spree_i18n/translatable.rb
+++ b/app/models/spree_i18n/translatable.rb
@@ -20,6 +20,7 @@ module SpreeI18n
 
         super(params, options)
       end
+      alias :search :ransack unless respond_to? :search
     end
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -22,6 +22,9 @@ module Spree
     it "handle translation in ransack" do
       result = described_class.ransack(name_cont: product.name[0..2]).result
       expect(result.first).to eq product
+
+      result = described_class.search(name_cont: product.name[0..2]).result
+      expect(result.first).to eq product
     end
 
     # Regression tests for #466

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -19,6 +19,11 @@ module Spree
       expect(product.taxons).to include(taxon)
     end
 
+    it "handle translation in ransack" do
+      result = described_class.ransack(name_cont: product.name[0..2]).result
+      expect(result.first).to eq product
+    end
+
     # Regression tests for #466
     describe ".like_any" do
       context "allow searching products through their translations" do

--- a/spec/models/variant_spec.rb
+++ b/spec/models/variant_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+
+module Globalize
+  module ActiveRecord
+    module ClassMethods
+      def with_translations(*locales)
+        puts "  with translations => #{self.name}"
+        locales = translated_locales if locales.empty?
+
+        joins(:translations).readonly(false).with_locales(locales)
+      end
+    end
+  end
+end
+
+module Spree
+  RSpec.describe Variant do
+    let(:product) do
+      Product.create!(
+        name: 'globalize',
+        price: 19.99,
+        shipping_category: ShippingCategory.create!(name: 'a')
+      )
+    end
+
+    let!(:variant) do
+      Variant.create!(
+        price: 19.99,
+        product: product
+      )
+    end
+
+    before do
+      ActiveRecord::Base.logger = Logger.new(STDOUT)
+    end
+
+    # Spree::Variant Load (0.6ms)
+    #
+    # SELECT  "spree_variants".* FROM "spree_variants"
+    #   INNER JOIN "spree_products" ON "spree_products"."id" = "spree_variants"."product_id"
+    #               AND "spree_products"."deleted_at" IS NULL
+    #   LEFT OUTER JOIN "spree_product_translations" ON "spree_product_translations"."spree_product_id" = "spree_products"."id"
+    #   WHERE "spree_variants"."deleted_at" IS NULL
+    #         AND "spree_products"."deleted_at" IS NULL
+    #         AND "spree_product_translations"."name" = 'globalize'
+    #         AND "spree_product_translations "."locale" = $1
+    #   ORDER BY "spree_variants"."id" ASC LIMIT 1  [["locale", "en"]]
+    #
+    it 'fetches variant from product via translation table' do
+      # globalize appends moar relations
+      #
+      # Product.preload(:translations)
+      #        .joins(:translations)
+      #        .readonly(false)
+      #        .merge(GlobalizeTranslation.where(locale: :en))
+      #        .where(name: 'globalize')
+
+      product_relation = Product.where(name: "globalize")
+      variant_relation = described_class.joins(:product).merge(product_relation)
+      described_class.includes(:product).ransack(name_cont: 'globalize').result.to_a
+
+      expect(variant_relation.last).to eq variant
+
+      variants = described_class.includes(:product).ransack(name_cont: 'globalize').result.to_a
+      expect(variants.last).to eq variant
+    end
+  end
+end


### PR DESCRIPTION
Since globalize 5 won't store translated data on default tables we need
to tweak the table / attribute name to let it fetch the data on the
right place.

This is just a proof of concept on what we could do to
improve the spree / ransack / globalize love here. Not sure this will
work with associations yet or even if it will work at all in all
scenarios

possible fix for #530