### PR TITLE
Admin UI improvements

### DIFF
--- a/app/assets/javascripts/spree/backend/translations.js.coffee
+++ b/app/assets/javascripts/spree/backend/translations.js.coffee
@@ -1,13 +1,15 @@
 display_locale_fields = () ->
-  attr = $('#attr_list li.active a').data('attr')
+  console.log 'display locale fields'
+  attr    = $('#attr_list a.active').data('attr')
   locales = $('#locale').val()
-  show = $("input[name='show-only']:checked").val()
+  show    = $("select[name='show-only']").val()
+  console.log show
 
-  $('table#attr_fields tr').hide()
+  $('#attr_fields .panel').hide()
 
   for locale in locales
     do (locale) ->
-      value = $('table#attr_fields tr.' + attr + '.' + locale + ' td.translation :input').val().replace /^\s+|\s+$/g, ""
+      value = $('#attr_fields .panel.' + attr + '.' + locale + ' :input').val().replace /^\s+|\s+$/g, ""
 
       if show == 'incomplete'
         display = value == ''
@@ -17,22 +19,24 @@ display_locale_fields = () ->
         display = true
 
       if display
-        $('table#attr_fields tr.' + attr + '.' + locale).show()
+        $('#attr_fields .panel.' + attr + '.' + locale).show()
 
-  if $('table#attr_fields tr:visible').length == 0 and show != 'all'
-    $('table#attr_fields tfoot tr').show()
-    $('table#attr_fields tfoot td').html('No <strong>' + show + '</strong> translations for <strong>' + attr + '</strong>.')
+  if $('#attr_fields .panel:visible').length == 0 and show != 'all'
+    $('#attr_fields .no-translations').show()
 
 
 $ ->
   $('#attr_list a').click ->
-    $('#attr_list li').removeClass('active')
-    $(this).parent().addClass('active')
+    $('#attr_list a').removeClass('active')
+    $(this).addClass('active')
 
     display_locale_fields()
     false
 
   $('#locale, #supported_locales_, #available_locales_').select2({placeholder: 'Please select a language.'})
-  $('#locale').change display_locale_fields
-  $("input[name='show-only']").change display_locale_fields
+  $('#locale').change ->
+    display_locale_fields()
+
+  $("select[name='show-only']").change ->
+    display_locale_fields()
 

--- a/app/assets/javascripts/spree/backend/translations.js.coffee
+++ b/app/assets/javascripts/spree/backend/translations.js.coffee
@@ -1,9 +1,7 @@
 display_locale_fields = () ->
-  console.log 'display locale fields'
   attr    = $('#attr_list a.active').data('attr')
   locales = $('#locale').val()
   show    = $("select[name='show-only']").val()
-  console.log show
 
   $('#attr_fields .panel').hide()
 

--- a/app/assets/stylesheets/spree/backend/spree_i18n.css
+++ b/app/assets/stylesheets/spree/backend/spree_i18n.css
@@ -6,3 +6,12 @@
  *= require spree/backend
  *= require_tree .
 */
+
+/* This belongs to the core, not that extension */
+.no-margin-bottom {
+	margin-bottom: 0;
+}
+
+.no-padding-bottom {
+	padding-bottom: 0;
+}

--- a/app/overrides/spree/admin/general_settings/edit/localization_settings.html.erb.deface
+++ b/app/overrides/spree/admin/general_settings/edit/localization_settings.html.erb.deface
@@ -1,12 +1,19 @@
 <!-- insert_after '.row .security' -->
-<fieldset class="security">
-  <legend><%= Spree.t(:'i18n.localization_settings') %></legend>
-  <div class="form-group">
-    <label for="supported_locales_"><%= Spree.t(:'i18n.supported_locales') %></label>
-    <%= select_supported_locales %>
+<div class="panel panel-default panel-localization">
+  <div class="panel-heading">
+    <h1 class="panel-title"><%= Spree.t(:'i18n.localization_settings') %></h1>
   </div>
