### PR TITLE
Set locales from URL using routing-filter, closes #488

### DIFF
--- a/app/assets/javascripts/spree/frontend/locale.js.coffee
+++ b/app/assets/javascripts/spree/frontend/locale.js.coffee
@@ -1,10 +1,3 @@
 $ ->
   $('#locale-select select').change ->
-    $.ajax(
-      type: 'POST'
-      url: $(this).data('href')
-      data:
-        locale: $(this).val()
-        authenticity_token: $('#locale-select input[name="authenticity_token"]').val()
-    ).done ->
-      window.location.reload()
+    @form.submit()

--- a/app/controllers/spree/locale_controller.rb
+++ b/app/controllers/spree/locale_controller.rb
@@ -1,12 +1,7 @@
 module Spree
   class LocaleController < Spree::StoreController
     def set
-      session[:locale] = params[:locale]
-
-      respond_to do |format|
-        format.json { render json: true }
-        format.html { redirect_to root_path }
-      end
+      redirect_to root_path(locale: params[:switch_to_locale])
     end
   end
 end

--- a/app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface
+++ b/app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface
@@ -1,10 +1,12 @@
 <!-- insert_bottom '#main-nav-bar > .navbar-right' -->
-<% if SpreeI18n::Config.supported_locales.size > 1 %>
+<% if SpreeI18n::Config.supported_locales.many? %>
   <li id="locale-select" data-hook>
     <%= form_tag spree.set_locale_path, class: 'navbar-form' do %>
       <div class="form-group">
-        <label for="locale" class="sr-only"><%= Spree.t(:'i18n.language') %></label>
-        <%= select_tag(:locale, options_for_select(supported_locales_options, I18n.locale), class: 'form-control', data: { href: spree.set_locale_path }) %>
+        <label for="switch_to_locale" class="sr-only">
+          <%= Spree.t(:'i18n.language') %>
+        </label>
+        <%= select_tag(:switch_to_locale, options_for_select(supported_locales_options, I18n.locale), class: 'form-control') %>
         <noscript><%= submit_tag %></noscript>
       </div>
     <% end %>

--- a/config/initializers/routing_filter.rb
+++ b/config/initializers/routing_filter.rb
@@ -1,0 +1,2 @@
+# do not include the default locale in the URL
+RoutingFilter::Locale.include_default_locale = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Spree::Core::Engine.add_routes do
+  # from routing-filter gem
+  filter :locale
+
   post '/locale/set', to: 'locale#set', defaults: { format: :json }, as: :set_locale
 
   namespace :admin do

--- a/lib/spree_i18n/controller_locale_helper.rb
+++ b/lib/spree_i18n/controller_locale_helper.rb
@@ -25,8 +25,8 @@ module SpreeI18n
         # supported locales defined by SpreeI18n::Config.supported_locales can
         # actually be set
         def set_user_language
-          I18n.locale = if session.key?(:locale) && Config.supported_locales.include?(session[:locale].to_sym)
-            session[:locale]
+          I18n.locale = if params[:locale] && Config.supported_locales.include?(params[:locale].to_sym)
+            params[:locale]
           elsif respond_to?(:config_locale, true) && !config_locale.blank?
             config_locale
           else

--- a/lib/spree_i18n/controller_locale_helper.rb
+++ b/lib/spree_i18n/controller_locale_helper.rb
@@ -5,19 +5,8 @@ module SpreeI18n
   module ControllerLocaleHelper
     extend ActiveSupport::Concern
     included do
-      # Ensures any existing action of the same kind and name retains its
-      # position in the callback chain
-      def self._stable_action(kind, name)
-        # When registering a callback where one of the same kind and name already
-        # exists in the chain, ActiveSupport removes the existing one and appends
-        # the new one to the end, disrupting the existing chain order
-        unless _process_action_callbacks.select { |c| c.kind == kind }.find { |c| c.filter == name }
-          send("#{kind}_action", name)
-        end
-      end
-
-      _stable_action :before, :set_user_language
       prepend_before_filter :globalize_fallbacks
+      prepend_before_filter :set_user_language
 
       private
 
@@ -25,6 +14,7 @@ module SpreeI18n
         # supported locales defined by SpreeI18n::Config.supported_locales can
         # actually be set
         def set_user_language
+          # params[:locale] can be added by routing-filter gem
           I18n.locale = if params[:locale] && Config.supported_locales.include?(params[:locale].to_sym)
             params[:locale]
           elsif respond_to?(:config_locale, true) && !config_locale.blank?

--- a/lib/spree_i18n/engine.rb
+++ b/lib/spree_i18n/engine.rb
@@ -1,5 +1,6 @@
 require 'globalize'
 require 'friendly_id/globalize'
+require 'routing_filter'
 
 module SpreeI18n
   class Engine < Rails::Engine

--- a/spec/controllers/locales_controller_spec.rb
+++ b/spec/controllers/locales_controller_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Spree::HomeController, type: :controller do
 
   context "tries not supported fr locale" do
     it "falls back do default locale" do
