### PR TITLE
Translates stores SEO fields, fixes #274

### DIFF
--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -1,0 +1,7 @@
+module Spree
+  Store.class_eval do
+    translates :name, :meta_description, :meta_keywords, :seo_title,
+               fallbacks_for_empty_translations: true
+    include SpreeI18n::Translatable
+  end
+end

--- a/app/overrides/spree/admin/shared/_configuration_menu/store_translations.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_configuration_menu/store_translations.html.erb.deface
@@ -1,0 +1,2 @@
+<!-- insert_bottom "[data-hook='admin_configurations_sidebar_menu']" -->
+<%= configurations_sidebar_menu_item Spree.t(:'i18n.store_translations'), admin_translations_path('stores', current_store) %>

--- a/app/views/spree/admin/translations/store.html.erb
+++ b/app/views/spree/admin/translations/store.html.erb
@@ -1,0 +1,17 @@
+<%= render partial: 'spree/admin/shared/configuration_menu' %>
+
+<div class="row">
+  <fieldset class="no-border-top translations">
+    <%= render 'settings' %>
+
+    <%= form_for [:admin, @resource], url: admin_general_settings_path do |f| %>
+      <%= render 'form_fields', f: f %>
+      <div class="form-buttons filter-actions actions" data-hook="buttons">
+        <%= button Spree.t('actions.update'), 'refresh' %>
+        <span class="or"><%= Spree.t(:or) %></span>
+        <%= button_link_to Spree.t('actions.cancel'), edit_admin_general_settings_path, icon: 'remove' %>
+      </div>
+
+    <% end %>
+  </fieldset>
+</div>

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -635,6 +635,7 @@ bg:
       only_incomplete: "Само незавършени."
       select_locale: "Избери място"
       show_only: "Покажи само"
+      store_translations:
       supported_locales: "Подържани места"
       this_file_language: "Български (БГ)"
       translations: "Преводи"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -633,6 +633,7 @@ ca:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: Catalan
       translations:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -662,6 +662,7 @@ cs:
       only_incomplete: Pouze neúplné
       select_locale: Vyberte lokalizaci
       show_only: Vybrat pouze
+      store_translations:
       supported_locales: Podporované jazyky
       this_file_language: "Čeština (CS)"
       translations: Překlady

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -635,6 +635,7 @@ da:
       only_incomplete: Kun ikke-komplette
       select_locale: Vælg sprog
       show_only: Vis kun
+      store_translations:
       supported_locales: Understøttede sprog
       this_file_language: Danish
       translations: Oversættelser

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -589,6 +589,7 @@ de-CH:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: Deutsch (Schweiz)
       translations:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -636,6 +636,7 @@ de:
       only_incomplete: Nur unvollständige
       select_locale: Wähle Locale
       show_only: Zeige nur
+      store_translations:
       supported_locales: Unterstützte Locales
       this_file_language: Deutsch (DE)
       translations: "Übersetzungen"

--- a/config/locales/en-AU.yml
+++ b/config/locales/en-AU.yml
@@ -633,6 +633,7 @@ en-AU:
       only_incomplete: 
       select_locale: 
       show_only: 
+      store_translations:
       supported_locales: 
       this_file_language: English (Australia)
       translations: 

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -635,6 +635,7 @@ en-GB:
       only_incomplete: Only incomplete
       select_locale: Select locale
       show_only: Show only
+      store_translations:
       supported_locales: Supported Locales
       this_file_language: English (UK)
       translations: Translations

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -635,6 +635,7 @@ en-IN:
       only_incomplete: 
       select_locale: 
       show_only: 
+      store_translations:
       supported_locales: 
       this_file_language: English (UK)
       translations: 

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -633,6 +633,7 @@ en-NZ:
       only_incomplete: 
       select_locale: 
       show_only: 
+      store_translations:
       supported_locales: 
       this_file_language: English (New Zealand)
       translations: 

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -647,6 +647,7 @@ es-CL:
       only_incomplete: Sólo incompletas
       select_locale: Seleccionar Locale
       show_only: Sólo mostrar
+      store_translations:
       supported_locales: Locales Soportados
       this_file_language: Español (Chile)
       translations: Traducciones