-  <div class="form-group">
-    <label for="available_locales_"><%= Spree.t(:'i18n.available_locales') %></label>
-    <%= select_available_locales %>
+
+  <div class="panel-body">
+    <div class="form-group">
+      <label for="supported_locales_"><%= Spree.t(:'i18n.supported_locales') %></label>
+      <%= select_supported_locales %>
+      <p class="help-block"><%= Spree.t(:'i18n.locales_displayed_on_frontend_select_box') %></p>
+    </div>
+    <div class="form-group">
+      <label for="available_locales_"><%= Spree.t(:'i18n.available_locales') %></label>
+      <%= select_available_locales %>
+      <p class="help-block"><%= Spree.t(:'i18n.locales_displayed_on_translation_forms') %></p>
+    </div>
   </div>
-</fieldset>
+</div>

--- a/app/views/spree/admin/translations/_fields.html.erb
+++ b/app/views/spree/admin/translations/_fields.html.erb
@@ -1,0 +1,8 @@
+<div class="panel panel-default fields">
+  <div class="panel-heading"><%= Spree.t(:'i18n.fields') %></div>
+  <div class="list-group" id="attr_list">
+    <% @resource.class.translated_attribute_names.each_with_index do |attr, i| %>
+      <a class="list-group-item <%= 'active' if i == 0 %>" data-attr="<%= attr %>" href="#"><%= Spree.t(attr) %></a>
+    <% end %>
+  </div>
+</div>

--- a/app/views/spree/admin/translations/_form.html.erb
+++ b/app/views/spree/admin/translations/_form.html.erb
@@ -1,28 +1,8 @@
-<div class="well well-sm">
-	<div class="row no-padding-bottom">
-	  <div class="col-md-4">
-	  	<div class="form-group no-margin-bottom">
-		  	<label><%= Spree.t(:show) %></label>
-		    <select class="form-control" name="show-only">
-			    <option value="all"><%= Spree.t(:all) %></option>
-			    <option value="incomplete"><%= Spree.t(:'i18n.only_incomplete') %></option>
-			    <option value="complete"><%= Spree.t(:'i18n.only_complete') %></option>
-		    </select>
-	    </div>
-	  </div>
-
-	  <div class="col-md-8">
-	  	<div class="form-group no-margin-bottom">
-	  		<label>Select locale</label>
-		  	<%= select_available_locales_fields %>
-		  </div>
-	  </div>
-	</div>
-</div>
+<%= render 'settings' %>
 
 <div class="row translations">
   <div class="col-md-4">
-    <%= render 'settings' %>
+    <%= render 'fields' %>
   </div>
   <div class="col-md-8">
     <%= form_for [:admin, @resource] do |f| %>

--- a/app/views/spree/admin/translations/_form.html.erb
+++ b/app/views/spree/admin/translations/_form.html.erb
@@ -1,3 +1,25 @@
+<div class="well well-sm">
+	<div class="row no-padding-bottom">
+	  <div class="col-md-4">
+	  	<div class="form-group no-margin-bottom">
+		  	<label><%= Spree.t(:show) %></label>
+		    <select class="form-control" name="show-only">
+			    <option value="all"><%= Spree.t(:all) %></option>
+			    <option value="incomplete"><%= Spree.t(:'i18n.only_incomplete') %></option>
+			    <option value="complete"><%= Spree.t(:'i18n.only_complete') %></option>
+		    </select>
+	    </div>
+	  </div>
+
+	  <div class="col-md-8">
+	  	<div class="form-group no-margin-bottom">
+	  		<label>Select locale</label>
+		  	<%= select_available_locales_fields %>
+		  </div>
+	  </div>
+	</div>
+</div>
+
 <div class="row translations">
   <div class="col-md-4">
     <%= render 'settings' %>