-      get :index, { use_route: :spree }, { locale: 'fr' }
+      get :index, use_route: :spree, locale: 'fr'
       expect(I18n.locale).to eq :en
     end
   end
 
   context "tries supported es locale" do
     it "falls back do default locale" do
-      get :index, { use_route: :spree }, { locale: 'es' }
+      get :index, use_route: :spree, locale: 'es'
       expect(I18n.locale).to eq :es
     end
   end

--- a/spec/features/admin/translations_spec.rb
+++ b/spec/features/admin/translations_spec.rb
@@ -231,12 +231,9 @@ RSpec.feature "Translations", :js do
 
   private
 
-  # sleep 1 second to make sure the ajax request process properly
   def change_locale
     visit spree.root_path
-    within("#locale-select") { select language, from: "locale" }
-    sleep 1
-    visit spree.root_path
+    within("#locale-select") { select language, from: "switch_to_locale" }
   end
 
   def fill_in_name(value)

--- a/spec/features/admin/translations_spec.rb
+++ b/spec/features/admin/translations_spec.rb
@@ -13,15 +13,15 @@ RSpec.feature "Translations", :js do
     given(:product) { create(:product) }
 
     context "fills in translations fields" do
-      scenario "displays translated name on frontend" do
+      scenario "saves translated attributes properly" do
         visit spree.admin_product_path(product)
         click_on "Translations"
 
         within("#attr_fields .name.en") { fill_in_name "Pearl Jam" }
         within("#attr_fields .name.pt-BR") { fill_in_name "Geleia de perola" }
         click_on "Update"
+        visit spree.admin_product_path(product, locale: 'pt-BR')
 
-        change_locale
         expect(page).to have_text_like 'Geleia de perola'
       end
     end
@@ -29,24 +29,22 @@ RSpec.feature "Translations", :js do
     context "product properties" do
       given!(:product_property) { create(:product_property, value: "red") }
 
-      scenario "displays translated value on frontend" do
+      scenario "saves translated attributes properly" do
         visit spree.admin_product_product_properties_path(product_property.product)
         within_row(1) { click_icon :translate }
 
         within("#attr_fields .value.pt-BR") { fill_in_name "vermelho" }
         click_on "Update"
+        visit spree.admin_product_product_properties_path(product_property.product, locale: 'pt-BR')
 
-        change_locale
-        visit spree.admin_product_product_properties_path(product_property.product)
-
-        expect(page).to have_text_like 'vermelho'
+        expect(page).to have_selector("input[value=vermelho]")
       end
     end
 
     context "option types" do
       given!(:option_type) { create(:option_value).option_type }
 
-      scenario "displays translated name on frontend" do
+      scenario "saves translated attributes properly" do
         visit spree.admin_option_types_path
         within_row(1) { click_icon :translate }
 
@@ -55,9 +53,8 @@ RSpec.feature "Translations", :js do
         within("#attr_fields .presentation.en") { fill_in_name "size" }
         within("#attr_fields .presentation.pt-BR") { fill_in_name "tamanho" }
         click_on "Update"
+        visit spree.admin_option_types_path(locale: 'pt-BR')
 
-        change_locale
-        visit spree.admin_option_types_path
         expect(page).to have_text_like 'tamanho'
       end
 
@@ -77,8 +74,8 @@ RSpec.feature "Translations", :js do
     context "option values" do
       given!(:option_type) { create(:option_value).option_type }
 
-      scenario "displays translated name on frontend" do
-        visit spree.edit_admin_option_type_path(option_type)
+      scenario "saves translated attributes properly" do
+        visit spree.admin_option_types_path
         within_row(1) { click_icon :translate }
 
         within("#attr_fields .name.en") { fill_in_name "big" }
@@ -86,17 +83,16 @@ RSpec.feature "Translations", :js do
         within("#attr_fields .presentation.en") { fill_in_name "big" }
         within("#attr_fields .presentation.pt-BR") { fill_in_name "grande" }
         click_on "Update"
+        visit spree.admin_option_types_path(locale: 'pt-BR')
 
-        change_locale
-        visit spree.edit_admin_option_type_path(option_type)
-        expect(page).to have_selector("input[value=grande]")
+        expect(page).to have_text_like 'grande'
       end
     end
 
     context "properties" do
       given!(:property) { create(:property) }
 
-      scenario "displays translated name on frontend" do
+      scenario "saves translated attributes properly" do
         visit spree.admin_properties_path
         within_row(1) { click_icon :translate }
 
@@ -105,9 +101,7 @@ RSpec.feature "Translations", :js do
         within("#attr_fields .presentation.en") { fill_in_name "Model" }
         within("#attr_fields .presentation.pt-BR") { fill_in_name "Modelo" }
         click_on "Update"
-
-        change_locale
-        visit spree.admin_properties_path
+        visit spree.admin_properties_path(locale: 'pt-BR')
 
         expect(page).to have_text_like 'Modelo'
       end