--- a/config/locales/es-EC.yml
+++ b/config/locales/es-EC.yml
@@ -637,6 +637,7 @@ es-EC:
       only_incomplete: Sólo incompletos
       select_locale: Seleccionar Locale
       show_only: Sólo mostrar
+      store_translations:
       supported_locales: Locales Soportados
       this_file_language: Español
       translations: Traducciones

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -635,6 +635,7 @@ es-MX:
       only_incomplete: Solo incompletas
       select_locale: Escoge traducción
       show_only: Mostrar solo
+      store_translations:
       supported_locales: Traducciones soportadas
       this_file_language:
       translations: Traducciones

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -637,6 +637,7 @@ es:
       only_incomplete: Sólo incompletos
       select_locale: Seleccionar Locale
       show_only: Sólo mostrar
+      store_translations:
       supported_locales: Locales Soportados
       this_file_language: Español
       translations: Traducciones

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -635,6 +635,7 @@ et:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: Eesti keel
       translations: Tõlked

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -633,6 +633,7 @@ fa:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: "فارسی(fa)"
       translations:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -647,6 +647,7 @@ fi:
       only_incomplete: Vain keskeneräiset
       select_locale: Valitse kieli
       show_only: Näytä vain
+      store_translations:
       supported_locales: Tuetut kielet
       this_file_language: Suomi
       translations: Käännökset

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -637,6 +637,7 @@ fr:
       only_incomplete: Incomplètes seulement
       select_locale: Sélectionnez vos paramètres régionaux
       show_only: Afficher seulement
+      store_translations:
       supported_locales: Paramètres régionaux supportés
       this_file_language: Français (FR)
       translations: Traductions

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -633,6 +633,7 @@ id:
       only_incomplete: 
       select_locale: 
       show_only: Tampilkan hanya
+      store_translations:
       supported_locales: 
       this_file_language: Indonesian (ID)
       translations: Terjemahan

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -12,11 +12,11 @@ it:
         state: Provincia
         zipcode: CAP
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount: 
-        preferred_tiers: 
+        preferred_base_amount:
+        preferred_tiers:
       spree/calculator/tiered_percent:
-        preferred_base_percent: 
-        preferred_tiers: 
+        preferred_base_percent:
+        preferred_tiers:
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,7 +24,7 @@ it:
         name: Nome
         numcode: Codice ISO
       spree/credit_card:
-        base: 
+        base:
         cc_type: Tipologia
         month: Mese
         name: Nome
@@ -42,7 +42,7 @@ it:
       spree/order:
         checkout_complete: Checkout Completato
         completed_at: Completato il
-        considered_risky: 
+        considered_risky:
         coupon_code: Codice Coupon
         created_at: Data Ordine
         email: E-Mail Cliente
@@ -107,11 +107,11 @@ it:
         abbr: Abbreviazione
         name: Nome
       spree/store:
-        meta_description: 
-        meta_keywords: 
-        name: 
-        seo_title: 
-        url: 
+        meta_description:
+        meta_keywords:
+        name:
+        seo_title:
+        url:
       spree/tax_category:
         description: Descrizione
         name: Nome
@@ -146,16 +146,16 @@ it:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: 
+              keys_should_be_positive_number:
             preferred_tiers:
-              should_be_hash: 
+              should_be_hash:
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: 
-              values_should_be_percent: 
+              keys_should_be_positive_number:
+              values_should_be_percent:
             preferred_tiers:
-              should_be_hash: 
+              should_be_hash:
         spree/classification:
           attributes:
             taxon_id:
@@ -164,11 +164,11 @@ it:
           attributes:
             base:
               card_expired: La Carta è scaduta
-              expiry_invalid: 
+              expiry_invalid:
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency: 
+              must_match_order_currency:
     models:
       spree/address:
         one: Indirizzo
@@ -185,8 +185,8 @@ it:
       spree/line_item:
         one: Riga d'Ordine
         other: Righe d'Ordine
-      spree/option_type: 
-      spree/option_value: 
+      spree/option_type:
+      spree/option_value:
       spree/order:
         one: Ordine
         other: Ordini
@@ -229,7 +229,7 @@ it:
       spree/stock_location:
         one: Magazzino
         other: Magazzini
-      spree/stock_movement: 
+      spree/stock_movement:
       spree/stock_transfer:
         one: Trasferimento di Magazzino
         other: Trasferimenti di Magazzino