--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -1,44 +1,35 @@
-<fieldset>
-  <legend><%= Spree.t(:'i18n.translations') %></legend>
-  <table id="attr_fields" class="table">
-    <colgroup>
-      <col style="width: 10%" />
-      <col style="width: 90%" />
-    </colgroup>
-    <tbody>
-      <% SpreeI18n::Config.available_locales.each do |locale| %>
-        <%= f.globalize_fields_for locale.to_sym do |g| %>
-          <% @resource.class.translated_attribute_names.each_with_index do |attr, i| %>
-            <tr style="display:<%= i == 0 ? 'auto' : 'none' %>;" class="<%= attr %> <%= locale %> even">
-              <td colspan="2">
-                <%= Spree.t(:'i18n.this_file_language', locale: locale) %> -
-                <%= Spree.t(attr, locale: locale) %>
-              </td>
-            </tr>
-            <tr style="display:<%= i == 0 ? 'auto' : 'none' %>;" class="<%= attr %> <%= locale %> odd">
-              <td class="flag">
-                <% if locale.to_s.include?('-') %>
-                  <img src="https://www.localeapp.com/assets/flags/regions/<%= locale.to_s.split('-').last %>.png">
-                <% else %>
-                  <img src="https://www.localeapp.com/assets/flags/languages/<%= locale %>.png">
-                <% end %>
-              </td>
-              <td class="translation">
-                <% if @resource.class.columns_hash[attr.to_s].type == :text %>
-                  <%= g.text_area attr, class: 'form-control', rows: 4 %>
-                <% else %>
-                  <%= g.text_field attr, class: 'form-control' %>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        <% end %>
+<div id="attr_fields">
+  <% SpreeI18n::Config.available_locales.each do |locale| %>
+    <%= f.globalize_fields_for locale.to_sym do |g| %>
+      <% @resource.class.translated_attribute_names.each_with_index do |attr, i| %>
+        <div class="panel panel-default <%= attr %> <%= locale %>" style="display:<%= i == 0 ? 'auto' : 'none' %>;">
+          <div class="panel-heading">
+            <%= Spree.t(attr, locale: locale) %>
+
+            <div class="pull-right text-muted">
+              <small><i><%= Spree.t(:'i18n.this_file_language', locale: locale) %></i></small>
+
+              <% if locale.to_s.include?('-') %>
+                <img src="https://www.localeapp.com/assets/flags/regions/<%= locale.to_s.split('-').last %>.png">
+              <% else %>
+                <img src="https://www.localeapp.com/assets/flags/languages/<%= locale %>.png">
+              <% end %>
+            </div>
+          </div>
+
+          <div class="panel-body">
+            <% if @resource.class.columns_hash[attr.to_s].type == :text %>
+              <%= g.text_area attr, class: 'form-control', rows: 4 %>
+            <% else %>
+              <%= g.text_field attr, class: 'form-control' %>
+            <% end %>
+          </div>
+        </div>
       <% end %>
-    </tbody>
-    <tfoot>
-      <tr style="display:none;">
-        <td colspan="2"></td>
-      </tr>
-    </tfoot>
-  </table>
-</fieldset>
+    <% end %>
+  <% end %>
+
+  <p class="no-translations" style="display: none">There are no any translation for given criteria</p>
+</div>
+
+<hr/>

