### PR TITLE
Fix move_data_to_model_table method of migration lib

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -130,7 +130,7 @@ module Globalize
             end
 
             # Now, update the actual model's record with the hash.
-            @model.update_all(fields_to_update, {id: translated_record['id']})
+            @model.where(id: translated_record['id']).update_all(fields_to_update)
           end
         end
 


### PR DESCRIPTION
- Use Rails 4.x syntax of ActiveRecord::Relation#update_all

See https://github.com/spree-contrib/spree_i18n/issues/562 issue