@@ -362,14 +362,14 @@ it:
         taxons: Taxon
         users: Utenti
       user:
-        account: 
-        addresses: 
-        items: 
-        items_purchased: 
-        order_history: 
-        order_num: 
-        orders: 
-        user_information: 
+        account:
+        addresses:
+        items:
+        items_purchased:
+        order_history:
+        order_num:
+        orders:
+        user_information:
     administration: Amministrazione
     agree_to_privacy_policy: Accetta Politica di Privacy
     agree_to_terms_of_service: Accetta i Termini di Servizio
@@ -401,7 +401,7 @@ it:
     authorization_failure: Autorizzazione Fallita
     auto_capture: Riscossione Automatica
     available_on: Disponibile Il
-    average_order_value: 
+    average_order_value:
     avs_response: Risposta AVS
     back: Indietro
     back_end: Backend
@@ -418,7 +418,7 @@ it:
     back_to_prototypes_list: Torna alla Lista dei Prototipi
     back_to_reports_list: Torna alla Lista dei Report
     back_to_shipping_categories: Torna alle Categorie di Spedizione
-    back_to_shipping_categories_list: 
+    back_to_shipping_categories_list:
     back_to_shipping_methods_list: Torna alla Lista dei Metodi di Spedizione
     back_to_states_list: Torna alla Lista degli Stati
     back_to_stock_locations_list: Torna alla Lista dei Magazzini
@@ -431,12 +431,12 @@ it:
     back_to_users_list: Torna alla Lista degli Utenti
     back_to_zones_list: Torna alla Lista delle Zone
     backorderable: Ordinabile anche se terminato
-    backorderable_default: 
+    backorderable_default:
     backordered: Ordinato
     backorders_allowed: consentiti ordini anche se terminato
     balance_due: Saldo Dovuto
-    base_amount: 
-    base_percent: 
+    base_amount:
+    base_percent:
     bill_address: Indirizzo di Fatturazione
     billing: Fatturazione
     billing_address: Indirizzo di Fatturazione
@@ -466,9 +466,9 @@ it:
     choose_a_taxon_to_sort_products_for: Scegli un taxon con cui ordinare i prodotti
     choose_currency: Scegli una Valuta
     choose_dashboard_locale: Scegli una Lingua per la Dashboard
-    choose_location: 
+    choose_location:
     city: Città
-    click_and_drag_on_the_products_to_sort_them: 
+    click_and_drag_on_the_products_to_sort_them:
     clone: Clona
     close: Chiudi
     close_all_adjustments: Chiudi Tutte le Variazioni
@@ -492,10 +492,10 @@ it:
     country_based: In Base alla Nazione
     country_name: Nome
     country_names:
-      CA: 
-      FRA: 
-      ITA: 
-      US: 
+      CA:
+      FRA:
+      ITA:
+      US:
     coupon: Coupon
     coupon_code: Codice coupon
     coupon_code_already_applied: Il codice coupon è stato già applicato a quest'ordine
@@ -505,10 +505,10 @@ it:
     coupon_code_max_usage: Limite di utilizzo codice coupon superato
     coupon_code_not_eligible: Questo codice coupon non è applicabile a quest'ordine
     coupon_code_not_found: Il codice coupon inserito non esiste. Per favore prova ancora.
-    coupon_code_unknown_error: 
+    coupon_code_unknown_error:
     create: Crea
     create_a_new_account: Crea un nuovo account
-    create_new_order: 
+    create_new_order:
     created_at: Creato Il
     credit: Credito
     credit_card: Carta di Credito
@@ -606,8 +606,8 @@ it:
           signup: Registrazione dell'utente
     exceptions:
       count_on_hand_setter: Non è possibile impostare la disponibilità manualmente dato che è calcolata automaticamente dalla callback 'recalculate_count_on_hand'. Per favore usa il metodo 'update_column(:count_on_hand, value)'.
-    excl: 
-    existing_shipments: 
+    excl:
+    existing_shipments:
     expiration: Scadenza
     extension: Estensione
     failed_payment_attempts: Tentativi di Pagamento falliti
@@ -649,6 +649,7 @@ it:
       only_incomplete: Solo incomplete
       select_locale: Seleziona lingua
       show_only: Mostra solo
