### PR TITLE
add kaminari-i18n requirement

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'globalize', '~> 5.0.1'
   s.add_runtime_dependency 'i18n_data', '~> 0.5.1'
   s.add_runtime_dependency 'rails-i18n', '~> 4.0.1'
+  s.add_runtime_dependency 'kaminari-i18n', '~> 0.3.2'
   s.add_runtime_dependency 'routing-filter', '~> 0.5.0'
   s.add_runtime_dependency 'spree_core', '~> 3.1.0.beta'
 


### PR DESCRIPTION
What about adding `kaminari-i18n`?
Without this any non-english site has a half-broken pagination because of missing i18n.