@@ -124,9 +118,8 @@ RSpec.feature "Translations", :js do
       within("#attr_fields .name.en") { fill_in_name "All free" }
       within("#attr_fields .name.pt-BR") { fill_in_name "Salve salve" }
       click_on "Update"
+      visit spree.admin_promotions_path(locale: 'pt-BR')
 
-      change_locale
-      visit spree.admin_promotions_path
       expect(page).to have_text_like 'Salve salve'
     end
 
@@ -134,6 +127,7 @@ RSpec.feature "Translations", :js do
       visit spree.admin_promotions_path
       within_row(1) { click_icon :translate }
       click_on 'Cancel'
+
       expect(page).to have_css('.content-header')
     end
   end
@@ -141,16 +135,15 @@ RSpec.feature "Translations", :js do
   context "taxonomies" do
     given!(:taxonomy) { create(:taxonomy) }
 
-    scenario "display translated name on frontend" do
+    scenario "saves translated attributes properly" do
       visit spree.admin_taxonomies_path
       within_row(1) { click_icon :translate }
 
       within("#attr_fields .name.en") { fill_in_name "Guitars" }
       within("#attr_fields .name.pt-BR") { fill_in_name "Guitarras" }
       click_on "Update"
+      visit spree.admin_taxonomies_path(locale: 'pt-BR')
 
-      change_locale
-      visit spree.root_path
       expect(page).to have_text_like 'Guitarras'
     end
   end
@@ -159,7 +152,7 @@ RSpec.feature "Translations", :js do
     given!(:taxonomy) { create(:taxonomy) }
     given!(:taxon) { create(:taxon, taxonomy: taxonomy, parent_id: taxonomy.root.id) }
 
-    scenario "display translated name on frontend" do
+    scenario "saves translated attributes properly" do
       visit spree.admin_translations_path('taxons', taxon.id)
 
       within("#attr_fields .name.en") { fill_in_name "Acoustic" }
@@ -176,9 +169,9 @@ RSpec.feature "Translations", :js do
       # ensure taxon is in root or it will not be visible
       expect(taxonomy.root.children.count).to be(1)
 
-      change_locale
-      visit spree.root_path
-      expect(page).to have_text_like 'Acusticas'
+      visit spree.admin_translations_path('taxons', taxon.id, locale: 'pt-BR')
+
+      expect(page).to have_selector("input[value=Acusticas]")
     end
   end
 
@@ -195,7 +188,6 @@ RSpec.feature "Translations", :js do
     scenario "adds german to supported locales and pick it on front end" do
       targetted_select2_search(language, from: '#s2id_supported_locales_')
       click_on 'Update'
-      change_locale
       expect(SpreeI18n::Config.supported_locales).to include(:de)
     end
 
@@ -230,11 +222,6 @@ RSpec.feature "Translations", :js do
   end
 
   private
-
-  def change_locale
-    visit spree.root_path
-    within("#locale-select") { select language, from: "switch_to_locale" }
-  end
 
   def fill_in_name(value)
     fill_in first("input[type='text']")["name"], with: value

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -11,8 +11,8 @@ RSpec.feature "Translations", :js do
   context 'page' do
     context 'switches locale from the dropdown' do
       scenario 'selected translation is applied' do
-        visit '/'
-        select('Português (BR)', from: 'Language')
+        visit spree.root_path
+        select('Português (BR)', from: Spree.t(:'i18n.language'))
         expect(page).to have_content('Início')
       end
     end

--- a/spec/support/matchers/have_text_like.rb
+++ b/spec/support/matchers/have_text_like.rb
@@ -1,7 +1,3 @@
-RSpec::Matchers.define :have_text_like do |expected|
-  match { have_text(/#{expected}/iu) }
-
-  failure_message do
-    "expected that text would exist with '#{expected}'"
-  end
+def have_text_like(expected)
+  have_text(/#{Regexp.quote(expected)}/iu)
 end

--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'globalize', '~> 5.0.1'
   s.add_runtime_dependency 'i18n_data', '~> 0.5.1'
   s.add_runtime_dependency 'rails-i18n', '~> 4.0.1'
+  s.add_runtime_dependency 'routing-filter', '~> 0.5.0'
   s.add_runtime_dependency 'spree_core', '~> 3.1.0.beta'
 
   s.add_development_dependency 'byebug'

--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'selenium-webdriver', '>= 2.41'
   s.add_development_dependency 'simplecov', '~> 0.9.0'
   s.add_development_dependency 'guard-rspec', '>= 4.2.0'
+  s.add_development_dependency 'launchy'
 end


### PR DESCRIPTION
This switches the locale setting logic from session to just URL, as discussed on https://github.com/spree-contrib/spree_i18n/issues/488

This should bring some advantages, from SEO to indipendent backend locale, and simplify things.

/cc @huoxito @JDutil  

Still working on specs.