+      store_translations: Traduzioni Store
       supported_locales: Lingue Supportate
       this_file_language: Italiano (IT)
       translations: Traduzioni
@@ -656,16 +657,16 @@ it:
     image: Immagine
     images: Immagini
     inactive: Inattivo
-    incl: 
+    incl:
     included_in_price: Incluso nel prezzo
     included_price_validation: non può essere selezionato senza aver impostato una Zona di Tassazione di Default
     instructions_to_reset_password: Per favore inserisci la tua email nel form sottostante
     insufficient_stock: Scorte insufficienti, ne rimangono solo %{on_hand}
-    insufficient_stock_lines_present: 
+    insufficient_stock_lines_present:
     intercept_email_address: Intercetta indirizzo Email
     intercept_email_instructions: Sovrascrivi il destinatario dell'email con questo indirizzo.
     internal_name: Nome Interno
-    invalid_credit_card: 
+    invalid_credit_card:
     invalid_payment_provider: Provider del pagamento non valido.
     invalid_promotion_action: Azione della promozione non valida.
     invalid_promotion_rule: Regola della promozione non valida.
@@ -688,7 +689,7 @@ it:
     last_name: Cognome
     last_name_begins_with: Cognome inizia con
     learn_more: Leggi di più
-    lifetime_stats: 
+    lifetime_stats:
     line_item_adjustments: Variazioni della riga d'ordine
     list: Lista
     listing_countries: Lista Nazioni
@@ -713,13 +714,13 @@ it:
     logs: Log
     look_for_similar_items: Cerca articoli simili
     make_refund: Esegui rimborso
-    manage_variants: 
+    manage_variants:
     master_price: Prezzo principale
     match_choices:
       all: Tutti
       none: Nessuno
     max_items: Articoli massimi
-    member_since: 
+    member_since:
     meta_description: Meta Description
     meta_keywords: Meta Keywords
     metadata: Metadata
@@ -747,7 +748,7 @@ it:
     new_property: Nuova Proprietà
     new_prototype: Nuovo Prototipo
     new_return_authorization: Nuovo Rimborso
-    new_shipment_at_location: 
+    new_shipment_at_location:
     new_shipping_category: Nuova Categoria di Spedizione
     new_shipping_method: Nuovo Metodo di Spedizione
     new_state: Nuova Provincia
@@ -764,9 +765,9 @@ it:
     new_zone: Nuova Zona
     next: Prossimo
     no_actions_added: Nessuna azione aggiunta
-    no_images_found: 
+    no_images_found:
     no_orders_found: Nessun ordine trovato
-    no_payment_found: 
+    no_payment_found:
     no_payment_methods_found: Nessun metodo di pagamento trovato
     no_pending_payments: Nessun pagamento pendente
     no_products_found: Nessun prodotto trovato
@@ -792,7 +793,7 @@ it:
       product_not_deleted: Il prodotto non può essere eliminato
       variant_deleted: La variante è stata eliminata
       variant_not_deleted: La variante non può essere eliminata
-    num_orders: 
+    num_orders:
     on_hand: Disponibilità
     open: Apri
     open_all_adjustments: Apri tutte le variazioni
@@ -807,7 +808,7 @@ it:
     or_over_price: "%{price} o maggiore"
     order: Ordine
     order_adjustments: Variazioni dell'ordine
-    order_already_updated: 
+    order_already_updated:
     order_approved: Ordine Approvato
     order_canceled: Ordine Annullato
     order_details: Dettagli Ordine
@@ -830,7 +831,7 @@ it:
         thanks: Grazie per il tuo ordine.
         total: 'Totale Ordine: %{total}'
     order_not_found: Non abbiamo trovato il tuo ordine. Per favore riprova ancora.
-    order_number: 
+    order_number:
     order_populator:
       out_of_stock: "%{item} non è disponibile."
       please_enter_reasonable_quantity: Per favore immetti una quantità ragionevole.
@@ -911,7 +912,7 @@ it:
       label: L'ordine deve contenere %{select} di questi prodotti
       match_all: tutti
       match_any: almeno uno
-      match_none: 
+      match_none:
       product_source:
         group: Dal gruppo di prodotti
         manual: Scegli manualmente
@@ -958,7 +959,7 @@ it:
         name: L'utente ha effettuato il login
     promotion_uses: Utilizzi Promozione
     promotions: Promozioni