--- a/app/views/spree/admin/translations/_settings.html.erb
+++ b/app/views/spree/admin/translations/_settings.html.erb
@@ -1,39 +1,8 @@
-<fieldset>
-  <legend><%= Spree.t(:settings) %></legend>
-  <div class="row">
-    <div class="col-md-12">
-      <label for="show-only"><%= Spree.t(:'i18n.show_only') %></label>
-      <div class="form-group">
-        <label for="show-only-all" class="radio-inline">
-          <input type="radio" name="show-only" value="all" id="show-only-all" checked>
-          <%= Spree.t(:all) %>
-        </label>
-        <label for="show-only-incomplete" class="radio-inline">
-          <input type="radio" name="show-only" value="incomplete" id="show-only-incomplete">
-          <%= Spree.t(:'i18n.only_incomplete') %>
-        </label>
-        <label for="show-only-complete" class="radio-inline">
-          <input type="radio" name="show-only" value="complete" id="show-only-complete">
-          <%= Spree.t(:'i18n.only_complete') %>
-        </label>
-      </div>
-      <div class="form-group">
-        <label for="locale"><%= Spree.t(:'i18n.select_locale') %></label>
-        <%= select_available_locales_fields %>
-      </div>
-    </div>
+<div class="panel panel-default fields">
+  <div class="panel-heading"><%= Spree.t(:'i18n.fields') %></div>
+  <div class="list-group" id="attr_list">
+    <% @resource.class.translated_attribute_names.each_with_index do |attr, i| %>
+      <a class="list-group-item <%= 'active' if i == 0 %>" data-attr="<%= attr %>" href="#"><%= Spree.t(attr) %></a>
+    <% end %>
   </div>
-</fieldset>
-
-<fieldset>
-  <legend><%= Spree.t(:'i18n.fields') %></legend>
-  <nav class="menu">
-    <ul id="attr_list">
-      <% @resource.class.translated_attribute_names.each_with_index do |attr, i| %>
-        <li class="<%= 'active' if i == 0 %>">
-          <a data-attr="<%= attr %>" href="#"><%= Spree.t(attr) %></a>
-        </li>
-      <% end %>
-    </ul>
-  </nav>
-</fieldset>
+</div>

--- a/app/views/spree/admin/translations/_settings.html.erb
+++ b/app/views/spree/admin/translations/_settings.html.erb
@@ -1,8 +1,21 @@
-<div class="panel panel-default fields">
-  <div class="panel-heading"><%= Spree.t(:'i18n.fields') %></div>
-  <div class="list-group" id="attr_list">
-    <% @resource.class.translated_attribute_names.each_with_index do |attr, i| %>
-      <a class="list-group-item <%= 'active' if i == 0 %>" data-attr="<%= attr %>" href="#"><%= Spree.t(attr) %></a>
-    <% end %>
-  </div>
+<div class="well well-sm">
+	<div class="row no-padding-bottom">
+	  <div class="col-md-4">
+	  	<div class="form-group no-margin-bottom">
+		  	<label><%= Spree.t(:show) %></label>
+		    <select class="form-control" name="show-only">
+			    <option value="all"><%= Spree.t(:all) %></option>
+			    <option value="incomplete"><%= Spree.t(:'i18n.only_incomplete') %></option>
+			    <option value="complete"><%= Spree.t(:'i18n.only_complete') %></option>
+		    </select>
+	    </div>
+	  </div>
+
+	  <div class="col-md-8">
+	  	<div class="form-group no-margin-bottom">
+	  		<label>Select locale</label>
+		  	<%= select_available_locales_fields %>
+		  </div>
+	  </div>
+	</div>
 </div>

--- a/app/views/spree/admin/translations/option_value.html.erb
+++ b/app/views/spree/admin/translations/option_value.html.erb
@@ -6,9 +6,11 @@
   <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn-primary', icon: 'arrow-left' %>
 <% end %>
 
+<%= render 'settings' %>
+
 <div class="row translations">
   <div class="col-md-4">
-    <%= render 'settings' %>
+    <%= render 'fields' %>
   </div>
   <div class="col-md-8">
     <%= form_for [:admin, :option_type, @resource] do |f| %>

--- a/app/views/spree/admin/translations/product_property.html.erb
+++ b/app/views/spree/admin/translations/product_property.html.erb
@@ -8,7 +8,7 @@
 
 <div class="row translations">
   <div class="col-md-4">
-    <%= render 'settings' %>
+    <%= render 'fields' %>
   </div>
   <div class="col-md-8">
     <%= form_for [:admin, @resource.product, @resource], method: :patch do |f| %>

