### PR TITLE
Add Spree routing proxy to configuration sidebar override

### DIFF
--- a/app/overrides/spree/admin/shared/sub_menu/_configuration/store_translations.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_configuration/store_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom "[data-hook='admin_configurations_sidebar_menu']" -->
-<%= configurations_sidebar_menu_item Spree.t(:'i18n.store_translations'), admin_translations_path('stores', current_store)  if can? :manage, Spree::Store %>
+<%= configurations_sidebar_menu_item Spree.t(:'i18n.store_translations'), spree.admin_translations_path('stores', current_store)  if can? :manage, Spree::Store %>


### PR DESCRIPTION
...Otherwise this breaks when rendering outside the Spree namespace.