-    propagate_all_variants: 
+    propagate_all_variants:
     properties: Proprietà
     property: Proprietà
     prototype: Prototipo
@@ -1066,10 +1067,10 @@ it:
     show_active: Mostra Attivi
     show_deleted: Mostra Eliminati
     show_only_complete_orders: Visualizza solo gli ordini completi
-    show_only_considered_risky: 
+    show_only_considered_risky:
     show_rate_in_label: Mostra percentuale nell'etichetta
     sku: SKU
-    skus: 
+    skus:
     slug: Slug
     source: Origine
     special_instructions: Istruzioni Speciali
@@ -1086,7 +1087,7 @@ it:
     stock_location: Magazzino
     stock_location_info: Informazioni Magazzino
     stock_locations: Magazzini
-    stock_locations_need_a_default_country: 
+    stock_locations_need_a_default_country:
     stock_management: Gestione Scorte
     stock_management_requires_a_stock_location: Per favore crea un Magazzino per poter gestire le scorte.
     stock_movements: Movimenti di Magazzino
@@ -1131,14 +1132,14 @@ it:
     there_are_no_items_for_this_order: Non ci sono articoli per questo ordine. Per favore aggiungi un articolo all'ordine per continuare.
     there_were_problems_with_the_following_fields: Ci sono dei problemi con i seguenti campi
     thumbnail: Immagine
-    tiered_flat_rate: 
-    tiered_percent: 
-    tiers: 
+    tiered_flat_rate:
+    tiered_percent:
+    tiers:
     time: Ora
     to_add_variants_you_must_first_define: Per aggiungere varianti, devi prima definire
     total: Totale
     total_price: Prezzo totale
-    total_sales: 
+    total_sales:
     track_inventory: Traccia Inventario
     tracking: Tracking
     tracking_number: Codice Tracking

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -633,6 +633,7 @@ ja:
       only_incomplete: 
       select_locale: 
       show_only: 
+      store_translations:
       supported_locales: "サポートしている言語"
       this_file_language: "日本語 (ja-JP)"
       translations: "翻訳"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -633,6 +633,7 @@ ko:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: "한국의 (KO)"
       translations:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -633,6 +633,7 @@ lv:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: Latvijas (LV)
       translations:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -637,6 +637,7 @@ nl:
       only_incomplete: Enkel onvolledige
       select_locale: Selecteer regio-instelling
       show_only: Toon enkel
+      store_translations:
       supported_locales: Ondersteunde regio-instellingen
       this_file_language: Nederlands (NL)
       translations: Vertalingen

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -617,6 +617,7 @@ pl:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: Polski (PL)
       translations:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -647,6 +647,7 @@ pt-BR:
       only_incomplete: Apenas incompletas
       select_locale: Selecione o idioma
       show_only: Mostrar apenas
+      store_translations:
       supported_locales: Idiomas suportados
       this_file_language: Português (BR)
       translations: Traduções

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -633,6 +633,7 @@ pt:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: Português (PT)
       translations:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -635,6 +635,7 @@ ro:
       only_incomplete: Doar nefinalizate
       select_locale: Setează localizare
       show_only: Afișează doar
+      store_translations:
       supported_locales: Localizări sprijinite
       this_file_language: Romanian (RO)
       translations: Traduceri

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -678,6 +678,7 @@ ru:
       only_incomplete: "Только незавершённые"
       select_locale: "Выберите локализацию"
       show_only: "Показывать только"
+      store_translations:
       supported_locales: "Поддерживаемые языки"
       this_file_language: Russian
       translations: "Переводы"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -633,6 +633,7 @@ sk:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: Slovenčina
       translations:

--- a/config/locales/sl-SI.yml
+++ b/config/locales/sl-SI.yml
@@ -633,6 +633,7 @@ sl-SI:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: Slovenščina (SL)
       translations:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -635,6 +635,7 @@ sv:
       only_incomplete: Endast ofullständiga
       select_locale: Välj språk
       show_only: Visa endast
+      store_translations:
       supported_locales: Tillgängliga språk
       this_file_language: Svenska (SE)
       translations: "Översättningar"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -633,6 +633,7 @@ th:
       only_incomplete: "เฉพาะที่ไม่สมบูรณ์"
       select_locale: "เลือกภาษา"
       show_only: "แสดงเฉพาะ"