--- a/app/views/spree/admin/translations/taxon.html.erb
+++ b/app/views/spree/admin/translations/taxon.html.erb
@@ -6,9 +6,11 @@
   <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary', icon: 'arrow-left' %>
 <% end %>
 
+<%= render 'settings' %>
+
 <div class="row translations">
   <div class="col-md-4">
-    <%= render 'settings' %>
+    <%= render 'fields' %>
   </div>
   <div class="col-md-8">
     <%= form_for [:admin, @resource.taxonomy, @resource], url: admin_taxonomy_taxon_path(@taxon.taxonomy, @taxon.id) do |f| %>

--- a/spec/features/admin/translations_spec.rb
+++ b/spec/features/admin/translations_spec.rb
@@ -17,8 +17,8 @@ RSpec.feature "Translations", :js do
         visit spree.admin_product_path(product)
         click_on "Translations"
 
-        within("#attr_fields .name.en.odd") { fill_in_name "Pearl Jam" }
-        within("#attr_fields .name.pt-BR.odd") { fill_in_name "Geleia de perola" }
+        within("#attr_fields .name.en") { fill_in_name "Pearl Jam" }
+        within("#attr_fields .name.pt-BR") { fill_in_name "Geleia de perola" }
         click_on "Update"
 
         change_locale
@@ -33,7 +33,7 @@ RSpec.feature "Translations", :js do
         visit spree.admin_product_product_properties_path(product_property.product)
         within_row(1) { click_icon :translate }
 
-        within("#attr_fields .value.pt-BR.odd") { fill_in_name "vermelho" }
+        within("#attr_fields .value.pt-BR") { fill_in_name "vermelho" }
         click_on "Update"
 
         change_locale
@@ -50,10 +50,10 @@ RSpec.feature "Translations", :js do
         visit spree.admin_option_types_path
         within_row(1) { click_icon :translate }
 
-        within("#attr_fields .name.en.odd") { fill_in_name "shirt sizes" }
+        within("#attr_fields .name.en") { fill_in_name "shirt sizes" }
         within("#attr_list") { click_on "Presentation" }
-        within("#attr_fields .presentation.en.odd") { fill_in_name "size" }
-        within("#attr_fields .presentation.pt-BR.odd") { fill_in_name "tamanho" }
+        within("#attr_fields .presentation.en") { fill_in_name "size" }
+        within("#attr_fields .presentation.pt-BR") { fill_in_name "tamanho" }
         click_on "Update"
 
         change_locale
@@ -81,10 +81,10 @@ RSpec.feature "Translations", :js do
         visit spree.edit_admin_option_type_path(option_type)
         within_row(1) { click_icon :translate }
 
-        within("#attr_fields .name.en.odd") { fill_in_name "big" }
+        within("#attr_fields .name.en") { fill_in_name "big" }
         within("#attr_list") { click_on "Presentation" }
-        within("#attr_fields .presentation.en.odd") { fill_in_name "big" }
-        within("#attr_fields .presentation.pt-BR.odd") { fill_in_name "grande" }
+        within("#attr_fields .presentation.en") { fill_in_name "big" }
+        within("#attr_fields .presentation.pt-BR") { fill_in_name "grande" }
         click_on "Update"
 
         change_locale
@@ -100,10 +100,10 @@ RSpec.feature "Translations", :js do
         visit spree.admin_properties_path
         within_row(1) { click_icon :translate }
 
-        within("#attr_fields .name.pt-BR.odd") { fill_in_name "Modelo" }
+        within("#attr_fields .name.pt-BR") { fill_in_name "Modelo" }
         within("#attr_list") { click_on "Presentation" }