+      store_translations:
       supported_locales: "ภาษาที่รองรับ"
       this_file_language: "ภาษาไทย (TH)"
       translations: "แปล"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -587,6 +587,7 @@ tr:
       only_incomplete: Sadece tamamlanmayanlar
       select_locale: Dil Seç
       show_only: Sadece Şunları Göster
+      store_translations:
       supported_locales: Desteklenen Diller
       this_file_language: Türkçe (TR)
       translations: "Çeviriler"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -719,6 +719,7 @@ uk:
       only_incomplete: "Тільки не завершені"
       select_locale: "Виберіть мову"
       show_only: "Відображати тільки"
+      store_translations:
       supported_locales: "Мови, що підтримуються"
       this_file_language: Ukrainian
       translations: "Переклади"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -633,6 +633,7 @@ vi:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: tiếng Việt (VN)
       translations:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -633,6 +633,7 @@ zh-CN:
       only_incomplete:
       select_locale:
       show_only:
+      store_translations:
       supported_locales:
       this_file_language: "中文(简体)"
       translations:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -593,6 +593,7 @@ zh-TW:
       only_incomplete: "只限非完成"
       select_locale: "選擇語系"
       show_only: "只顯示"
+      store_translations:
       supported_locales: "支援語系"
       this_file_language: "中文 (繁體)"
       translations: "翻譯"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.add_routes do
-  post '/locale/set', :to => 'locale#set', :defaults => { :format => :json }, :as => :set_locale
+  post '/locale/set', to: 'locale#set', defaults: { format: :json }, as: :set_locale
 
   namespace :admin do
     get '/:resource/:resource_id/translations' => 'translations#index', as: :translations

--- a/db/migrate/20150323210949_add_translations_to_store.rb
+++ b/db/migrate/20150323210949_add_translations_to_store.rb
@@ -1,0 +1,12 @@
+class AddTranslationsToStore < ActiveRecord::Migration
+  def up
+    unless table_exists?(:spree_store_translations)
+      params = { name: :string, meta_description: :text, meta_keywords: :text, seo_title: :string }
+      Spree::Store.create_translation_table!(params, { migrate_data: true })
+    end
+  end
+
+  def down
+    Spree::Store.drop_translation_table! migrate_data: true
+  end
+end

--- a/lib/spree_i18n/engine.rb
+++ b/lib/spree_i18n/engine.rb
@@ -28,6 +28,9 @@ module SpreeI18n
 
       option_value_attributes = { translations_attributes: [:id, :locale, :name, :presentation] }
       Spree::PermittedAttributes.option_value_attributes << option_value_attributes
+
+      store_attributes = { translations_attributes: [:id, :locale, :name, :meta_description, :meta_keywords, :seo_title] }
+      Spree::PermittedAttributes.store_attributes << store_attributes
     end
 
     def self.activate

--- a/spec/features/admin/translations_spec.rb
+++ b/spec/features/admin/translations_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Translations', :js do
   given(:language) { Spree.t(:'i18n.this_file_language', locale: 'pt-BR') }
 
   background do
+    create(:store)
     reset_spree_preferences
     SpreeI18n::Config.available_locales = [:en, :'pt-BR']
     SpreeI18n::Config.supported_locales = [:en, :'pt-BR']
@@ -166,6 +167,21 @@ RSpec.feature 'Translations', :js do
       change_locale
       visit spree.root_path
       expect(page).to have_content('Acusticas')
+    end
+  end
+
+  context "store" do
+    scenario 'saves translated attributes properly' do
+      visit spree.edit_admin_general_settings_path
+      click_link "Store Translations"
+
+      within("#attr_fields .name.pt-BR.odd") { fill_in_name "nome store" }
+      click_on "Update"
+
+      visit spree.edit_admin_general_settings_path
+      click_link "Store Translations"
+
+      expect(page).to have_selector("input[value='nome store']")
     end
   end
 


### PR DESCRIPTION
This is my attempt to add globalize support to `Store` SEO fields.
It's pretty similar to all other models, but this time the translations page is linked from the configuration side menu.

BUT:

migrations are broken on new stores, because an old Spree migration (`create_store_from_preferences`) adds some Store data, so it search for the translation table, which is not there yet.
Any idea how to fix this in a proper way?

Will also add specs after that