-        within("#attr_fields .presentation.en.odd") { fill_in_name "Model" }
-        within("#attr_fields .presentation.pt-BR.odd") { fill_in_name "Modelo" }
+        within("#attr_fields .presentation.en") { fill_in_name "Model" }
+        within("#attr_fields .presentation.pt-BR") { fill_in_name "Modelo" }
         click_on "Update"
 
         change_locale
@@ -121,8 +121,8 @@ RSpec.feature "Translations", :js do
       visit spree.admin_promotions_path
       within_row(1) { click_icon :translate }
 
-      within("#attr_fields .name.en.odd") { fill_in_name "All free" }
-      within("#attr_fields .name.pt-BR.odd") { fill_in_name "Salve salve" }
+      within("#attr_fields .name.en") { fill_in_name "All free" }
+      within("#attr_fields .name.pt-BR") { fill_in_name "Salve salve" }
       click_on "Update"
 
       change_locale
@@ -145,8 +145,8 @@ RSpec.feature "Translations", :js do
       visit spree.admin_taxonomies_path
       within_row(1) { click_icon :translate }
 
-      within("#attr_fields .name.en.odd") { fill_in_name "Guitars" }
-      within("#attr_fields .name.pt-BR.odd") { fill_in_name "Guitarras" }
+      within("#attr_fields .name.en") { fill_in_name "Guitars" }
+      within("#attr_fields .name.pt-BR") { fill_in_name "Guitarras" }
       click_on "Update"
 
       change_locale
@@ -162,12 +162,12 @@ RSpec.feature "Translations", :js do
     scenario "display translated name on frontend" do
       visit spree.admin_translations_path('taxons', taxon.id)
 
-      within("#attr_fields .name.en.odd") { fill_in_name "Acoustic" }
-      within("#attr_fields .name.pt-BR.odd") { fill_in_name "Acusticas" }
+      within("#attr_fields .name.en") { fill_in_name "Acoustic" }
+      within("#attr_fields .name.pt-BR") { fill_in_name "Acusticas" }
       click_on "Update"
 
       visit spree.admin_translations_path('taxons', taxon.id)
-      
+
       # ensure we're not duplicating translated records on database
       expect {
         click_on "Update"
@@ -217,8 +217,8 @@ RSpec.feature "Translations", :js do
       visit spree.admin_product_path(product)
       click_on "Translations"
       click_on "Slug"
-      within("#attr_fields .slug.en.odd") { fill_in_name "en_link" }
-      within("#attr_fields .slug.de.odd") { fill_in_name "de_link" }
+      within("#attr_fields .slug.en") { fill_in_name "en_link" }
+      within("#attr_fields .slug.de") { fill_in_name "de_link" }
       click_on "Update"
 
       visit spree.product_path 'en_link'


### PR DESCRIPTION
Hey there, i've decided to make a PR with some admin UI improvements for spree_i18n. They are basically connected to making spree_i18n use bootstrap components a bit more and, in my opinion, making some parts of it easier to use. Here is how it looks:

### General settings
![image](https://cloud.githubusercontent.com/assets/581569/7102098/2e7d748e-e076-11e4-9f64-f003577a6f8d.png)
I've decided to add a help blocks to make it a bit more clear on what these fields actually mean. I know that anyone can check that on spree_i18n docs but still it would be much more user friendly and **client friendly** to have them in place.

### Product translations
I've decided to move settings section to the top and make it horizontal because probably much more used part of that whole form is a `Fields` picker so it should be higher (it was almost always below my screen so i was forced to scroll down each time i wanted to change a translated field = super irritating). On the other hand, these two sections (`Settings` and `Fields`) has really big height and it can just look a bit _ill-balanced_ in some situations (like when there are just two languages set) + settings section took a lot more space that it should (as an element which is not used alot). Hope you like it that way :)

![image](https://cloud.githubusercontent.com/assets/581569/7102100/58702fe8-e076-11e4-8b46-a15da1515985.png)

What do you guys think?

ps. the second screen basically applies to all the other translation pages of spree_i18n which is promotions and taxonomies