### PR TITLE
Add i18n-task + translation placeholders

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,4 +1,4 @@
-base_locale: en
+base_locale: en-GB
 
 data:
   read:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,36 @@
+base_locale: en
+
+data:
+  read:
+  yaml:
+    write:
+      line_width: -1
+
+search:
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+# ignore_unused:
+# - 'activerecord.attributes.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,4 +1,6 @@
+---
 bg:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ bg:
         state: "Област"
         zipcode: "Пощенски код"
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ bg:
         name: "Име"
         numcode: ISO Код
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Type
         month: "Месец"
-        name:
+        name: TODO_TRANSLATE
         number: "Номер"
         verification_value: "Стойност за потвърждение"
         year: "Година"
@@ -42,7 +44,7 @@ bg:
       spree/order:
         checkout_complete: "Завършена поръчка"
         completed_at: "Завършена на"
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: "Код на ваучер"
         created_at: "Дата на поръчка"
         email: "Клиентски и-мейл"
@@ -72,6 +74,7 @@ bg:
         zipcode: "Адрес за доставка - пощ. код"
       spree/payment:
         amount: "Сума"
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: "Име"
       spree/product:
@@ -95,7 +98,8 @@ bg:
         starts_at: "Започва на"
         usage_limit: "Лимит"
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: "Име"
         presentation: "Презентация"
@@ -105,24 +109,26 @@ bg:
         amount: "Количество"
       spree/role:
         name: "Име"
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: "Съкращение"
         name: "Име"
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: "Описание"
         name: "Име"
@@ -157,48 +163,54 @@ bg:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: "Картата е изтекла"
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: "Адрес"
         other: "Адреси"
@@ -208,39 +220,43 @@ bg:
       spree/credit_card:
         one: "Кредитна карта"
         other: "Кредитни карти"
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: "Складна единица"
         other: "Складни единици"
       spree/line_item:
-      spree/option_type:
-      spree/option_value:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: "Поръчка"
         other: "Поръчки"
       spree/payment:
         one: "Плащане"
         other: "Плащания"
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: "Продукт"
         other: "Продукти"
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: "Харатеристика"
         other: "Характеристики"
       spree/prototype:
         one: "Прототип"
         other: "Прототипи"
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: "Върни ауторизация"
         other: "Върни ауторизации"
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: "Роли"
         other: "Роли"
       spree/shipment:
@@ -249,14 +265,14 @@ bg:
       spree/shipping_category:
         one: "Доставна категория"
         other: "Доставни категории"
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: "Държава"
         other: "Държави"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: "Данъчна категория"
         other: "Данъчна категория"
@@ -264,8 +280,12 @@ bg:
         one: "Данъчен процент"
         other: "данъчни проценти"
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
-      spree/tracker:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: "Потребител"
         other: "Потребители"
@@ -275,6 +295,9 @@ bg:
       spree/zone:
         one: Zone Зона
         other: "Зони"
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: "Вашият акаунт е потвърден. Вече сте вписан."
@@ -313,6 +336,7 @@ bg:
     user_sessions:
       signed_in: "Успешно влизане"
       signed_out: "Успешно излизане"
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: "Вече бе потвърден"
@@ -321,12 +345,30 @@ bg:
       not_saved:
         one: "Една грешка предоотврати запазването на %{resource}"
         other: "%{count} грешки предоотвратиха запазването на %{resource}"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: "Абривиатура"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "Акаунт"
     account_updated: "Акаунтът бе обновен!"
     action: "Действие"
@@ -339,7 +381,7 @@ bg:
       list: "Списък"
       listing: Listing
       new: "Нов"
-      refund:
+      refund: TODO_TRANSLATE
       save: "Запази"
       update: "Обновни"
     activate: "Активирай"
@@ -347,7 +389,7 @@ bg:
     add: "Добави"
     add_action_of_type: "Добави действие от тип"
     add_country: "Добави страна"
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: "Добави нов хедър"
     add_new_style: "Добави нов стил"
     add_one: "Добави едно"
@@ -361,11 +403,16 @@ bg:
     add_to_cart: "Добави в кошницата"
     add_variant: "Добави вариант"
     additional_item: Additional Цена на артикул
+    address: TODO_TRANSLATE
     address1: "Адрес"
     address2: "Адрес (продължение)"
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: "Поправка"
     adjustment_amount: "Стойност"
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: "Поправката бе успешно затворена"
     adjustment_successfully_opened: "Поправката бе успешно отворена"
     adjustment_total: "Обща стойност на поправката"
@@ -373,114 +420,148 @@ bg:
     admin:
       tab:
         configuration: "Конфигурация"
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: "Поръчки"
         overview: "Прегледай"
         products: "Продукти"
         promotions: "Промоции"
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: "Доклади"
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: "Потребители"
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: "Администрация"
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: "Съгласен съм с политиката за защита на лични данни"
     agree_to_terms_of_service: "Съгласен съм с Общите условия"
     all: "Всички"
     all_adjustments_closed: "Всички промени завършени успешно!"
     all_adjustments_opened: "Всички промени отворено успешно!"
     all_departments: "Всички отдели"
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: "Позволи SSL да бъде ползвано при тестов режим"
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    allow_ssl_in_production: TODO_TRANSLATE
+    allow_ssl_in_staging: TODO_TRANSLATE
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: "Алтернативен текст"
     alternative_phone: "Алтернативен телефон"
     amount: "Сума"
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
-    analytics_trackers:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
+    analytics_trackers: TODO_TRANSLATE
     and: "и"
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: "Сигурни ли сте"
     are_you_sure_delete: "Сигурни ли сте, че искате да изтриете този запис?"
-    associated_adjustment_closed:
-    authorization_failure:
-    authorized:
-    auto_capture:
-    available_on:
-    average_order_value:
-    avs_response:
-    back:
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
-    back_to_store:
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
-    balance_due:
-    base_amount:
-    base_percent:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
+    authorization_failure: TODO_TRANSLATE
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
+    available_on: TODO_TRANSLATE
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
+    back: TODO_TRANSLATE
+    back_end: TODO_TRANSLATE
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
+    back_to_store: TODO_TRANSLATE
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
+    balance_due: TODO_TRANSLATE
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: "Адрес на плащане"
     billing: "Плащане"
     billing_address: "Адрес на плащане"
     both: "И двете"
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: "Калкулатор"
-    calculator_settings_warning:
-    cancel:
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    calculator_settings_warning: TODO_TRANSLATE
+    cancel: TODO_TRANSLATE
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: "Не може да платите без да сте избрали начин на плащане"
     cannot_create_returns: "Не можете да върнете стока обратно преди поръчката да е пусната."
     cannot_perform_operation: "Желаното действие не може да бъде извършено."
     cannot_set_shipping_method_without_address: "Начин за доставка не може да бъде зададен без данни на клиента."
     capture: "Картина"
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: "Код на карта"
     card_number: "Номер на карта"
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: "Видът на картата"
     cart: "Кошница"
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: "Категории"
     category: "Категория"
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: "Плащане"
     choose_a_customer: "Избери клиент"
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: "Избери валута"
-    choose_dashboard_locale:
-    choose_location:
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
     city: "Град"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: "Клонирай"
     close: "Затвори"
     close_all_adjustments: "Затвори всички промени"
@@ -489,26 +570,27 @@ bg:
     complete: "Завърши"
     configuration: "Конфигурация"
     configurations: "Конфигурации"
+    configure_s3: TODO_TRANSLATE
     confirm: "Потвърди"
     confirm_delete: "Потвърди изтриване"
     confirm_password: "Потвърди парола"
     continue: "Продължи"
     continue_shopping: "Продължи пазаруването"
     cost_currency: "Валута"
-    cost_price:
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    cost_price: TODO_TRANSLATE
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
+    countries: TODO_TRANSLATE
     country: "Страна"
-    country_based:
+    country_based: TODO_TRANSLATE
     country_name: "Име"
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: "Ваучер"
     coupon_code: "Код на ваучер"
     coupon_code_already_applied: "Този код вече е използван за тази доставка."
@@ -518,88 +600,107 @@ bg:
     coupon_code_max_usage: "Употребата на ваучери преминава лимита."
     coupon_code_not_eligible: "Този код не е валиден за тази поръчка."
     coupon_code_not_found: "Въведеният код не е валиден. Опитайте отново."
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: "Създай"
     create_a_new_account: "Създай нов акаунт"
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: "Създаден на"
     credit: "Кредит"
     credit_card: "Кредитна карта"
     credit_cards: "Кредитни карти"
     credit_owed: "Дължима сума по кредит"
-    credits:
+    credits: TODO_TRANSLATE
     currency: "Валута"
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
-    current:
-    current_promotion_usage:
-    customer:
-    customer_details:
-    customer_details_updated:
-    customer_return:
-    customer_returns:
-    customer_search:
-    cut:
-    cvv_response:
+    currency_decimal_mark: TODO_TRANSLATE
+    currency_settings: TODO_TRANSLATE
+    currency_symbol_position: TODO_TRANSLATE
+    currency_thousands_separator: TODO_TRANSLATE
+    current: TODO_TRANSLATE
+    current_promotion_usage: TODO_TRANSLATE
+    customer: TODO_TRANSLATE
+    customer_details: TODO_TRANSLATE
+    customer_details_updated: TODO_TRANSLATE
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
+    customer_search: TODO_TRANSLATE
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
+    date_completed: TODO_TRANSLATE
     date_picker:
       first_day: 0
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
-    date_range:
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    date_range: TODO_TRANSLATE
+    default: TODO_TRANSLATE
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
     delete: "Изтрий"
-    deleted_variants_present:
-    delivery:
-    depth:
-    description:
-    destination:
-    destroy:
-    details:
-    discount_amount:
-    dismiss_banner:
-    display:
-    display_currency:
-    doesnt_track_inventory:
-    edit:
-    editing_resource:
-    editing_rma_reason:
-    editing_user:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
+    delivery: TODO_TRANSLATE
+    depth: TODO_TRANSLATE
+    description: TODO_TRANSLATE
+    destination: TODO_TRANSLATE
+    destroy: TODO_TRANSLATE
+    details: TODO_TRANSLATE
+    discount_amount: TODO_TRANSLATE
+    dismiss_banner: TODO_TRANSLATE
+    display: TODO_TRANSLATE
+    display_currency: TODO_TRANSLATE
+    doesnt_track_inventory: TODO_TRANSLATE
+    edit: TODO_TRANSLATE
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
+    editing_user: TODO_TRANSLATE
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
-    empty:
-    empty_cart:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
+    email: TODO_TRANSLATE
+    empty: TODO_TRANSLATE
+    empty_cart: TODO_TRANSLATE
     enable_mail_delivery: "Позволи изпращане по поща"
     end: "Край"
     ending_in: "Приключване в"
@@ -629,28 +730,30 @@ bg:
           signup: "Потребителски вход"
     exceptions:
       count_on_hand_setter: "Грешка при ръчното обновяването на count_on_hand, тъй като бе обновено от повик към recalculate_count_on_hand. Моля използвайте`update_column(:count_on_hand, value)` вместо това."
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: "Срок на годност"
     extension: "Удъжения"
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: "Име на файл"
     fill_in_customer_info: "Моля попълнете потребителска информация"
+    filter: TODO_TRANSLATE
     filter_results: "Филтриране на резултатите"
     finalize: "Финализирай"
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: "Цена на първи предмет"
     first_name: "Първо име"
     first_name_begins_with: "Първо име  започва с"
     flat_percent: "Плосък процент"
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: "Пропорционална такса (на поръчка)"
     flexible_rate: "Гъвкав курс"
     forgot_password: "Забравена парола"
     free_shipping: "Безплатна доставка"
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: "Преден Край"
     gateway: "Портал"
     gateway_config_unavailable: "Порталът не е на разположение за тази среда"
@@ -674,37 +777,41 @@ bg:
       only_incomplete: "Само незавършени."
       select_locale: "Избери място"
       show_only: "Покажи само"
+      store_translations: TODO_TRANSLATE
       supported_locales: "Подържани места"
       this_file_language: "Български (БГ)"
       translations: "Преводи"
     icon: "Икона"
-    identifier:
+    identifier: TODO_TRANSLATE
     image: "Образ"
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: "Образи"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: "Включено в цената"
     included_price_validation: "Не може да бъде избрано докато не изберете подходяща област"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
+    instructions_to_reset_password: TODO_TRANSLATE
     insufficient_stock: "Недостатъчно количество стока в наличност, само %{on_hand} остават."
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: "Пресрещане на имеил адрес"
     intercept_email_instructions: "Отемни сегашните имеил приемници и замени с този адрес."
     internal_name: "Вътрешно име."
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: "Невалиден разплащателен метод."
     invalid_promotion_action: "Невалидна промоционална дейност."
     invalid_promotion_rule: "Невалидно промоционално правило."
     inventory: "Инвентар"
     inventory_adjustment: "Наглацяне на инвентара"
     inventory_error_flash_for_insufficient_quantity: "Количествата на предмет във вашата кошница се изчерпаха."
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: "Не е достъпно до адрес на доставка"
     iso_name: Iso Име
     item: "Предмет"
@@ -714,26 +821,32 @@ bg:
       operators:
         gt: "повече ог"
         gte: "повече от или равно на"
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: "Нямаме възможносттта да доставим тези предмети до този адрес. Моля изберете друг адрес на доставка."
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: "Жираф"
     landing_page_rule:
       path: "Път"
     last_name: "Последно име"
     last_name_begins_with: "Последното име започва с"
     learn_more: "Научи повече"
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: "Списък"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "Зареждане"
     locale_changed: "Местоположение сменено"
     location: "Местоположение"
     lock: "Закючи"
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: "Влезте като"
     logged_in_succesfully: "Успешно влизане"
     logged_out: "Успешен изход."
@@ -742,23 +855,26 @@ bg:
     login_failed: "Неуспешно за установяване на автентичността."
     login_name: "Потребителско име"
     logout: "Изход"
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: "Потърси за подобни предмети"
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: "Въстановяване на сума"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: "Главна сума"
     match_choices:
       all: "Всички"
       none: "Никои"
     max_items: "Максимален брой предмети"
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: "Описание"
     meta_keywords: "Ключови думи"
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: "Дата"
     minimal_amount: "Минимално количество"
     month: "Месец"
@@ -767,13 +883,13 @@ bg:
     my_account: "Моя профил"
     my_orders: "Моите поръчки"
     name: "Име"
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: "Име или Идентификационен номер на продукт"
     new: "Име"
     new_adjustment: "Ново нагалсяне"
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: "Нов клиент"
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: "Нов образ"
     new_option_type: "Нов метод за настойки"
     new_order: "Нова поръчка"
@@ -782,14 +898,15 @@ bg:
     new_payment_method: "Нов метод за заплащане"
     new_product: "Нов продукт"
     new_promotion: "Нова промоция"
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: "Ново свойство"
     new_prototype: "Нов прототип"
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: "Нов метод за оторизиране на връщане"
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: "Нова категория за доставки"
     new_shipping_method: "Нов метод за доставки"
     new_state: "Ново състояние"
@@ -806,24 +923,30 @@ bg:
     new_zone: "Нова зона"
     next: "Следващ"
     no_actions_added: "Няма избрани дейности"
-    no_payment_found:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: "Няма настоящи плащания"
     no_products_found: "Няма открити пордукти"
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: "Няма резилтати"
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: "Никакви правила прибавени"
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: "Няма информация за следене"
     none: "Нищо"
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: "Нормално количество"
     not: "не"
     not_available: "Няма в наличност"
     not_enough_stock: "Няма достатъчно налични количества в стока да се извърши поръчката."
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: "Продуктът бе дупликиран"
       product_deleted: "Продуктът беше изтрит"
@@ -831,70 +954,77 @@ bg:
       product_not_deleted: "Продуктът не можеше да бъде изтрит"
       variant_deleted: "Вариантът бе изтрит"
       variant_not_deleted: "Вариантът не можеше да бъде изтрит"
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: "Наличност"
-    open:
-    open_all_adjustments:
-    option_type:
-    option_type_placeholder:
-    option_types:
-    option_value:
-    option_values:
-    optional:
-    options:
-    or:
-    or_over_price:
-    order:
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
-    order_details:
-    order_email_resent:
-    order_information:
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
+    option_type: TODO_TRANSLATE
+    option_type_placeholder: TODO_TRANSLATE
+    option_types: TODO_TRANSLATE
+    option_value: TODO_TRANSLATE
+    option_values: TODO_TRANSLATE
+    optional: TODO_TRANSLATE
+    options: TODO_TRANSLATE
+    or: TODO_TRANSLATE
+    or_over_price: TODO_TRANSLATE
+    order: TODO_TRANSLATE
+    order_adjustments: TODO_TRANSLATE
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
+    order_details: TODO_TRANSLATE
+    order_email_resent: TODO_TRANSLATE
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
-    order_processed_successfully:
-    order_resumed:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
+    order_processed_successfully: TODO_TRANSLATE
+    order_resumed: TODO_TRANSLATE
     order_state:
-      address:
-      awaiting_return:
+      address: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
       canceled: "отказано"
       cart: "количка"
       complete: "завършено"
       confirm: "потвърди"
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: "доставка"
       payment: "плащане"
       resumed: "възобновено"
       returned: "върнато"
     order_summary: "Преглед на поръчка"
-    order_sure_want_to:
+    order_sure_want_to: TODO_TRANSLATE
     order_total: "Цялостна стойност"
     order_updated: "Поръчката бе обновена"
     orders: "Поръчки"
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: "Не е в наличност"
     overview: "Преглед"
     package_from: package from
     pagination:
+      first: TODO_TRANSLATE
       next_page: next page »
+      previous: TODO_TRANSLATE
       previous_page: "« previous page"
       truncate: "…"
     password: "Парола"
@@ -902,217 +1032,233 @@ bg:
     path: "Път"
     pay: "Плати"
     payment: "Плащане"
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: "Информация за плащане"
     payment_method: "Начин на плащане"
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: "Методи на плащане"
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
+    payment_processing_failed: TODO_TRANSLATE
+    payment_processor_choose_banner_text: TODO_TRANSLATE
+    payment_processor_choose_link: TODO_TRANSLATE
     payment_state: "Статус на плащането"
     payment_states:
-      balance_due:
-      checkout:
-      completed:
-      credit_owed:
+      balance_due: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      credit_owed: TODO_TRANSLATE
       failed: "провалено"
-      paid:
-      pending:
-      processing:
-      void:
+      paid: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     payment_updated: "Плащането бе обновено"
     payments: "Плащания"
-    pending:
+    pending: TODO_TRANSLATE
     percent: "Процент"
-    percent_per_item:
+    percent_per_item: TODO_TRANSLATE
     permalink: Permalink
     phone: "Телефон"
     place_order: "Направи поръчка"
     please_define_payment_methods: "Моля, първо дефинирайте методи за плащане."
-    populate_get_error:
+    please_enter_reasonable_quantity: TODO_TRANSLATE
+    populate_get_error: TODO_TRANSLATE
     powered_by: "Уебсайтът е задвижван от"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
-    presentation:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
+    presentation: TODO_TRANSLATE
     previous: "Предходен"
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: "Цена"
-    price_range:
-    price_sack:
+    price_range: TODO_TRANSLATE
+    price_sack: TODO_TRANSLATE
     process: "Продукт"
     product: Product
     product_details: "Информация за продукта"
-    product_has_no_description:
-    product_not_available_in_this_currency:
-    product_properties:
+    product_has_no_description: TODO_TRANSLATE
+    product_not_available_in_this_currency: TODO_TRANSLATE
+    product_properties: TODO_TRANSLATE
     product_rule:
       choose_products: "Избери продукти"
-      label:
+      label: TODO_TRANSLATE
       match_all: "всички"
       match_any: "поне един"
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: "От продуктова група"
         manual: "Избери ръчно"
     products: "Продукти"
-    promotion:
-    promotion_action:
+    promotion: TODO_TRANSLATE
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: TODO_TRANSLATE
+        any: TODO_TRANSLATE
+    promotion_label: TODO_TRANSLATE
+    promotion_rule: TODO_TRANSLATE
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       item_total:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       landing_page:
         description: "Потребителят трябва да е посетил определена страница"
         name: "Целева страница"
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: "Поръчката има следният/ите продукт(и)"
         name: "Продукт(и)"
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: "Достъпно само за определени потребители"
         name: "Потребител"
       user_logged_in:
         description: "Достъпно само за потребители, които са влезли в сайта"
         name: "Потребителят е влязал в сайта"
-    promotion_uses:
-    promotionable:
-    promotions:
-    propagate_all_variants:
-    properties:
-    property:
-    prototype:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
+    promotions: TODO_TRANSLATE
+    propagate_all_variants: TODO_TRANSLATE
+    properties: TODO_TRANSLATE
+    property: TODO_TRANSLATE
+    prototype: TODO_TRANSLATE
     prototypes: "Прототипи"
     provider: "Доставчик"
-    provider_settings_warning:
+    provider_settings_warning: TODO_TRANSLATE
     qty: "Кол."
     quantity: "Количество"
     quantity_returned: "Количество върнато"
     quantity_shipped: "Количество пратено"
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Rate
     reason: "Причина"
     receive: "получи"
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: "Получено"
-    reception_status:
-    reference:
-    refund:
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
+    refund: TODO_TRANSLATE
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: "Регистрирай се като нов потребител"
     registration: "Регистрация"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: "Запомни ме"
     remove: "Премахни"
     rename: "Преименувай"
-    report:
-    reports:
+    report: TODO_TRANSLATE
+    reports: TODO_TRANSLATE
+    resellable: TODO_TRANSLATE
     resend: "Препрати"
     reset_password: "Възстанови паролата"
-    response_code:
+    response_code: TODO_TRANSLATE
     resume: "продължи"
     resumed: "Продължено"
     return: "върни"
-    return_authorization:
-    return_authorization_reasons:
-    return_authorization_updated:
-    return_authorizations:
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
-    returned:
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
-    rma_number:
-    rma_value:
+    return_authorization: TODO_TRANSLATE
+    return_authorization_reasons: TODO_TRANSLATE
+    return_authorization_updated: TODO_TRANSLATE
+    return_authorizations: TODO_TRANSLATE
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
+    return_quantity: TODO_TRANSLATE
+    returned: TODO_TRANSLATE
+    returns: TODO_TRANSLATE
+    review: TODO_TRANSLATE
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
+    rma_credit: TODO_TRANSLATE
+    rma_number: TODO_TRANSLATE
+    rma_value: TODO_TRANSLATE
+    role_id: TODO_TRANSLATE
     roles: "Роли"
     rules: "ПРавила"
-    safe:
-    sales_total:
-    sales_total_description:
-    sales_totals:
-    save_and_continue:
-    save_my_address:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
+    sales_total: TODO_TRANSLATE
+    sales_total_description: TODO_TRANSLATE
+    sales_totals: TODO_TRANSLATE
+    save_and_continue: TODO_TRANSLATE
+    save_my_address: TODO_TRANSLATE
     say_no: "Не"
     say_yes: "Да"
     scope: Scope
     search: "Търси"
     search_results: "Резултати за '%{keywords}'"
     searching: "Търсене"
-    secure_connection_type:
-    security_settings:
-    select:
-    select_a_return_authorization_reason:
-    select_a_stock_location:
-    select_from_prototype:
-    select_stock:
-    send_copy_of_all_mails_to:
-    send_mails_as:
+    secure_connection_type: TODO_TRANSLATE
+    security_settings: TODO_TRANSLATE
+    select: TODO_TRANSLATE
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
+    select_from_prototype: TODO_TRANSLATE
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
+    send_copy_of_all_mails_to: TODO_TRANSLATE
+    send_mails_as: TODO_TRANSLATE
     server: "Сървър"
     server_error: "Сървърът върна грешла"
     settings: "Настройки"
@@ -1120,8 +1266,9 @@ bg:
     ship_address: "Адрес"
     ship_total: "Общо"
     shipment: "Доставка"
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: "Драги клиент"
@@ -1129,169 +1276,190 @@ bg:
         shipment_summary: "Обзор на поръчката"
         subject: Shipment  Нотификация
         thanks: "Благодарим Ви!"
-        track_information:
-        track_link:
+        track_information: TODO_TRANSLATE
+        track_link: TODO_TRANSLATE
     shipment_state: "Положение на пратката"
     shipment_states:
       backorder: "неизпълнена"
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: "частична"
       pending: "изчакваща"
       ready: "готова"
       shipped: "пратена"
-    shipment_transfer_error:
-    shipment_transfer_success:
-    shipments:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
+    shipments: TODO_TRANSLATE
     shipped: "пратена"
     shipping: "Пратки"
     shipping_address: "Адрес на доставка"
     shipping_categories: "Катергории за доставки"
     shipping_category: "Категория за доставка"
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
-    shipping_instructions:
-    shipping_method:
-    shipping_methods:
-    shipping_price_sack:
-    shipping_total:
-    shop_by_taxonomy:
-    shopping_cart:
-    show:
-    show_active:
-    show_deleted:
-    show_only_complete_orders:
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku:
-    skus:
-    slug:
-    source:
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
+    shipping_instructions: TODO_TRANSLATE
+    shipping_method: TODO_TRANSLATE
+    shipping_methods: TODO_TRANSLATE
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
+    shop_by_taxonomy: TODO_TRANSLATE
+    shopping_cart: TODO_TRANSLATE
+    show: TODO_TRANSLATE
+    show_active: TODO_TRANSLATE
+    show_deleted: TODO_TRANSLATE
+    show_only_complete_orders: TODO_TRANSLATE
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
+    sku: TODO_TRANSLATE
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
+    special_instructions: TODO_TRANSLATE
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
+    spree_gateway_error_flash_for_checkout: TODO_TRANSLATE
     ssl:
-      change_protocol:
-    start:
-    state:
-    state_based:
+      change_protocol: TODO_TRANSLATE
+    start: TODO_TRANSLATE
+    start_date: TODO_TRANSLATE
+    state: TODO_TRANSLATE
+    state_based: TODO_TRANSLATE
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states:
-    states_required:
-    status:
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
-    stop:
-    store:
-    street_address:
-    street_address_2:
-    subtotal:
-    subtract:
-    success:
-    successfully_created:
-    successfully_refunded:
-    successfully_removed:
-    successfully_signed_up_for_analytics:
-    successfully_updated:
-    summary:
-    tax:
-    tax_categories:
-    tax_category:
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
-    tax_rates:
-    taxon:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
+    states: TODO_TRANSLATE
+    states_required: TODO_TRANSLATE
+    status: TODO_TRANSLATE
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
+    stop: TODO_TRANSLATE
+    store: TODO_TRANSLATE
+    street_address: TODO_TRANSLATE
+    street_address_2: TODO_TRANSLATE
+    subtotal: TODO_TRANSLATE
+    subtract: TODO_TRANSLATE
+    success: TODO_TRANSLATE
+    successfully_created: TODO_TRANSLATE
+    successfully_refunded: TODO_TRANSLATE
+    successfully_removed: TODO_TRANSLATE
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
+    successfully_updated: TODO_TRANSLATE
+    summary: TODO_TRANSLATE
+    tax: TODO_TRANSLATE
+    tax_categories: TODO_TRANSLATE
+    tax_category: TODO_TRANSLATE
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
+    tax_rates: TODO_TRANSLATE
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
+    taxon: TODO_TRANSLATE
     taxon_edit: "Промени таксон"
     taxon_placeholder: "Добави таксон"
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: "Таксономии"
     taxonomy: "Таксономия"
     taxonomy_edit: "Промени таксономия"
-    taxonomy_tree_error:
-    taxonomy_tree_instruction:
+    taxonomy_tree_error: TODO_TRANSLATE
+    taxonomy_tree_instruction: TODO_TRANSLATE
     taxons: "Таксони"
     test: "Тест"
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
-        greeting:
-        message:
-        subject:
-    test_mode:
-    thank_you_for_your_order:
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields:
-    this_order_has_already_received_a_refund:
-    thumbnail:
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+    test_mode: TODO_TRANSLATE
+    thank_you_for_your_order: TODO_TRANSLATE
+    there_are_no_items_for_this_order: TODO_TRANSLATE
+    there_were_problems_with_the_following_fields: TODO_TRANSLATE
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
+    thumbnail: TODO_TRANSLATE
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: "Време"
     to_add_variants_you_must_first_define: "За да добавите варианти, трябва да дефинирате"
     total: "Общо"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
-    tracking:
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
+    tracking: TODO_TRANSLATE
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
     transfer_stock: "Трансферирай запаси"
     transfer_to_location: "Трансферирай към"
     tree: "Дърво"
     type: "Тип"
     type_to_search: "Тип на търсене"
-    unable_to_connect_to_gateway:
-    unable_to_create_reimbursements:
+    unable_to_connect_to_gateway: TODO_TRANSLATE
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: "Под %{price}"
     unlock: "Отключи"
     unrecognized_card_type: "Неразпознат тип карта"
@@ -1299,9 +1467,11 @@ bg:
     update: "Обнови"
     updating: "Обновване"
     usage_limit: "Лимит на ползване"
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: "Използвай адрес за фактуриране"
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: "Използвай нова карта"
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: "Използвай Amazon S3 за изображения"
     user: User
     user_rule:
@@ -1309,12 +1479,13 @@ bg:
     users: "Потребители"
     validation:
       cannot_be_less_than_shipped_units: "не може да бъде по-малко от броя на изпратените единици"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: "е над наличността. Моля, уверете че уговорните покупки имат валидна стойност."
       is_too_large: "е прекалено голяма --  наличността не достига!"
       must_be_int: "трябва да е цяло число"
       must_be_non_negative: "трябва да е позитивна стойност"
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: "Стойност"
     variant: "Вариант"
     variant_placeholder: "Избери вариант"
@@ -1333,3 +1504,10 @@ bg:
     zipcode: "пощ. код"
     zone: "Зона"
     zones: "Зони"
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,4 +1,6 @@
+---
 ca:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ ca:
         state: Estat
         zipcode: Codi postal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ ca:
         name: Nom
         numcode: Codi ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tipus
         month: Mes
-        name:
+        name: TODO_TRANSLATE
         number: Nombre
         verification_value: Codi de verificació
         year: Any
@@ -37,17 +39,17 @@ ca:
         price: Preu
         quantity: Quantitat
       spree/option_type:
-        name:
-        presentation:
+        name: TODO_TRANSLATE
+        presentation: TODO_TRANSLATE
       spree/order:
         checkout_complete: Comanda completada
         completed_at: Completat el
-        considered_risky:
-        coupon_code:
+        considered_risky: TODO_TRANSLATE
+        coupon_code: TODO_TRANSLATE
         created_at: Data Comanda
-        email:
+        email: TODO_TRANSLATE
         ip_address: Adreça IP
-        item_total:
+        item_total: TODO_TRANSLATE
         number: Nombre
         payment_state: Estat Pagament
         shipment_state: Estat Enviament
@@ -55,25 +57,26 @@ ca:
         state: Estat
         total: Total
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/payment:
-        amount:
+        amount: TODO_TRANSLATE
+        number: TODO_TRANSLATE
       spree/payment_method:
-        name:
+        name: TODO_TRANSLATE
       spree/product:
         available_on: Disponible en
         cost_currency: Cost Moneda
@@ -95,7 +98,8 @@ ca:
         starts_at: Comença el
         usage_limit: Límit d'ús
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Nom
         presentation: Presentació
@@ -105,24 +109,26 @@ ca:
         amount: Quantitat
       spree/role:
         name: Nom
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abreviatura
         name: Nom
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Descripció
         name: Nom
@@ -157,48 +163,54 @@ ca:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adreça
         other: Adreces
@@ -208,41 +220,43 @@ ca:
       spree/credit_card:
         one: Targeta de crèdit
         other: Targetes de crèdit
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Unitat en inventari
         other: Unitats en inventari
       spree/line_item:
         one: Article
         other: Articles
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Comanda
         other: Comandes
       spree/payment:
         one: Pagament
         other: Pagaments
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Producte
         other: Productes
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Propietat
         other: Propietats
       spree/prototype:
         one: Prototip
         other: Prototips
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Autorització de devolució
         other: Autoritzacions de devolució
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Funció
         other: Funcions
       spree/shipment:
@@ -251,14 +265,14 @@ ca:
       spree/shipping_category:
         one: Categoria d'enviament
         other: Categories de enviament
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Estat
         other: Estats
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Categoria d'impostos
         other: Categories d'impostos
@@ -271,66 +285,90 @@ ca:
       spree/taxonomy:
         one: Propietat
         other: Propietats
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Usuari
         other: Usuaris
       spree/variant:
-        one:
-        other:
+        one: 
+        other: 
       spree/zone:
         one: Zona
-        other:
+        other: 
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
       inactive: El seu compte no s'ha estat activat encara.
       invalid: Correu electrònic o contrasenya no vàlids.
       invalid_token: Token d'autenticació no vàlid.
       locked: El seu compte està bloquejat.
-      timeout:
-      unauthenticated:
-      unconfirmed:
+      timeout: TODO_TRANSLATE
+      unauthenticated: TODO_TRANSLATE
+      unconfirmed: TODO_TRANSLATE
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
+      already_confirmed: TODO_TRANSLATE
       not_found: no trobat
-      not_locked:
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abreviatura
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Compte
     account_updated: Explica actualitzada!
     action: Acció
@@ -343,15 +381,15 @@ ca:
       list: Llesta
       listing: Llistat
       new: Nova
-      refund:
-      save:
+      refund: TODO_TRANSLATE
+      save: TODO_TRANSLATE
       update: Actualitzar
     activate: Activate
     active: Actiu
     add: Afegir
     add_action_of_type: Add action of type
     add_country: Afegir País
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Add New Header
     add_new_style: Add New Style
     add_one: Afegeix un
@@ -360,247 +398,306 @@ ca:
     add_product_properties: Afegir propietats de producte
     add_rule_of_type: Afegir regla de tipus
     add_state: Afegir província
-    add_stock:
-    add_stock_management:
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: Afegir al carret
-    add_variant:
+    add_variant: TODO_TRANSLATE
     additional_item: Cost addicional per element
+    address: TODO_TRANSLATE
     address1: Adreça
     address2: Adreça(cont.)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Ajust
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: Ajust total
     adjustments: Ajustos
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administració
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
     all: Tots
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
     all_departments: Tots els departaments
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    all_items_have_been_returned: TODO_TRANSLATE
+    allow_ssl_in_development_and_test: TODO_TRANSLATE
+    allow_ssl_in_production: TODO_TRANSLATE
+    allow_ssl_in_staging: TODO_TRANSLATE
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: Text alternatiu
     alternative_phone: Telèfon alternatiu
     amount: Quantia
     analytics_desc_header_1: Spree Analytics
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
     analytics_trackers: Trackers de Google Analytics
-    and:
-    approve:
-    approved_at:
-    approver:
+    and: TODO_TRANSLATE
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Està segur?
     are_you_sure_delete: Està segur que vol eliminar aquesta entrada?
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Fallada d'autorització
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Disponible en
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Enrere
     back_end: Part Interna
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Tornar a la tenda
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Saldo pendent
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Adreça de facturació
     billing: Facturació
     billing_address: Adreça de facturació
     both: tots dos
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculadora
     calculator_settings_warning: Si està canviant el tipus de calculadora, ha de guardar la seva selecció abans d'editar la seva configuració
     cancel: Cancel·lar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
+    cannot_create_payment_without_payment_methods: TODO_TRANSLATE
     cannot_create_returns: No pot crear-se la devolució ja que aquest demanat encara no ha estat enviat.
     cannot_perform_operation: No pot realitzar-se l'operació
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: captura
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Codi de la targeta
     card_number: Nombre de targeta
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Tipus de targeta
     cart: Carret
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categories
     category: Categoria
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Pagar
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: TODO_TRANSLATE
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: TODO_TRANSLATE
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
     city: Ciutat
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clonar
     close: Tanca
-    close_all_adjustments:
+    close_all_adjustments: TODO_TRANSLATE
     code: Codi
-    company:
+    company: TODO_TRANSLATE
     complete: complet
     configuration: Configuració
     configurations: Configuracions
+    configure_s3: TODO_TRANSLATE
     confirm: Confirmar
     confirm_delete: Confirmar esborrat
     confirm_password: Confirmi la contrasenya
     continue: Continuar
     continue_shopping: Seguir comprant
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: Preu del Cost
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
     countries: Països
     country: País
     country_based: País basi
     country_name: Nom
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Cupó
     coupon_code: Codi de cupó
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_already_applied: TODO_TRANSLATE
+    coupon_code_applied: TODO_TRANSLATE
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Crear
     create_a_new_account: Crear un nou compte
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
     credit: Crèdit
     credit_card: Targeta de crèdit
-    credit_cards:
+    credit_cards: TODO_TRANSLATE
     credit_owed: Crèdit disponible
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credits: TODO_TRANSLATE
+    currency: TODO_TRANSLATE
+    currency_decimal_mark: TODO_TRANSLATE
+    currency_settings: TODO_TRANSLATE
+    currency_symbol_position: TODO_TRANSLATE
+    currency_thousands_separator: TODO_TRANSLATE
     current: Actual
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Client
     customer_details: Detalls del client
-    customer_details_updated:
-    customer_return:
-    customer_returns:
+    customer_details_updated: TODO_TRANSLATE
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Cerca de clients
-    cut:
-    cvv_response:
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
     date: Data
-    date_completed:
+    date_completed: TODO_TRANSLATE
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: Rang de Data
     default: Per omissió
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
     delete: Eliminar
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Enviament
     depth: Profunditat
     description: Descripció
-    destination:
+    destination: TODO_TRANSLATE
     destroy: Eliminar
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Import del descompte
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Mostrar
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: TODO_TRANSLATE
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Editar
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editant usuari
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Correu Electrònic
     empty: Buit
     empty_cart: Buidar carret
@@ -621,40 +718,42 @@ ca:
     events:
       spree:
         cart:
-          add:
+          add: TODO_TRANSLATE
         checkout:
-          coupon_code_added:
+          coupon_code_added: TODO_TRANSLATE
         content:
-          visited:
+          visited: TODO_TRANSLATE
         order:
-          contents_changed:
-        page_view:
+          contents_changed: TODO_TRANSLATE
+        page_view: TODO_TRANSLATE
         user:
-          signup:
+          signup: TODO_TRANSLATE
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Caducitat
     extension: Extensió
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Nom d'arxiu
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
+    filter_results: TODO_TRANSLATE
     finalize: Finalitzar
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Cost del primer element
     first_name: Nom
     first_name_begins_with: Nom comença per
     flat_percent: Percentatge simple
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Quantitat fixa (per comanda)
     flexible_rate: Quantitat variable
     forgot_password: Vas oblidar la teva contrasenya?
     free_shipping: Despeses d'enviament gratuïts
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Sistema Intern
     gateway: mitjà
     gateway_config_unavailable: Passarel·la no disponible per configuració
@@ -667,50 +766,54 @@ ca:
     guest_user_account: Comprar sense registrar-se
     has_no_shipped_units: no té unitats enviades
     height: Altura
-    hide_cents:
+    hide_cents: TODO_TRANSLATE
     home: Inici
     i18n:
-      available_locales:
+      available_locales: TODO_TRANSLATE
       fields: Camps
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: Català
-      translations:
+      translations: TODO_TRANSLATE
     icon: Icona
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Imatge
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Imatges
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
+    included_in_price: TODO_TRANSLATE
+    included_price_validation: TODO_TRANSLATE
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Empleni el formulari i rebrà per email instruccions sobre com reiniciar el seu password:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Interceptar adreça d'Email
     intercept_email_instructions: Substituir el receptor de l'email amb aquesta adreça.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: Inventari
     inventory_adjustment: Ajust d'inventari
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: No es troba disponible per a l'adreça d'enviament
-    iso_name:
+    iso_name: TODO_TRANSLATE
     item: article
     item_description: Descripció de l'article
     item_total: Total d'articles
@@ -718,26 +821,32 @@ ca:
       operators:
         gt: major que
         gte: major o igual que
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: Cognoms
     last_name_begins_with: Cognom comença per
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Llesta
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Carregant
     locale_changed: S'ha canviat l'idioma
-    location:
-    lock:
-    log_entries:
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
     logged_in_as: Identificat com
     logged_in_succesfully: Connectat amb èxit
     logged_out: S'ha tancat la sessió.
@@ -746,38 +855,41 @@ ca:
     login_failed: No s'ha pogut iniciar la sessió, error d'autenticació.
     login_name: Nom d'usuari
     logout: Tancar sessió
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Buscar articles similars
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Realitzar devolució
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Preu principal
     match_choices:
-      all:
-      none:
+      all: TODO_TRANSLATE
+      none: TODO_TRANSLATE
     max_items: Màxim d'elements
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Fiqui descripció
     meta_keywords: Fiqui paraules clau
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadades
     minimal_amount: Quantitat mínima
     month: Mes
-    more:
-    move_stock_between_locations:
+    more: TODO_TRANSLATE
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: El meu compte
     my_orders: Les meves comandes
     name: Nom
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Nom o codi de producte
     new: Nou
     new_adjustment: nou ajust
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Nou client
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nova Imatge
     new_option_type: Nou tipus d'opció
     new_order: Nova comanda
@@ -786,20 +898,21 @@ ca:
     new_payment_method: Nova forma de pagament
     new_product: Nou producte
     new_promotion: nova promoció
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nova propietat
     new_prototype: Nou prototip
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Nova autorització de devolució
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Nova categoria d'enviament
     new_shipping_method: Nova forma d'enviament
     new_state: Nova província
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: Nova categoria
     new_tax_rate: Nou tipus impositiu
     new_taxon: Nova Categoria
@@ -809,25 +922,31 @@ ca:
     new_variant: Nova Variant
     new_zone: Nova zona
     next: següent
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: No s'han trobat productes
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Sense resultats
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: No s'han afegit noves normes
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: Cap
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Quantitat normal
     not: false
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Producte clonat
       product_deleted: Producte esborrat
@@ -835,47 +954,52 @@ ca:
       product_not_deleted: No ha pogut esborrar-se el producte
       variant_deleted: Variant esborrada
       variant_not_deleted: La variant no ha pogut esborrar-se
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Disponible
     open: Obert
-    open_all_adjustments:
+    open_all_adjustments: TODO_TRANSLATE
     option_type: Tipus d'opció
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Tipus d'opció
     option_value: Valor de l'opció
     option_values: Valors de l'opció
-    optional:
+    optional: TODO_TRANSLATE
     options: Opcions
     or: o
     or_over_price: "%{price} or over"
     order: Demanat
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Detalls de la comanda
     order_email_resent: Email de comanda reexpedida
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
         subject: Cancel·lació de comanda
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
         subject: Confirmació de comanda
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: La seva comanda s'ha processat correctament
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: adreça
       awaiting_return: esperant resposta
@@ -883,7 +1007,7 @@ ca:
       cart: carret
       complete: completat
       confirm: confirmat
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: enviament
       payment: pagament
       resumed: continuat
@@ -893,24 +1017,26 @@ ca:
     order_total: Total de la comanda
     order_updated: Comanda actualitzada
     orders: Demanats
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Sense estoc
     overview: General
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
-      next_page:
-      previous_page:
+      first: TODO_TRANSLATE
+      next_page: TODO_TRANSLATE
+      previous: TODO_TRANSLATE
+      previous_page: TODO_TRANSLATE
       truncate: "…"
     password: Contrasenya
-    paste:
+    paste: TODO_TRANSLATE
     path: Ruta
     pay: Pagar
     payment: Pagament
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Informació del pagament
     payment_method: Mètode de pagament
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Mètodes de pagament
     payment_processing_failed: El pagament no ha pogut ser processat, per favor, revisi les dades proporcionades.
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -928,61 +1054,67 @@ ca:
       void: buit
     payment_updated: Pagament actualitzat
     payments: Pagaments
-    pending:
-    percent:
-    percent_per_item:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
+    percent_per_item: TODO_TRANSLATE
     permalink: Enllaç permanent
     phone: Telèfon
     place_order: Fer comanda
-    please_define_payment_methods:
+    please_define_payment_methods: TODO_TRANSLATE
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Suportat per
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentació
     previous: Anterior
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Preu
-    price_range:
-    price_sack:
+    price_range: TODO_TRANSLATE
+    price_sack: TODO_TRANSLATE
     process: Processar
     product: Producte
     product_details: Detalls del producte
     product_has_no_description: El producte no té descripció
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Propietats del producte
     product_rule:
       choose_products: Triï productes
-      label:
+      label: TODO_TRANSLATE
       match_all: tots
       match_any: almenys un de
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Del grup de productes
         manual: Triar manualment
     products: Productes
     promotion: Promoció
-    promotion_action:
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Coincideix amb alguna de les següents regles
         any: Coincideix amb totes les següents regles
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
@@ -992,30 +1124,30 @@ ca:
         description: Total de la comanda coincideix amb els següents criteris
         name: Total d'elements
       landing_page:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: La comanda inclou els següents productes
         name: Productes
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Disponible només per als següents clients
         name: Client
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promocions
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Propietats
     property: Propietat
     prototype: Prototip
@@ -1026,47 +1158,49 @@ ca:
     quantity: Quantitat
     quantity_returned: Quantitat retornada
     quantity_shipped: Quantitat enviada
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: proporció
     reason: Raó
     receive: rebre
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: Rebut
-    reception_status:
-    reference:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
     refund: Retornar
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registrar com a nou client
     registration: Registre
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Recordar-me en aquest equip
     remove: Eliminar
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: Informes
+    resellable: TODO_TRANSLATE
     resend: Tornar a enviar
     reset_password: Reiniciar la meva contrasenya
     response_code: Codi de resposta
@@ -1074,36 +1208,43 @@ ca:
     resumed: Reprès
     return: tornar
     return_authorization: Autorització per a devolució
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Retornar autorització actualitzada
     return_authorizations: Autoritzacions per a devolucions
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Retornar quantitat
     returned: va tornar
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
+    returns: TODO_TRANSLATE
+    review: TODO_TRANSLATE
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: Crèdit RMA
     rma_number: Nombre RMA
     rma_value: Valor RMA
+    role_id: TODO_TRANSLATE
     roles: Funcions
     rules: Regles
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Total de vendes
     sales_total_description: Total de vendes de totes les comandes
-    sales_totals:
+    sales_totals: TODO_TRANSLATE
     save_and_continue: Guardar i continuar
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: TODO_TRANSLATE
+    say_no: TODO_TRANSLATE
+    say_yes: TODO_TRANSLATE
     scope: Scope
     search: Buscar
     search_results: Buscar resultats per '%{keywords}'
@@ -1111,10 +1252,11 @@ ca:
     secure_connection_type: Tipus de connexió segura
     security_settings: Security Settings
     select: Seleccionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Seleccionar des de prototip
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Envia una còpia de tots els correus a
     send_mails_as: Enviar correus com
     server: Servidor
@@ -1122,206 +1264,231 @@ ca:
     settings: Configuració
     ship: enviar
     ship_address: adreça d'enviament
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: Enviament
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        shipment_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        track_information: TODO_TRANSLATE
+        track_link: TODO_TRANSLATE
     shipment_state: Estat de l'enviament
     shipment_states:
-      backorder:
-      canceled:
+      backorder: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
       partial: parcial
       pending: pendent
       ready: llest
       shipped: enviat
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Enviaments
     shipped: Enviat
     shipping: Enviament
     shipping_address: Adreça d'enviament
     shipping_categories: Categories d'enviament
     shipping_category: Categoria d'enviament
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: Instruccions d'enviament
     shipping_method: Mètode d'enviament
     shipping_methods: Mètodes d'enviament
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Comprar per %{taxonomy}
     shopping_cart: Cistella de compres
     show: Mostrar
     show_active: mostrar actius
     show_deleted: Mostrar esborrats
     show_only_complete_orders: Mostrar només les comandes completades
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
     sku: Codi
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Font
     special_instructions: Instruccions especials
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: va haver-hi un problema amb la seva informació de pagament. Per favor, revisi-la i intenti-ho de nou.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Inici
+    start_date: TODO_TRANSLATE
     state: Província
     state_based: Província
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Províncies
-    states_required:
+    states_required: TODO_TRANSLATE
     status: Estat
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
     stop: Fins a
     store: Tenda
     street_address: Adreça
     street_address_2: Adreça (continuació)
     subtotal: Subtotal
     subtract: Restar
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} ha estat creat amb èxit"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} ha estat esborrat amb èxit"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource} ha estat actualitzat amb èxit"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Imposats
     tax_categories: Categories fiscals
     tax_category: Categoria fiscal
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Taxes d'impostos
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Categoria
     taxon_edit: Editar categoria
-    taxon_placeholder:
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
-    taxonomies:
-    taxonomy:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
+    taxonomies: TODO_TRANSLATE
+    taxonomy: TODO_TRANSLATE
     taxonomy_edit: Editar categories
     taxonomy_tree_error: El canvi sol·licitat no ha estat acceptat i l'arbre ha tornat al seu estat anterior. Per favor, intenti-ho de nou.
     taxonomy_tree_instruction: "* Clic dret en un dels nodes per accedir al menu per afegir, eliminar o ordenar nodes"
     taxons: Categories
-    test:
+    test: TODO_TRANSLATE
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
-        greeting:
-        message:
-        subject:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
     test_mode: Manera Prova
     thank_you_for_your_order: Gràcies per la seva comanda
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: 'Han hagut problemes amb els següents camps:'
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Miniatura
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: Per agregar variants, primer ha de definir
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Seguiment
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Arbre
     type: Tipus
     type_to_search: Tipus a buscar
     unable_to_connect_to_gateway: No ha estat possible connectar-se a la passarel·la.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
-    unlock:
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: Tipus de targeta desconegut
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: Actualitzar
     updating: Actualitzant
     usage_limit: Límit d'ús
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Usar l'adreça de facturació
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Usar una targeta diferent
-    use_s3:
+    use_new_cc_or_payment_method: TODO_TRANSLATE
+    use_s3: TODO_TRANSLATE
     user: Usuari
     user_rule:
       choose_users: Triar usuaris
     users: Usuaris
     validation:
       cannot_be_less_than_shipped_units: no pot ser menys que el nombre d'unitats enviades.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: "és massa gran -- no hi ha suficients productes disponibles per a aquesta quantitat"
       must_be_int: ha de ser un sencer
       must_be_non_negative: ha de ser un valor no negatiu
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: valor
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Variants
     version: Versió
     void: Buit
@@ -1332,8 +1499,15 @@ ca:
     year: Any
     you_have_no_orders_yet: Encara no té cap comanda.
     your_cart_is_empty: La seva cistella està buida
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: Codi postal
     zipcode: Codi Postal
     zone: Zona
     zones: Zones
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,4 +1,6 @@
+---
 cs:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ cs:
         state: Země
         zipcode: PSČ
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ cs:
         name: Název
         numcode: ISO kód
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Typ
         month: Měsíc
-        name:
+        name: TODO_TRANSLATE
         number: "Číslo"
         verification_value: Verifikační hodnota
         year: Rok
@@ -42,7 +44,7 @@ cs:
       spree/order:
         checkout_complete: Odhlášení dokončeno
         completed_at: Dokončeno
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: Kód kuónu
         created_at: Datum objednávky
         email: Email zákazníka
@@ -72,6 +74,7 @@ cs:
         zipcode: PSČ
       spree/payment:
         amount: "Částka"
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Název
       spree/product:
@@ -95,7 +98,8 @@ cs:
         starts_at: Začíná
         usage_limit: Omezení počtu použití
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Název
         presentation: Prezentace
@@ -105,24 +109,26 @@ cs:
         amount: Množství
       spree/role:
         name: Název
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Zkratka
         name: Název
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Popis
         name: Název
@@ -157,48 +163,54 @@ cs:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         few: Adresy
         one: Adresa
@@ -211,7 +223,7 @@ cs:
         few: Kreditní karty
         one: Kreditní karta
         other: Kreditních karet
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         few: Inventární jednotky
         one: Inventární jednotka
@@ -220,8 +232,8 @@ cs:
         few: "Řádkové položky"
         one: "Řádková položka"
         other: "Řádkových položek"
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         few: Objednávky
         one: Objednávka
@@ -230,13 +242,13 @@ cs:
         few: Platby
         one: Platba
         other: Plateb
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         few: Výrobky
         one: Výrobek
         other: Výrobků
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         few: Vlastnosti
         one: Vlastnost
@@ -245,16 +257,17 @@ cs:
         few: "Šablony"
         one: "Šablona"
         other: "Šablon"
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         few: Návraty oprávnění
         one: Návrat oprávnění
         other: Návratů oprávnění
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
         few: Role
+        oher: TODO_TRANSLATE
         one: Role
         other: Rolí
       spree/shipment:
@@ -265,15 +278,15 @@ cs:
         few: Kategorie dodání
         one: Kategorie dodání
         other: Kategorií dodání
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         few: Státy
         one: Stát
         other: Států
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         few: Kategorie daně
         one: Kategorie daně
@@ -290,7 +303,7 @@ cs:
         few: Sekce
         one: Sekce
         other: Sekcí
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         few: Uživatelé
         one: Uživatel
@@ -303,6 +316,9 @@ cs:
         few: Zóny
         one: Zóna
         other: Zón
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Váš účet byl úspěšně potvrzen. Nyní jste přihlášen(a).
@@ -341,6 +357,7 @@ cs:
     user_sessions:
       signed_in: Přihlášení bylo úspěšné.
       signed_out: Odhlášení bylo úspěšné.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: již byl potvrzen
@@ -350,12 +367,30 @@ cs:
         few: "%{count} chyby zabraňují uložení %{resource}:"
         one: '1 chyba zabraňuje uložení %{resource}:'
         other: "%{count} chyb zabraňuje uložení %{resource}:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Zkratka
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "Účet"
     account_updated: "Účet aktualizován"
     action: Akce
@@ -368,7 +403,7 @@ cs:
       list: Vypsat
       listing: Výpis
       new: Nový
-      refund:
+      refund: TODO_TRANSLATE
       save: Uložit
       update: Uložit
     activate: Aktivovat
@@ -376,7 +411,7 @@ cs:
     add: Přidat
     add_action_of_type: Přidat typ akce
     add_country: Přidat zemi
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Přidat nové záhlaví
     add_new_style: Přidat nový styl
     add_one: Přidat
@@ -390,47 +425,52 @@ cs:
     add_to_cart: Přidat do košíku
     add_variant: Přidat variantu
     additional_item: Dodatečné náklady na jednotku
+    address: TODO_TRANSLATE
     address1: Adresa
     address2: Adresa (pokrač.)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Přizpůsobení
     adjustment_amount: "Částka"
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Nastavení bylo úspěšně uzavřeno!
     adjustment_successfully_opened: Nastavení bylo úspěšně otevřeno!
     adjustment_total: Celkové přizpůsobení
     adjustments: Přizpůsobení
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administrace
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Souhlasím se zásadami ochrany osobních údajů
     agree_to_terms_of_service: Souhlasím s podmínkami služby
     all: Vše
     all_adjustments_closed: Nastavení byla úspěšně uzavřena!
     all_adjustments_opened: Nastavení byla úspěšně otevřena!
     all_departments: Všechna oddělení
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Povolit užívání SSL ve vývojovém a testovacím režimu
     allow_ssl_in_production: Povolit užíván�� SSL v produkčním režimu
     allow_ssl_in_staging: Povolit užívání SSL ve staging režimu
@@ -446,70 +486,104 @@ cs:
     analytics_desc_list_4: Je kompletně zdarma!
     analytics_trackers: Google Analytics
     and: a
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Jste si jisti?
     are_you_sure_delete: Jste si jisti, že chcete vymazat tento záznam?
     associated_adjustment_closed: Přidružené nastavení je uzavřeno a nebude přepočítáno. Chcete jej otevřít?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Chyba autorizace
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Dostupný
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Zpět
     back_end: Administrace
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Zpět do obchodu
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Zpět na seznam uživatelů
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Možnost objednávky z externího skladu
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Nezaplacený zůstatek
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Fakturační adresa
     billing: Fakturace
     billing_address: Fakturační adresa
     both: Obě
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Kalkulátor
     calculator_settings_warning: Pokud měníte typ kalkulátoru, musíte před změnou uložit nastavení
     cancel: zrušit
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: Vytvoření platby objednávky nejde bez uvedení platební metody.
     cannot_create_returns: Nemohu vytvořit položku pro vrácení zboží (RMA), protože zboží ještě nebylo odesláno.
     cannot_perform_operation: Nelze provést požadovanou operaci
     cannot_set_shipping_method_without_address: Nelze nastavit způsob dodání dokud nejsou poskytnuty zákaznické údaje.
     capture: Strhnout
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Bezpečnostní číslo karty
     card_number: "Číslo karty"
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Typ karty je
     cart: Košík
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategorie
     category: Kategorie
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Zkontrolovat Spree upozornění
     checkout: K pokladně
     choose_a_customer: Vyberte zákazníka
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Vyberte měnu
     choose_dashboard_locale: Vyberte lokalizaci
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Město
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Klonovat
     close: Zavřít
     close_all_adjustments: Uzavřít přizpůsobení
@@ -518,6 +592,7 @@ cs:
     complete: dokončit
     configuration: Konfigurace
     configurations: Konfigurace
+    configure_s3: TODO_TRANSLATE
     confirm: Potvrdit
     confirm_delete: Potvrdit vymazání
     confirm_password: Potvrzení hesla
@@ -526,7 +601,7 @@ cs:
     cost_currency: Cena měny
     cost_price: Nákupní cena
     could_not_connect_to_jirafe: Nelze se připojit k Jirafe k synchronizaci dat. Akce bude automaticky opakována později.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Došlo k problému při ukládání tohoto pohybu skladových zásob. Zkuste to prosím znovu.
     count_on_hand: Počet zboží k dispozici
     countries: Země
@@ -534,10 +609,10 @@ cs:
     country_based: Založeno na zemi
     country_name: Název země
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Kupón
     coupon_code: Kód kupónu
     coupon_code_already_applied: Kuponu již byla aplikován pro tuto objednávku
@@ -547,17 +622,17 @@ cs:
     coupon_code_max_usage: Překročen limit použití kódu kupónu
     coupon_code_not_eligible: Tento kód kupónu není uplatnitelný na tuto objednávku
     coupon_code_not_found: Zadaný kód kupónu neexistuje. Zadejte prosím jiný.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Vytvořit
     create_a_new_account: Vytvořit nový účet
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Vytvořeno v
     credit: Kredit
     credit_card: Kreditní karta
     credit_cards: Kreditní karty
     credit_owed: Dlužná částka (kredit)
-    credits:
+    credits: TODO_TRANSLATE
     currency: Měna
     currency_decimal_mark: Desetinná značka měny
     currency_settings: Nastavení měn
@@ -571,16 +646,16 @@ cs:
     customer: Zákazník
     customer_details: "Údaje zákazníka"
     customer_details_updated: "Údaje zákazníka byly aktualizovány"
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Vyhledávání zákazníků
     cut: Vyjmout
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable:
+        currently_unavailable: TODO_TRANSLATE
         explanation: Pole níže již může být vyplněno, pokud jste se rozhodli zaregistrovat Jirafe z admin panelu.
         header: Nastavení Jirafe Analytics
         site_id: Site ID
@@ -589,46 +664,65 @@ cs:
     date: Datum
     date_completed: Datum dokončení
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%d.%m.%Y"
       js_format: dd.mm.yy
     date_range: Datum (od-do)
     default: Výchozí
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Výchozí Daň
     default_tax_zone: Výchozí daňová zóna
     delete: Vymazat
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Dodávka
     depth: Hloubka
     description: Popis
     destination: Cíl
     destroy: Vymazat
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Množství slev
     dismiss_banner: Ne, děkuji. Nemám zájem, neukazujte tuto zprávu znovu
     display: Zobrazit
     display_currency: Zobrazit symbol měny
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Upravit
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Můj účet
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Prázdné
     empty_cart: Vyprázdnit košík
@@ -662,28 +756,30 @@ cs:
           signup: Registrace uživatele
     exceptions:
       count_on_hand_setter: Nelze nastavit count_on_hand manuálně, protože je automaticky nastaven callback recalculate_count_on_hand. Prosím, použijte raději `update_column(:count_on_hand, value)`.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Expirace
     extension: Rozměr
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Název souboru
     fill_in_customer_info: Vyplňte prosím zákaznické informace
+    filter: TODO_TRANSLATE
     filter_results: Zobrazit výsledky
     finalize: Dokončit
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Cena první položky
     first_name: Křestní jméno
     first_name_begins_with: Jméno začíná na
     flat_percent: Paušál (procent)
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Paušál (za objednávku)
     flexible_rate: Pružná sazba
     forgot_password: Zapomenuté heslo
     free_shipping: Dodání zdarma
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Veřejná část
     gateway: Platební brána
     gateway_config_unavailable: Platební brána není k dispozici pro režim
@@ -707,37 +803,41 @@ cs:
       only_incomplete: Pouze neúplné
       select_locale: Vyberte lokalizaci
       show_only: Vybrat pouze
+      store_translations: TODO_TRANSLATE
       supported_locales: Podporované jazyky
       this_file_language: "Čeština (CS)"
       translations: Překlady
     icon: Ikona
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Obrázek
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Obrázky
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Zahrnuto v ceně
     included_price_validation: nemůže být vybráno pokud není nastavena výchozí daňová zóna
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: Zadejte prosím svůj email do formuláře níže
     insufficient_stock: Nedostatečné skladové zásoby, zbývá pouze %{on_hand}
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Odchytávání emailů
     intercept_email_instructions: Anulovet email příjemce a nahradit s touto adresou
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Neplatný poskytovatel plateb.
     invalid_promotion_action: Neplatná propagační akce.
     invalid_promotion_rule: Neplatné propagační pravidlo.
     inventory: Inventář
     inventory_adjustment: Přizpůsobení inventáře
     inventory_error_flash_for_insufficient_quantity: Jedna z položek ve Vašem košíku byla vyprodána.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: není k dispozici pro dodací adresu
     iso_name: ISO název
     item: Položka
@@ -747,26 +847,32 @@ cs:
       operators:
         gt: větší než
         gte: větší nebo stejný než
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Cesta
     last_name: Příjmení
     last_name_begins_with: Příjmení začíná na
     learn_more: Dozvědět se více
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Vypsat
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Nahrávání
     locale_changed: Nastavení jazyka změněno
     location: Umístění
     lock: Uzamknout
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Přihlášen jako
     logged_in_succesfully: Přihlášení proběhlo úspěšně
     logged_out: Byli jste odhlášeni
@@ -775,23 +881,26 @@ cs:
     login_failed: Přihlášení se nezdařilo
     login_name: Přihlásit se
     logout: Odhlásit se
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Vyhledat podobné položky
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Provést vrácení
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Základní cena
     match_choices:
       all: Vše
       none: Ani jeden
     max_items: Maximum položek
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Popis (meta)
     meta_keywords: Klíčová slova (meta)
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Minimální částka
     month: Měsíc
@@ -800,13 +909,13 @@ cs:
     my_account: Můj účet
     my_orders: Mé objednávky
     name: Název
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Nazev nebo SKU (zadejte alespoň první 4 písmena z názvu výrobku)
     new: Nový
     new_adjustment: Nová úprava
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Nový zákazník
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nový obrázek
     new_option_type: Nový typ volby
     new_order: Nová objednávka
@@ -815,14 +924,15 @@ cs:
     new_payment_method: Nový způsob platby
     new_product: Nový výrobek
     new_promotion: Nová propagace
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nová vlastnost
     new_prototype: Nová šablona
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Nová položka pro vrácení zboží (RMA)
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Nová kategorie dodání
     new_shipping_method: Nový způsob dodání
     new_state: Nový stát
@@ -839,24 +949,30 @@ cs:
     new_zone: Nová zóna
     next: Další
     no_actions_added: Není potřeba žádné další akce
-    no_payment_found:
-    no_pending_payments:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Nebyly nalezeny žádné výrobky
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: "Žádné výsledky"
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: "Žádné přidané pravidla"
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Sledování zásilky není dostupné
     none: "Žádný"
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normální množství
     not: ne
     not_available: N/A
     not_enough_stock: Pro dokončení tohoto přesunu není dostatek zásob na zdrojovém umístění.
     not_found: "%{resource} nenalezen"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Výrobek byl naklonován
       product_deleted: Výrobek byl smazán
@@ -864,12 +980,12 @@ cs:
       product_not_deleted: Výrobek nelze odstranit
       variant_deleted: Variantu lze odstranit
       variant_not_deleted: Variantu nelze odstranit
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Dostupný
     open: Otevřít
     open_all_adjustments: Otevřít všechna přizpůsobení
     option_type: Typ volby
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Typy voleb
     option_value: Hodnota volby
     option_values: Hodnoty voleb
@@ -879,32 +995,37 @@ cs:
     or_over_price: "%{price} nebo více"
     order: Objednávka
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Detail objednávky
     order_email_resent: Potvrzení objednávky znovu zasláno
     order_information: Informace o objednávce
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Vážený zákazníku,\n
         instructions: Vaše objednávka byla zrušena. Uschovejte si prosím tyto informace o zrušení k vaší evidenci.
         order_summary_canceled: Shrnutí objednávky [Zrušeno]
         subject: Zrušení objednávky
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Vážený zákazníku,\n
         instructions: Zkontrolujte si a uschovejte si prosím následující údaje objednávky k vaší evidenci.
         order_summary: Přehled objednávek
         subject: Potvrzení objednávky
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Děkujeme za Váš nákup.
-        total:
+        total: TODO_TRANSLATE
     order_not_found: Nemůžeme nalézt Vaši objednávku. Zkuste prosím akci provést později.
-    order_number: 
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Vaše objednávka byla úspěšně zpracována
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: Adresa
       awaiting_return: "Čeká na návrat"
@@ -912,7 +1033,7 @@ cs:
       cart: Košik
       complete: Dokončení
       confirm: Potvrzení
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: Možnosti dodání
       payment: Platba
       resumed: Obnovená
@@ -922,12 +1043,14 @@ cs:
     order_total: Objednávka celkem
     order_updated: Objednávka byla aktualizována
     orders: Objednávky
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Není skladem
     overview: Přehled
     package_from: 'umístění:'
     pagination:
+      first: TODO_TRANSLATE
       next_page: další strana »
+      previous: TODO_TRANSLATE
       previous_page: "« předchozí strana"
       truncate: "…"
     password: Heslo
@@ -935,11 +1058,11 @@ cs:
     path: Cesta
     pay: zaplatit
     payment: Platba
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Informace k platbě
     payment_method: Způsob platby
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Způsoby platby
     payment_processing_failed: Platba nemohla být zpracována, zkontrolujte prosím zadané údaje.
     payment_processor_choose_banner_text: Pokud potřebujete poradit při výběru platební služby, navštivte prosím
@@ -957,22 +1080,23 @@ cs:
       void: Neplatná
     payment_updated: Platba upravena
     payments: Platby
-    pending:
+    pending: TODO_TRANSLATE
     percent: Procenta
     percent_per_item: Procent na položku
     permalink: Stálý odkaz
     phone: Telefon
     place_order: Objednat
     please_define_payment_methods: Nejprve zadefinujte platební metody.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Něco je špatně. Zkuste prosím přidat položku znovu.
     powered_by: Pohání
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Prezentace
     previous: Předchozí
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Cena
     price_range: Cenové rozpětí
     price_sack: Ceny balíku
@@ -984,10 +1108,10 @@ cs:
     product_properties: Vlastnosti výrobku
     product_rule:
       choose_products: Vyberte výrobky
-      label:
+      label: TODO_TRANSLATE
       match_all: Vše
       match_any: Alespoň jeden
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Ze skupiny výrobků
         manual: Vybrat manuálně
@@ -999,19 +1123,24 @@ cs:
         description: Vytvoří přizpůsobeni kreditní propagaci v objednávce
         name: Vytvořit nastavení
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Naplní košík určeným množstvím variant
         name: Vytvořit řádkové položky
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Propagační akce
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: V souladu se všemi pravidly
         any: V souladu s některými pravidly
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Pravidla propagace
     promotion_rule_types:
       first_order:
@@ -1024,27 +1153,27 @@ cs:
         description: Zákazník musí navštívit určenou stránku
         name: Cílové stránky
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Objednávka obsahuje zadaný výrobek(y)
         name: Výrobky
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Dostupné pouze pro uvedené uživatele
         name: Uživatel
       user_logged_in:
         description: Dostupné pouze pro přihlášené uživatele
         name: Uživatel přihlášen
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Propagace
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Vlastnosti
     property: Vlastnost
     prototype: "Šablona"
@@ -1055,47 +1184,49 @@ cs:
     quantity: Množství
     quantity_returned: Vrácené množství
     quantity_shipped: Odeslané množství
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Sazba
     reason: Důvod
     receive: obdržet
     receive_stock: Přijmout zásoby do skladu
     received: Obdrženo
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Reference
+    reference_contains: TODO_TRANSLATE
     refund: Vráceno
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Zaregistrovat se jako nový uživatel
     registration: Registrace
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Zapamatovat si mě
     remove: Vyjmout
     rename: Přejmenovat
-    report:
+    report: TODO_TRANSLATE
     reports: Reporty
+    resellable: TODO_TRANSLATE
     resend: Zaslat znovu
     reset_password: Resetovat mé heslo
     response_code: Kód odpovědi
@@ -1103,34 +1234,41 @@ cs:
     resumed: Obnoveno
     return: vrátit
     return_authorization: Položka pro vrácení zboží (RMA)
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Položka pro vrácení zboží (RMA) aktualizována
     return_authorizations: Položky pro vrácení zboží (RMA)
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Množství položek pro vrácení zboží (RMA)
     returned: Vráceno
-    returns:
+    returns: TODO_TRANSLATE
     review: Recenze
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA kredity
     rma_number: "Číslo položky pro vrácení zboží (RMA)"
     rma_value: Hodnota položky pro vrácení zboží (RMA)
+    role_id: TODO_TRANSLATE
     roles: Role
     rules: Pravidla
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Prodej celkem
     sales_total_description: Slevy na všechny objednávky
     sales_totals: Celkové prodeje
     save_and_continue: Uložit a pokračovat
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: Ne
     say_yes: Ano
     scope: Rozsah
@@ -1140,10 +1278,11 @@ cs:
     secure_connection_type: Typ bezpečného připojení
     security_settings: Nastavení zabezpečení
     select: Výběr
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Výběr ze šablon
     select_stock: Vyberte zásoby ze skladu
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Zasílat kopie všech emailů na emailovou adresu
     send_mails_as: Posílat emaily jako
     server: Server
@@ -1153,8 +1292,9 @@ cs:
     ship_address: Dodací adresa
     ship_total: Dodání celkem
     shipment: Dodání
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Vážený zákazníku,\n
@@ -1167,89 +1307,105 @@ cs:
     shipment_state: Stav dodávky
     shipment_states:
       backorder: V externím skladu
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: "Částečná"
       pending: "Čekající na vyřízení"
       ready: Připravit
       shipped: Dodáno
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Dopravy
     shipped: Dodáno
     shipping: Dodání
     shipping_address: Dodací adresa
     shipping_categories: Kategorie dodání
     shipping_category: Kategorie dodání
-    shipping_flat_rate_per_item:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
     shipping_flat_rate_per_order: Jednotná sazba za dodání
     shipping_flexible_rate: Flexibilní sazba za dodání
     shipping_instructions: Instrukce k dodání
     shipping_method: Způsob dodání
     shipping_methods: Způsoby dodání
     shipping_price_sack: Jednotná sazba za balik
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Nakupovat podle %{taxonomy}
     shopping_cart: Nákupní košík
     show: Ukázat
     show_active: Zobrazit platné
     show_deleted: Zobrazit smazané
     show_only_complete_orders: Zobrazit pouze dokončené objednávky
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Zobrazit sazby v popisku
     sku: "Číslo zboží (SKU)"
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Zdroj
     special_instructions: Zvláštní instrukce
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Došlo k problému s Vašimi platebními informacemi. Zkontrolujte je prosím a opakujte akci znovu.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Začátek
+    start_date: TODO_TRANSLATE
     state: Stav
     state_based: Založeno na státu
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Státy
     states_required: Stát povinen
     status: Stav
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Sklad
     stock_location_info: Informace o skladu
     stock_locations: Sklady
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Správa skladu
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
     stock_movements: Pohyby skladových zásob
     stock_movements_for_stock_location: Pohyb skladových zásob pro %{stock_location_name}
     stock_successfully_transferred: Skladové zásoby byly úspěšně přesunuty mezi lokacemi.
@@ -1261,28 +1417,30 @@ cs:
     street_address_2: "Číslo ulice"
     subtotal: Mezisoučet
     subtract: Odečet
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} byl úspěšně vytvořen!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} byl úspěšně odstraněn!"
     successfully_signed_up_for_analytics: Registrace do Spree Analytics proběhla úspěšně.
     successfully_updated: "%{resource} byl úspěšně aktualizován!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Daň
     tax_categories: Daňové kategorie
     tax_category: Daňová kategorie
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Daňové sazby jsou desetinná čísla použitá při výpočtech, (je-li daňová sazba je 5% zadejte 0.05)
     tax_rates: Sazby daně
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Kategorie
     taxon_edit: Upravit kategorii
     taxon_placeholder: Přidat kategorii
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Sekce
     taxonomy: Sekce
     taxonomy_edit: Upravit sekci
@@ -1291,32 +1449,35 @@ cs:
     taxons: Kategorie
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Gratulujeme!
         message: Pokud jste obdrželi tento email, Vaše nastavení emailu je správné.
         subject: Testovací email
     test_mode: Testovací režim
     thank_you_for_your_order: Děkujeme za Váš nákup. Doporučujeme Vám vytisknout si kopii této stránky.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: Opravte prosím následující chyby
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Náhled obrázku
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: "Čas"
     to_add_variants_you_must_first_define: Pro přidání variant je musíte nejprve nadefinovat.
     total: Celkem
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Sledování
     tracking_number: "Číslo pro sledování"
     tracking_url: URL pro sledování
     tracking_url_placeholder: 'URL pro doručovací služby, např: http://quickship.com/package?num=:tracking'
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Převést z
     transfer_stock: Převést skladové zásoby
     transfer_to_location: Převést do
@@ -1324,7 +1485,7 @@ cs:
     type: Typ
     type_to_search: Typ hledání
     unable_to_connect_to_gateway: Nelze se připojit k platební bráně.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Pod %{price}
     unlock: Odemknout
     unrecognized_card_type: Typ karty nebyl rozpoznán
@@ -1332,9 +1493,11 @@ cs:
     update: Uložit změny
     updating: Ukládám změny
     usage_limit: Limit pro použití
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Použít fakturační adresu
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Použít novou kartu
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Použít Amazon S3 pro ukládání obrázků
     user: Uživatel
     user_rule:
@@ -1342,15 +1505,16 @@ cs:
     users: Uživatelé
     validation:
       cannot_be_less_than_shipped_units: Nesmí být menší než číslo poslaných jednotek.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: přesahuje dostupné skladové zásoby. Ujistěte se, že pro položky objednávky je požadované množství.
       is_too_large: je příliš mnoho -- stávající skladové zásoby nepokryjí požadované množství!
       must_be_int: musí být celé číslo
       must_be_non_negative: musí být nezáporná hodnota
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Hodnota
     variant: Varianta
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Varianty
     version: Verze
     void: Prázdné
@@ -1366,3 +1530,10 @@ cs:
     zipcode: PSČ
     zone: Zóna
     zones: Zóny
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1,4 +1,6 @@
+---
 da:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ da:
         state: Delstat
         zipcode: Postnummer
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ da:
         name: Navn
         numcode: ISO-kode
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Type
         month: Måned
-        name:
+        name: TODO_TRANSLATE
         number: Nummer
         verification_value: CVV-kode
         year: "År"
@@ -72,6 +74,7 @@ da:
         zipcode: Postnummer
       spree/payment:
         amount: Beløb
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Navn
       spree/product:
@@ -95,7 +98,8 @@ da:
         starts_at: Starter
         usage_limit: Brugsbegrænsning
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Navn
         presentation: Præsentation
@@ -105,24 +109,26 @@ da:
         amount: Antal
       spree/role:
         name: Navn
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Forkortelse
         name: Navn
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Beskrivelse
         name: Navn
@@ -157,48 +163,54 @@ da:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adresse
         other: Adresser
@@ -208,41 +220,43 @@ da:
       spree/credit_card:
         one: Betalingskort
         other: Betalingskort
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
       spree/line_item:
         one: Ordrelinje
         other: Ordrelinjer
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Ordre
         other: Ordrer
       spree/payment:
         one: Betaling
         other: Betalinger
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Vare
         other: Varer
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Egenskab
         other: Egenskaber
       spree/prototype:
         one: Prototype
         other: Prototyper
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Return Authorization
         other: Return Authorizations
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Rolle
         other: Roller
       spree/shipment:
@@ -251,14 +265,14 @@ da:
       spree/shipping_category:
         one: Leveringskategori
         other: Leveringskategorier
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Delstat
         other: Delstater
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Momskategori
         other: Momskategorier
@@ -271,7 +285,7 @@ da:
       spree/taxonomy:
         one: Taksonomi
         other: Taksonomier
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Bruger
         other: Brugere
@@ -281,6 +295,9 @@ da:
       spree/zone:
         one: Zone
         other: Zoner
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Du har bekræftet din konto. Du er nu logget ind.
@@ -319,6 +336,7 @@ da:
     user_sessions:
       signed_in: Du er nu logget ind.
       signed_out: Du er nu logget ud.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: er blevet bekræftet
@@ -327,12 +345,30 @@ da:
       not_saved:
         one: '1 fejl forhindrede %{resource} i at blive gemt:'
         other: "%{count} fejl forhindrede %{resource} i at blive gemt:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Forkortelse
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Konto
     account_updated: Konto opdateret!
     action: Handling
@@ -345,7 +381,7 @@ da:
       list: Liste
       listing: Liste
       new: Ny
-      refund:
+      refund: TODO_TRANSLATE
       save: Gem
       update: Opdater
     activate: Aktivér
@@ -353,7 +389,7 @@ da:
     add: Tilføj
     add_action_of_type: Tilføj handling
     add_country: Tilføj land
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Tilføj nyt hovede
     add_new_style: Tilføj ny stil
     add_one: Tilføj en
@@ -367,11 +403,16 @@ da:
     add_to_cart: Tilføj til indkøbskurv
     add_variant: Tilføj variant
     additional_item: Yderligere varepris
+    address: TODO_TRANSLATE
     address1: Adresse
     address2: Adresse (fortsat)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Justering
     adjustment_amount: Beløb
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Justeringer lukket
     adjustment_successfully_opened: Justeringer åbnet
     adjustment_total: Samlet justering
@@ -379,35 +420,35 @@ da:
     admin:
       tab:
         configuration: Konfiguration
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: Ordrer
         overview: Oversigt
         products: Produkter
         promotions: Kampagner
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: Rapporter
-        taxonomies:
-        taxons:
-        users:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administration
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Godkend vores privatlivs-betingelser
     agree_to_terms_of_service: Godkend vores handelsbetingelser
     all: Alle
     all_adjustments_closed: Alle justeringer lukkede
     all_adjustments_opened: Alle justeringer åbne
     all_departments: Alle afdelinger
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Tillad SSL i 'development mode'
     allow_ssl_in_production: Tillad SSL i produktion
     allow_ssl_in_staging: Tillad SSL i 'staging mode'
@@ -423,70 +464,104 @@ da:
     analytics_desc_list_4: Det er 100% gratis!
     analytics_trackers: Statestik-tracker
     and: og
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: Godkend
     approved_at: Godkendt d.
     approver: Godkendt af
     are_you_sure: Er du sikker?
     are_you_sure_delete: Er du sikker på at du vil slette denne post?
     associated_adjustment_closed: Den tilhørende justering er lukket, og vil ikke blive genberegnet. Vil du åben den?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Autorisation fejlede
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Tilgængelig
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Tilbage
     back_end: Administrationsgrænseflade
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Gå tilbage til butikken
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Tilbage til brugerlisten
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Ventelist mulig
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Forfalden saldo
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Faktureringsadresse
     billing: Fakturering
     billing_address: Faktureringsadresse
     both: Begge
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Beregner
     calculator_settings_warning: Hvis du ændrer beregnertypen, må du først gemme inden du kan ændre beregnerindstillingerne
     cancel: annuller
     canceled_at: Annulleret d.
     canceler: Annulleret af
-    cannot_create_customer_returns:
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: Du kan ikke skabe en betaling for en ordre uden valgt betalingsmetode
     cannot_create_returns: Kan ikke returnere ordren, eftersom den endnu ikke er leveret.
     cannot_perform_operation: Kan ikke udføre den ønskede operation
     cannot_set_shipping_method_without_address: Kan ikke vælge leveringsmetode før adresseinformation er oplyst.
     capture: hæv beløb (capture)
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kortkode
     card_number: Kortnummer
     card_type: Korttype
     card_type_is: Korttypen er
     cart: Indkøbskurv
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategorier
     category: Kategori
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Check for Spree sikkerhedsopdateringer
     checkout: Til kassen
     choose_a_customer: Vælg kunde
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Vælg valuta
     choose_dashboard_locale: Vælg sprog i kontrolpanel
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: By
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Dupliker
     close: Luk
     close_all_adjustments: Luk alle justeringer
@@ -495,6 +570,7 @@ da:
     complete: afsluttet
     configuration: Konfiguration
     configurations: Konfigurationer
+    configure_s3: TODO_TRANSLATE
     confirm: Bekræft
     confirm_delete: Bekræft sletning
     confirm_password: Bekræft adgangskode
@@ -503,7 +579,7 @@ da:
     cost_currency: Kostvaluta
     cost_price: Kostpris
     could_not_connect_to_jirafe: Kunne ikke forbinde til Jirafe. Det vil blive forsøgt automatisk senere.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Der var et problem med at gemme lagerbevægelsen. Prøv igen.
     count_on_hand: Antal tilgængelig
     countries: Lande
@@ -511,10 +587,10 @@ da:
     country_based: Landbaseret
     country_name: Navn
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Rabat
     coupon_code: Rabatkode
     coupon_code_already_applied: Rabatkoden er allerede anvendt på denne ordre
@@ -524,17 +600,17 @@ da:
     coupon_code_max_usage: Rabatkoden har nået maksimum brug
     coupon_code_not_eligible: Denne rabatkode kan ikke anvendes på denne ordre
     coupon_code_not_found: Rabatkoden eksisterer ikke. Prøv venligst igen.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Opret
     create_a_new_account: Opret en ny konto
     create_new_order: Opret ny ordre
-    create_reimbursement:
+    create_reimbursement: TODO_TRANSLATE
     created_at: Oprettet den
     credit: Kredit
     credit_card: Kreditkort
     credit_cards: Kreditkort
     credit_owed: Skyldig kredit
-    credits:
+    credits: TODO_TRANSLATE
     currency: Valuta
     currency_decimal_mark: Valuta decimaltegn
     currency_settings: Indstillinger for valuta
@@ -545,11 +621,11 @@ da:
     customer: Kunde
     customer_details: Kunde detaljer
     customer_details_updated: Kundedetaljer opdateret
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Søg på kunde
     cut: Klip
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: App ID
@@ -563,16 +639,20 @@ da:
     date: Dato
     date_completed: Dato gennemført
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%d/%m/%Y"
       js_format: dd/mm/yy
     date_range: Datointerval
     default: Standard
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Standardmoms
     default_tax_zone: Standardmomszone
     delete: Slet
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Levering
     depth: Dybde
     description: Beskrivelse
@@ -583,26 +663,41 @@ da:
     dismiss_banner: Nej Tak. Jeg er ikke interesseret. Vis ikke denne meddelelse igen.
     display: Visning
     display_currency: Vis valuta
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Rediger
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Redigering af bruger
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: E-mail
     empty: Tom
     empty_cart: Tom indkøbskurv
@@ -634,29 +729,31 @@ da:
         user:
           signup: Tilmeld dig
     exceptions:
-      count_on_hand_setter: "Antal tilgængelig kan ikke sættes manuelt. Det sættes automatisk af recalculate_count_on_hand callback. Brug `update_column(:count_on_hand, value)` istedet."
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: Antal tilgængelig kan ikke sættes manuelt. Det sættes automatisk af recalculate_count_on_hand callback. Brug `update_column(:count_on_hand, value)` istedet.
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Udløbsdato
     extension: Udvidelse
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Filnavn
     fill_in_customer_info: Udfyld venligst kunde- /adresse-informationer
+    filter: TODO_TRANSLATE
     filter_results: Søg med filtre
     finalize: Afslut
     finalized: Afsluttet
-    find_a_taxon:
+    find_a_taxon: TODO_TRANSLATE
     first_item: Første vares pris
     first_name: Fornavn
     first_name_begins_with: Fornavn begynder med
     flat_percent: Fast procentsats
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Fast pris (per ordre)
     flexible_rate: Flexible pris
     forgot_password: Glemt adgangskode
     free_shipping: Gratis levering
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Kunde interface
     gateway: Betalingsleverandør
     gateway_config_unavailable: Betalingsleverandør er ikke tilgængelig for nuværende miljø
@@ -680,37 +777,41 @@ da:
       only_incomplete: Kun ikke-komplette
       select_locale: Vælg sprog
       show_only: Vis kun
+      store_translations: TODO_TRANSLATE
       supported_locales: Understøttede sprog
       this_file_language: Danish
       translations: Oversættelser
     icon: Ikon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Billed
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Billeder
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
     incl: inkl.
     included_in_price: Inkluderet i prisen
     included_price_validation: kan ikke vælges med mindre du har sat en standard skatte-zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Udfyld formen nedenfor og vi vil sende dig instruktionerne til at nulstille din adgangskode:'
     insufficient_stock: Der er ikke nok på lager, kun %{on_hand} tilbage
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Opsnap e-mail-adresse
     intercept_email_instructions: Overskriv e-mail-modtagerens adresse med denne adresse.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Ugyldig betalingsformidler
     invalid_promotion_action: Ugyldig rabat handling.
     invalid_promotion_rule: Ugyldig rabat regel.
     inventory: Beholdning
     inventory_adjustment: Beholdningsjustering
     inventory_error_flash_for_insufficient_quantity: En vare i din kurv er ikke længere på lager.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: er ikke tilgængelig for leveringsadressen
     iso_name: ISO-navn
     item: Artikel
@@ -723,23 +824,29 @@ da:
         lt: mindre end
         lte: mindre end eller lig med
     items_cannot_be_shipped: Vi kan ikke levere til adressen. Vælg venlist en anden adresse.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe Statistik
     landing_page_rule:
       path: Path
     last_name: Efternavn
     last_name_begins_with: Efternavn begynder med
     learn_more: Læs mere
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Liste
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Indlæser
     locale_changed: Sproget er ændret
     location: Sted
     lock: Lås
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Logget ind som
     logged_in_succesfully: Du er nu logget ind
     logged_out: Du er nu logget ud.
@@ -748,23 +855,26 @@ da:
     login_failed: Login mislykkedes.
     login_name: Login
     logout: Log ud
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Lignende varer
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Foretage tilbagebetaling
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Hovedpris
     match_choices:
       all: All
       none: None
     max_items: Maksimalt antal varer
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Metabeskrivelse
     meta_keywords: Metanøgleord
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Minimalt beløb
     month: Måned
@@ -773,13 +883,13 @@ da:
     my_account: Min konto
     my_orders: Mine ordrer
     name: Navn
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: navn eller varenummer
     new: Ny
     new_adjustment: Ny justering
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Ny kunde
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nyt billed
     new_option_type: Ny alternative udgave
     new_order: Ny ordre
@@ -788,14 +898,15 @@ da:
     new_payment_method: Ny betaings
     new_product: Ny vare
     new_promotion: Ny kampagne
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Ny egenskab
     new_prototype: Ny prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Ny returnerings autorisation
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Ny leveringskategori
     new_shipping_method: Ny leveringsmetode
     new_state: Ny delstat
@@ -812,24 +923,30 @@ da:
     new_zone: Ny zone
     next: Næste
     no_actions_added: Ingen handlinger tilføjet
-    no_payment_found:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: Ingen afventende betalinger
     no_products_found: Ingen varer fundet
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Ingen resultater
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Ingen regler tilføjet
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Ingen track & trace oplysninger.
     none: Ingen
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normalt beløb
     not: ikke
     not_available: N/A
     not_enough_stock: Ikke nok på lager til at gennemføre denne lagerflytning.
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Varen er blevet duplikeret
       product_deleted: Varen er blevet slettet
@@ -837,12 +954,12 @@ da:
       product_not_deleted: Varen kunne ikke slettes
       variant_deleted: Variant er blevet slettet
       variant_not_deleted: Variant kunne ikke slettes
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: På lager
     open: "Åben"
     open_all_adjustments: "Åbn alle justeringer"
     option_type: Alternativ udgave
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Alternative udgaver
     option_value: Alternativ værdi
     option_values: Alternative værdier
@@ -852,32 +969,37 @@ da:
     or_over_price: "%{price} or over"
     order: Ordre
     order_adjustments: Ordrejusteringer
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Ordredetaljer
     order_email_resent: Send ordre-e-mail igen
     order_information: Ordreinformation
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Kære kunde,\n
         instructions: Din ordre er blevet annulleret. Gem venligst denne annullering
         order_summary_canceled: Sammendrag af ordre [Annulleret]
         subject: Annullering af ordre
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Kære kunde,\n
         instructions: Gennemlæs og gem venligst følgende orderinformation.
         order_summary: Sammendrag af ordre
         subject: Ordrebekræftelse
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Tak for handelen.
-        total:
+        total: TODO_TRANSLATE
     order_not_found: Vi kunne ikke finde din ordre. Prøv venligst sidste handling igen.
-    order_number:
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Din ordre er blevet modtaget
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: adresse
       awaiting_return: afventer returnering
@@ -895,12 +1017,14 @@ da:
     order_total: Ordre total
     order_updated: Ordre opdateret
     orders: Ordrer
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Ikke på lager
     overview: Oversigt
     package_from: pakke fra
     pagination:
+      first: TODO_TRANSLATE
       next_page: next page »
+      previous: TODO_TRANSLATE
       previous_page: "« previous page"
       truncate: "…"
     password: Adgangskode
@@ -908,11 +1032,11 @@ da:
     path: Sti
     pay: betal
     payment: Betaling
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Betalingsinformation
     payment_method: Betalingsmetode
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Betalingsmetoder
     payment_processing_failed: Betalingen kunne ikke gennemføres. Hver venlig at checke de detaljer du har indtastet.
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -930,22 +1054,23 @@ da:
       void: annulleret
     payment_updated: Betaling er opdater
     payments: Betalinger
-    pending:
+    pending: TODO_TRANSLATE
     percent: Procent
     percent_per_item: Percent Per Item
     permalink: Permalink
     phone: Telefonnummer
     place_order: Afgiv ordre
     please_define_payment_methods: Vær venlig at opret nogle betalingsmuligheder først.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Der gik noget galt. Forsøg at tilføje artiklen igen.
     powered_by: Leveret af
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: præsentation
     previous: Foregående
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Pris
     price_range: Prisklasse
     price_sack: Prisgruppe
@@ -957,10 +1082,10 @@ da:
     product_properties: Vareegenskaber
     product_rule:
       choose_products: Vælg varer
-      label:
+      label: TODO_TRANSLATE
       match_all: alle
       match_any: mindst en
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Fra varegruppe
         manual: Vælg manuelt
@@ -972,19 +1097,24 @@ da:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Handlinger
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Match enhver af disse regler
         any: Match alle disse regler
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
@@ -997,27 +1127,27 @@ da:
         description: Kunde skal have besøgt the angivne side
         name: Landingsside
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Ordrer inkluderer angivne vare(r)
         name: Vare(r)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Kun tilgængelig for de angivne bruger
         name: Bruger
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Kampagner
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Egenskaber
     property: Egenskab
     prototype: Prototype
@@ -1028,47 +1158,49 @@ da:
     quantity: Antal
     quantity_returned: Antal returneret
     quantity_shipped: Antal leveret
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Sats
     reason: Anledning
     receive: Modtage
     receive_stock: Modtag varer
     received: Modtaget
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Reference
+    reference_contains: TODO_TRANSLATE
     refund: Tilbagebetal
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registrer som nu bruger
     registration: Registrering
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Husk mig
     remove: Fjern
     rename: Omdøb
     report: Rapport
     reports: Rapporter
+    resellable: TODO_TRANSLATE
     resend: Gensend
     reset_password: Nulstil min adgangskode
     response_code: Svarkode
@@ -1076,28 +1208,35 @@ da:
     resumed: Genoptaget
     return: vend tilbage
     return_authorization: Retur-godkendelse
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Retur-godkendelse opdateret
     return_authorizations: Retur-godkendelser
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Retur-antal
     returned: Returneret
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
     risky: Risikabel
     rma_credit: RMA-kredit
     rma_number: RMA-nummer
     rma_value: RMA-værdi
+    role_id: TODO_TRANSLATE
     roles: Roller
     rules: Regler
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
     safe: Sikker
     sales_total: Samlet salg
     sales_total_description: Samlet salg af alle ordre
@@ -1108,15 +1247,16 @@ da:
     say_yes: Ja
     scope: Område
     search: Søg
-    search_results: "Søgeresultater for '%{keywords}'"
+    search_results: Søgeresultater for '%{keywords}'
     searching: Søger
     secure_connection_type: Sikker forbindelsestype
     security_settings: Sikkerhedsindstillinger
     select: Vælg
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Vægl fra prototype
     select_stock: Vælg
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Send kopi af alle e-mails til
     send_mails_as: Send e-mails som
     server: Server
@@ -1126,8 +1266,9 @@ da:
     ship_address: Leveringsadresse
     ship_total: Leveret total
     shipment: Levering
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1140,89 +1281,105 @@ da:
     shipment_state: Leveringsstatus
     shipment_states:
       backorder: restnoter
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: delvis
       pending: afventende
       ready: klar
       shipped: leveret
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Leveringer
     shipped: Leveret
     shipping: Levering
     shipping_address: Leveringsadresse
     shipping_categories: Leveringskategori
     shipping_category: Leveringskategori
-    shipping_flat_rate_per_item:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
     shipping_flat_rate_per_order: Fastpris
     shipping_flexible_rate: Variabel fragtpris
     shipping_instructions: Leveringsinstruktioner
     shipping_method: Leveringsmetode
     shipping_methods: Leveringsmetoder
     shipping_price_sack: Prissænkning
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Køb via %{taxonomy}
     shopping_cart: Indkøbskurv
     show: Vis
     show_active: Vis aktive
     show_deleted: Vis slettede
     show_only_complete_orders: Vis kun afsluttede ordrer
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Vis sats i label
     sku: Varenummer
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Kilde
     special_instructions: Specielle instrukser
     split: Del
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Der var et problem med din betalingsinformation. Check dine informationer og prøv igen.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Start
+    start_date: TODO_TRANSLATE
     state: Delstat
     state_based: Delstatsbaseret
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Delstater
     states_required: Stat/region kræves
     status: Status
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Lagersted
     stock_location_info: Information om lagersted
     stock_locations: Lagersteder
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Lagerstyring
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
     stock_movements: Lagerbevægelser
     stock_movements_for_stock_location: Lagerbevægelser for %{stock_location_name}
     stock_successfully_transferred: Varerne er blevet flyttet mellem lagerstederne.
@@ -1234,28 +1391,30 @@ da:
     street_address_2: Adresse (forts.)
     subtotal: Subtotal
     subtract: Fratræk
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} er blevet oprettet!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} er blevet slettet!"
     successfully_signed_up_for_analytics: Du er nu koblet på Spree Analytics
     successfully_updated: "%{resource} er blevet opdateret!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Moms
     tax_categories: Momskategorier
     tax_category: Momskategori
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Moms tastes som decimaltal. (25% tastes som 0.25)
     tax_rates: Momssatser
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taksonomisk gruppe
     taxon_edit: Rediger taksonomisk gruppe
     taxon_placeholder: Tilføj taksonomisk gruppe
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taksonomier
     taxonomy: Taxonomy
     taxonomy_edit: Rediger taksonomi
@@ -1264,32 +1423,35 @@ da:
     taxons: Taksonomisk gruppe
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Congratulations!
         message: If you have received this email, then your email settings are correct.
         subject: Testmail
     test_mode: Testtilstand
     thank_you_for_your_order: Tag for din bestilling. Udskriv venligst en kopi af denne bekræftelsesside til opbevaring.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: Der var problemer med følgende felter
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Tid
     to_add_variants_you_must_first_define: For at tilføje varianter, må du først definere
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Sporing
     tracking_number: Track & trace nummer
     tracking_url: Track & trace url
     tracking_url_placeholder: fx. http://www.postdanmark.dk/da/Sider/TrackTrace.aspx?search=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Flyt fra
     transfer_stock: Flyt varer
     transfer_to_location: Flyt til
@@ -1297,7 +1459,7 @@ da:
     type: Type
     type_to_search: Skriv for at søge
     unable_to_connect_to_gateway: Ude af stand til at forbinde til betalingsleverandør.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
     unlock: Lås op
     unrecognized_card_type: Ukendt korttype
@@ -1305,9 +1467,11 @@ da:
     update: Opdater
     updating: Opdaterer
     usage_limit: Brugsgrænse
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Brug faktureringsadresse
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Brug et nyt kort
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Brug Amazon S3 til varebilleder
     user: Bruger
     user_rule:
@@ -1315,12 +1479,13 @@ da:
     users: Brugere
     validation:
       cannot_be_less_than_shipped_units: kan ikke være mindre end antallet af leverede enheder.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: Overskrider tilgængelig beholdning. Du bør sikre dig varer har et gyldigt antal
       is_too_large: er for stor – der er ikke nok på lager!
       must_be_int: skal være et heltal
       must_be_non_negative: skal være et positivt tal
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Værdi
     variant: Variant
     variant_placeholder: Vælg en variant
@@ -1339,3 +1504,10 @@ da:
     zipcode: Postnummer
     zone: Zone
     zones: Zoner
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -1,835 +1,1005 @@
+---
 de-CH:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
-        address1:
-        address2:
-        city:
-        country:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        address2: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        country: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
-        iso:
-        iso3:
-        iso_name:
-        name:
-        numcode:
+        iso: TODO_TRANSLATE
+        iso3: TODO_TRANSLATE
+        iso_name: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        numcode: TODO_TRANSLATE
       spree/credit_card:
-        base:
-        cc_type:
-        month:
-        name:
-        number:
-        verification_value:
-        year:
+        base: TODO_TRANSLATE
+        cc_type: TODO_TRANSLATE
+        month: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        number: TODO_TRANSLATE
+        verification_value: TODO_TRANSLATE
+        year: TODO_TRANSLATE
       spree/inventory_unit:
-        state:
+        state: TODO_TRANSLATE
       spree/line_item:
-        price:
-        quantity:
+        price: TODO_TRANSLATE
+        quantity: TODO_TRANSLATE
       spree/option_type:
-        name:
-        presentation:
+        name: TODO_TRANSLATE
+        presentation: TODO_TRANSLATE
       spree/order:
-        checkout_complete:
-        completed_at:
+        checkout_complete: TODO_TRANSLATE
+        completed_at: TODO_TRANSLATE
         considered_risky: Riskant
-        coupon_code:
-        created_at:
-        email:
-        ip_address:
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        coupon_code: TODO_TRANSLATE
+        created_at: TODO_TRANSLATE
+        email: TODO_TRANSLATE
+        ip_address: TODO_TRANSLATE
+        item_total: TODO_TRANSLATE
+        number: TODO_TRANSLATE
+        payment_state: TODO_TRANSLATE
+        shipment_state: TODO_TRANSLATE
+        special_instructions: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/payment:
-        amount:
+        amount: TODO_TRANSLATE
+        number: TODO_TRANSLATE
       spree/payment_method:
-        name:
+        name: TODO_TRANSLATE
       spree/product:
-        available_on:
-        cost_currency:
-        cost_price:
-        description:
-        master_price:
-        name:
-        on_hand:
-        shipping_category:
-        tax_category:
+        available_on: TODO_TRANSLATE
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        description: TODO_TRANSLATE
+        master_price: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        on_hand: TODO_TRANSLATE
+        shipping_category: TODO_TRANSLATE
+        tax_category: TODO_TRANSLATE
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: TODO_TRANSLATE
+        code: TODO_TRANSLATE
+        description: TODO_TRANSLATE
+        event_name: TODO_TRANSLATE
+        expires_at: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        path: TODO_TRANSLATE
+        starts_at: TODO_TRANSLATE
+        usage_limit: TODO_TRANSLATE
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
-        name:
-        presentation:
+        name: TODO_TRANSLATE
+        presentation: TODO_TRANSLATE
       spree/prototype:
-        name:
+        name: TODO_TRANSLATE
       spree/return_authorization:
-        amount:
+        amount: TODO_TRANSLATE
       spree/role:
-        name:
+        name: TODO_TRANSLATE
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
-        abbr:
-        name:
+        abbr: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: TODO_TRANSLATE
+        included_in_price: TODO_TRANSLATE
+        show_rate_in_label: TODO_TRANSLATE
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: TODO_TRANSLATE
+        permalink: TODO_TRANSLATE
+        position: TODO_TRANSLATE
       spree/taxonomy:
-        name:
+        name: TODO_TRANSLATE
       spree/user:
-        email:
-        password:
-        password_confirmation:
+        email: TODO_TRANSLATE
+        password: TODO_TRANSLATE
+        password_confirmation: TODO_TRANSLATE
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        depth: TODO_TRANSLATE
+        height: TODO_TRANSLATE
+        price: TODO_TRANSLATE
+        sku: TODO_TRANSLATE
+        weight: TODO_TRANSLATE
+        width: TODO_TRANSLATE
       spree/zone:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/country:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/credit_card:
-      spree/customer_return:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/line_item:
-      spree/option_type:
-      spree/option_value:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/payment:
-      spree/payment_method:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
-      spree/promotion:
-      spree/promotion_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
-      spree/return_authorization_reason:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipment:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipping_category:
-      spree/shipping_method:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/tax_rate:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
-      spree/tracker:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/tracker: TODO_TRANSLATE
       spree/user:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/variant:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/zone:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
-      inactive:
-      invalid:
-      invalid_token:
-      locked:
-      timeout:
-      unauthenticated:
-      unconfirmed:
+      inactive: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      invalid_token: TODO_TRANSLATE
+      locked: TODO_TRANSLATE
+      timeout: TODO_TRANSLATE
+      unauthenticated: TODO_TRANSLATE
+      unconfirmed: TODO_TRANSLATE
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abkürzung
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Konto
     account_updated: Konto aktualisiert!
     action: Aktion
     actions:
       cancel: Abbrechen
-      continue:
+      continue: TODO_TRANSLATE
       create: Erstellen
       destroy: Löschen
-      edit:
+      edit: TODO_TRANSLATE
       list: Auflisten
       listing: Liste
       new: Neu
-      refund:
-      save:
+      refund: TODO_TRANSLATE
+      save: TODO_TRANSLATE
       update: Aktualisieren
     activate: Activate
     active: Aktiv
     add: Hinzufügen
     add_action_of_type: Add action of type
     add_country: Land hinzufügen
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: TODO_TRANSLATE
     add_option_value: Option Wert hinzufügen
     add_product: Produkt hinzufügen
     add_product_properties: Produkteigenschaft hinzufügen
     add_rule_of_type: Add rule of type
     add_state: Kanton hinzufügen
-    add_stock:
-    add_stock_management:
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: In den Warenkorb
-    add_variant:
+    add_variant: TODO_TRANSLATE
     additional_item: Additional Item Cost
-    address1:
-    address2:
-    adjustable:
+    address: TODO_TRANSLATE
+    address1: TODO_TRANSLATE
+    address2: TODO_TRANSLATE
+    adjustable: TODO_TRANSLATE
     adjustment: Anpassung
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: Adjustment Total
     adjustments: Preis-Anpassungen
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Verwaltung
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
     all: Alles
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
     all_departments: Alle Bereiche
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: Alternative Text
     alternative_phone: Alternative Telefonnummer
     amount: Summe
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
-    analytics_trackers:
-    and:
-    approve:
-    approved_at:
-    approver:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
+    analytics_trackers: TODO_TRANSLATE
+    and: TODO_TRANSLATE
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Sind Sie sicher
     are_you_sure_delete: Sind sie sicher, dass Sie diesen Eintrag löschen möchten?
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Anmeldung fehlgeschlagen
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Verfügbar ab
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Zurück
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Zurück zum Shop
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Total ausstehend
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Rechnungsadresse
-    billing:
+    billing: TODO_TRANSLATE
     billing_address: Rechnungsadresse
-    both:
-    calculated_reimbursements:
+    both: TODO_TRANSLATE
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Rechner
     calculator_settings_warning: Wenn Sie den Rechner-Typ ändern, müssen Sie erst speichern, bevor Sie die Rechner-Einstellungen bearbeiten können
     cancel: verwerfen
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has not shipped yet.
     cannot_perform_operation: Cannot perform requested operation
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: stornieren
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kartenprüfnummer
     card_number: Kartennummer
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Kartentyp ist
     cart: Warenkorb
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategorien
     category: Kategorie
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Zur Kasse
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: TODO_TRANSLATE
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: TODO_TRANSLATE
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
     city: Stadt
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Klonen
-    close:
-    close_all_adjustments:
-    code:
-    company:
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
+    code: TODO_TRANSLATE
+    company: TODO_TRANSLATE
     complete: komplett
     configuration: Konfiguration
     configurations: Konfigurationen
+    configure_s3: TODO_TRANSLATE
     confirm: Bestätigen
     confirm_delete: Löschen bestätigen
     confirm_password: Passwort bestätigen
     continue: Weitermachen
     continue_shopping: Weiter Einkaufen
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: Einkaufspreis
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
+    countries: TODO_TRANSLATE
     country: Land
     country_based: Länderbasiert
-    country_name:
+    country_name: TODO_TRANSLATE
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon:
-    coupon_code:
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
+    coupon: TODO_TRANSLATE
+    coupon_code: TODO_TRANSLATE
+    coupon_code_already_applied: TODO_TRANSLATE
+    coupon_code_applied: TODO_TRANSLATE
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Erstellen
     create_a_new_account: Neues Konto erstellen
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
     credit: Credit
     credit_card: Kreditkarte
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credits: TODO_TRANSLATE
+    currency: TODO_TRANSLATE
+    currency_decimal_mark: TODO_TRANSLATE
+    currency_settings: TODO_TRANSLATE
+    currency_symbol_position: TODO_TRANSLATE
+    currency_thousands_separator: TODO_TRANSLATE
     current: Stand
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Kunde
     customer_details: Kundenangaben
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Kundensuche
-    cut:
-    cvv_response:
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
+    date_completed: TODO_TRANSLATE
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: Datum (von/bis)
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default: TODO_TRANSLATE
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
     delete: Löschen
-    deleted_variants_present:
-    delivery:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
+    delivery: TODO_TRANSLATE
     depth: Tiefe
     description: Beschreibung
-    destination:
+    destination: TODO_TRANSLATE
     destroy: Entfernen
-    details:
-    discount_amount:
-    dismiss_banner:
+    details: TODO_TRANSLATE
+    discount_amount: TODO_TRANSLATE
+    dismiss_banner: TODO_TRANSLATE
     display: Anzeigen
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: TODO_TRANSLATE
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Bearbeiten
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Benutzer bearbeiten
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
-    empty:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
+    email: TODO_TRANSLATE
+    empty: TODO_TRANSLATE
     empty_cart: Warenkorb leeren
     enable_mail_delivery: Mailversand einschalten
-    end:
+    end: TODO_TRANSLATE
     ending_in: Ending in
     environment: Umgebung
     error: Fehler
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
+        could_not_create_taxon: TODO_TRANSLATE
+        no_payment_methods_available: TODO_TRANSLATE
+        no_shipping_methods_available: TODO_TRANSLATE
     errors_prohibited_this_record_from_being_saved:
+      one: TODO_TRANSLATE
+      other: TODO_TRANSLATE
     event: Ereignis
     events:
       spree:
         cart:
-          add:
+          add: TODO_TRANSLATE
         checkout:
-          coupon_code_added:
+          coupon_code_added: TODO_TRANSLATE
         content:
-          visited:
+          visited: TODO_TRANSLATE
         order:
-          contents_changed:
-        page_view:
+          contents_changed: TODO_TRANSLATE
+        page_view: TODO_TRANSLATE
         user:
-          signup:
+          signup: TODO_TRANSLATE
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Gültigkeitsdauer
     extension: Erweiterung
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Dateiname
-    fill_in_customer_info:
-    filter_results:
-    finalize:
-    finalized:
-    find_a_taxon:
-    first_item:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
+    filter_results: TODO_TRANSLATE
+    finalize: TODO_TRANSLATE
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
+    first_item: TODO_TRANSLATE
     first_name: Vorname
     first_name_begins_with: Vorname beginnt mit
-    flat_percent:
-    flat_rate_per_order:
-    flexible_rate:
+    flat_percent: TODO_TRANSLATE
+    flat_rate_per_item: TODO_TRANSLATE
+    flat_rate_per_order: TODO_TRANSLATE
+    flexible_rate: TODO_TRANSLATE
     forgot_password: Passwort vergessen?
-    free_shipping:
-    free_shipping_amount:
-    front_end:
-    gateway:
-    gateway_config_unavailable:
+    free_shipping: TODO_TRANSLATE
+    free_shipping_amount: TODO_TRANSLATE
+    front_end: TODO_TRANSLATE
+    gateway: TODO_TRANSLATE
+    gateway_config_unavailable: TODO_TRANSLATE
     gateway_error: Gateway-Fehler
-    general:
+    general: TODO_TRANSLATE
     general_settings: Allgemeine Einstellungen
-    google_analytics:
-    google_analytics_id:
+    google_analytics: TODO_TRANSLATE
+    google_analytics_id: TODO_TRANSLATE
     guest_checkout: Gast-Einkauf
     guest_user_account: Ohne Registrierung bestellen
-    has_no_shipped_units:
+    has_no_shipped_units: TODO_TRANSLATE
     height: Höhe
-    hide_cents:
-    home:
+    hide_cents: TODO_TRANSLATE
+    home: TODO_TRANSLATE
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: Deutsch (Schweiz)
-      translations:
-    icon:
-    identifier:
+      translations: TODO_TRANSLATE
+    icon: TODO_TRANSLATE
+    identifier: TODO_TRANSLATE
     image: Bild
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Bilder
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password:
-    insufficient_stock:
-    insufficient_stock_lines_present:
-    intercept_email_address:
-    intercept_email_instructions:
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
+    included_in_price: TODO_TRANSLATE
+    included_price_validation: TODO_TRANSLATE
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
+    instructions_to_reset_password: TODO_TRANSLATE
+    insufficient_stock: TODO_TRANSLATE
+    insufficient_stock_lines_present: TODO_TRANSLATE
+    intercept_email_address: TODO_TRANSLATE
+    intercept_email_instructions: TODO_TRANSLATE
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: Lager
     inventory_adjustment: Lager-Anpassung
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
-    is_not_available_to_shipment_address:
-    iso_name:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
+    is_not_available_to_shipment_address: TODO_TRANSLATE
+    iso_name: TODO_TRANSLATE
     item: Artikel
     item_description: Artikelbeschreibung
     item_total: Artikel Gesamt
     item_total_rule:
       operators:
-        gt:
-        gte:
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        gt: TODO_TRANSLATE
+        gte: TODO_TRANSLATE
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
-      path:
+      path: TODO_TRANSLATE
     last_name: Nachname
     last_name_begins_with: Nachname beginnt mit
-    learn_more:
-    lifetime_stats:
-    line_item_adjustments:
+    learn_more: TODO_TRANSLATE
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Liste
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Lade
     locale_changed: Sprache geändert
-    location:
-    lock:
-    log_entries:
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
     logged_in_as: Angemeldet als
     logged_in_succesfully: Erfolgreich angemeldet
     logged_out: Sie sind nun ausgeloggt.
-    login:
+    login: TODO_TRANSLATE
     login_as_existing: Als bestehender Kunde einloggen
     login_failed: Login-Authentifizierung fehlgeschlagen.
     login_name: Benutzer
     logout: Abmelden
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: "Ähnliche Artikel"
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
+    make_refund: TODO_TRANSLATE
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Grundpreis
     match_choices:
-      all:
-      none:
-    max_items:
-    member_since:
-    memo:
+      all: TODO_TRANSLATE
+      none: TODO_TRANSLATE
+    max_items: TODO_TRANSLATE
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta-Beschreibung
     meta_keywords: Meta-Schlüsselwörter
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadaten
-    minimal_amount:
+    minimal_amount: TODO_TRANSLATE
     month: Monat
-    more:
-    move_stock_between_locations:
+    more: TODO_TRANSLATE
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: Mein Konto
     my_orders: Meine Bestellungen
     name: Name
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Name oder Lagerhaltungsnummer
     new: Neu
     new_adjustment: Neue Preis-Anpassung
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Neuer Kunde
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Neues Bild
     new_option_type: Neue Option
     new_order: Neue Bestellung
-    new_order_completed:
+    new_order_completed: TODO_TRANSLATE
     new_payment: Neue Bezahlung
     new_payment_method: New Payment Method
     new_product: Neues Produkt
     new_promotion: Neue Promotion
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Neue Eigenschaft
     new_prototype: Neuer Prototyp
-    new_refund:
-    new_refund_reason:
-    new_return_authorization:
-    new_rma_reason:
-    new_shipment_at_location:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
+    new_return_authorization: TODO_TRANSLATE
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Neue Versandkategorie
     new_shipping_method: Neue Versandmethode
     new_state: Neuer Kanton
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: Neue Steuer-Kategorie
     new_tax_rate: Neuer Steuersatz
-    new_taxon:
+    new_taxon: TODO_TRANSLATE
     new_taxonomy: Neue Taxonomie
-    new_tracker:
+    new_tracker: TODO_TRANSLATE
     new_user: Neuer Benutzer
     new_variant: Neue Variante
     new_zone: Neue Zone
     next: weiter
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Keine Produkte gefunden
-    no_resource_found:
-    no_results:
-    no_returns_found:
-    no_rules_added:
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
+    no_results: TODO_TRANSLATE
+    no_returns_found: TODO_TRANSLATE
+    no_rules_added: TODO_TRANSLATE
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: kein
-    none_selected:
-    normal_amount:
-    not:
-    not_available:
-    not_enough_stock:
-    not_found:
-    note:
+    none_selected: TODO_TRANSLATE
+    normal_amount: TODO_TRANSLATE
+    not: TODO_TRANSLATE
+    not_available: TODO_TRANSLATE
+    not_enough_stock: TODO_TRANSLATE
+    not_found: TODO_TRANSLATE
+    note: TODO_TRANSLATE
     notice_messages:
-      product_cloned:
-      product_deleted:
-      product_not_cloned:
-      product_not_deleted:
-      variant_deleted:
-      variant_not_deleted:
-    num_orders:
+      product_cloned: TODO_TRANSLATE
+      product_deleted: TODO_TRANSLATE
+      product_not_cloned: TODO_TRANSLATE
+      product_not_deleted: TODO_TRANSLATE
+      variant_deleted: TODO_TRANSLATE
+      variant_not_deleted: TODO_TRANSLATE
+    num_orders: TODO_TRANSLATE
     on_hand: Auf Lager
-    open:
-    open_all_adjustments:
-    option_type:
-    option_type_placeholder:
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
+    option_type: TODO_TRANSLATE
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Optionen
-    option_value:
+    option_value: TODO_TRANSLATE
     option_values: Optionswalues
-    optional:
+    optional: TODO_TRANSLATE
     options: Optionen
     or: oder
     or_over_price: "%{price} or over"
     order: Bestellung
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_adjustments: TODO_TRANSLATE
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Details der Bestellung
     order_email_resent: Bestellbestätigung erneut versendet
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Ihre Bestellung wurde erfolgreich bearbeitet
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: Adresse
       awaiting_return: awaiting return
@@ -837,7 +1007,7 @@ de-CH:
       cart: Warenkorb
       complete: Abgeschlossen
       confirm: Bestätigt
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: Versendet
       payment: Bezahlt
       resumed: resumed
@@ -847,248 +1017,267 @@ de-CH:
     order_total: Gesamtsumme
     order_updated: Bestellung aktualisiert
     orders: Bestellungen
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Ausverkauft
     overview: "Übersicht"
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
-      next_page:
-      previous_page:
+      first: TODO_TRANSLATE
+      next_page: TODO_TRANSLATE
+      previous: TODO_TRANSLATE
+      previous_page: TODO_TRANSLATE
       truncate: "…"
     password: Passwort
     paste: Paste
     path: Pfad
     pay: zahlen
     payment: Zahlung
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Zahlungsinformationen
     payment_method: Zahlungsmethode
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Zahlungsmethoden
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
+    payment_processing_failed: TODO_TRANSLATE
+    payment_processor_choose_banner_text: TODO_TRANSLATE
     payment_processor_choose_link: our payments page
     payment_state: Bezahlstatus
     payment_states:
       balance_due: fällig
-      checkout:
-      completed:
+      checkout: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
       credit_owed: credit owed
       failed: failed
       paid: bezahlt
       pending: ausstehend
       processing: processing
       void: void
-    payment_updated:
+    payment_updated: TODO_TRANSLATE
     payments: Zahlungen
-    pending:
-    percent:
-    percent_per_item:
-    permalink:
-    phone:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
+    percent_per_item: TODO_TRANSLATE
+    permalink: TODO_TRANSLATE
+    phone: TODO_TRANSLATE
     place_order: Bestellung ausführen
-    please_define_payment_methods:
-    populate_get_error:
-    powered_by:
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    please_define_payment_methods: TODO_TRANSLATE
+    please_enter_reasonable_quantity: TODO_TRANSLATE
+    populate_get_error: TODO_TRANSLATE
+    powered_by: TODO_TRANSLATE
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Anzeige
     previous: zurück
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Preis
-    price_range:
-    price_sack:
+    price_range: TODO_TRANSLATE
+    price_sack: TODO_TRANSLATE
     process: Abschicken
     product: Produkt
     product_details: Produkt-Details
     product_has_no_description: Produkt hat keine Beschreibung
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Produkt-Eigenschaften
     product_rule:
-      choose_products:
-      label:
-      match_all:
-      match_any:
-      match_none:
+      choose_products: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
+      match_none: TODO_TRANSLATE
       product_source:
-        group:
-        manual:
+        group: TODO_TRANSLATE
+        manual: TODO_TRANSLATE
     products: Produkte
-    promotion:
-    promotion_action:
+    promotion: TODO_TRANSLATE
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: TODO_TRANSLATE
+        any: TODO_TRANSLATE
+    promotion_label: TODO_TRANSLATE
+    promotion_rule: TODO_TRANSLATE
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       item_total:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       landing_page:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promotionen
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Eigenschaften
     property: Eigenschaft
     prototype: Prototype
     prototypes: Prototypen
-    provider:
-    provider_settings_warning:
+    provider: TODO_TRANSLATE
+    provider_settings_warning: TODO_TRANSLATE
     qty: Anzahl
-    quantity:
-    quantity_returned:
-    quantity_shipped:
-    quick_search:
-    rate:
-    reason:
-    receive:
-    receive_stock:
-    received:
-    reception_status:
-    reference:
-    refund:
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    quantity: TODO_TRANSLATE
+    quantity_returned: TODO_TRANSLATE
+    quantity_shipped: TODO_TRANSLATE
+    quick_search: TODO_TRANSLATE
+    rate: TODO_TRANSLATE
+    reason: TODO_TRANSLATE
+    receive: TODO_TRANSLATE
+    receive_stock: TODO_TRANSLATE
+    received: TODO_TRANSLATE
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
+    refund: TODO_TRANSLATE
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Als Neukunde registrieren
     registration: Registrierung
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Auf diesem Computer speichern
     remove: Entfernen
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: Berichte
+    resellable: TODO_TRANSLATE
     resend: Neu versenden
     reset_password: Mein Passwort zurücksetzen
     response_code: Rückgabewert
     resume: Fortsetzen
     resumed: Fortgesetzt
-    return:
-    return_authorization:
-    return_authorization_reasons:
-    return_authorization_updated:
-    return_authorizations:
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
-    returned:
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
-    rma_number:
-    rma_value:
+    return: TODO_TRANSLATE
+    return_authorization: TODO_TRANSLATE
+    return_authorization_reasons: TODO_TRANSLATE
+    return_authorization_updated: TODO_TRANSLATE
+    return_authorizations: TODO_TRANSLATE
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
+    return_quantity: TODO_TRANSLATE
+    returned: TODO_TRANSLATE
+    returns: TODO_TRANSLATE
+    review: TODO_TRANSLATE
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
+    rma_credit: TODO_TRANSLATE
+    rma_number: TODO_TRANSLATE
+    rma_value: TODO_TRANSLATE
+    role_id: TODO_TRANSLATE
     roles: Rollen
-    rules:
-    safe:
+    rules: TODO_TRANSLATE
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Umsatz Gesamt
-    sales_total_description:
-    sales_totals:
+    sales_total_description: TODO_TRANSLATE
+    sales_totals: TODO_TRANSLATE
     save_and_continue: Speichern und fortsetzen
-    save_my_address:
-    say_no:
-    say_yes:
-    scope:
+    save_my_address: TODO_TRANSLATE
+    say_no: TODO_TRANSLATE
+    say_yes: TODO_TRANSLATE
+    scope: TODO_TRANSLATE
     search: Suchen
-    search_results:
-    searching:
-    secure_connection_type:
-    security_settings:
+    search_results: TODO_TRANSLATE
+    searching: TODO_TRANSLATE
+    secure_connection_type: TODO_TRANSLATE
+    security_settings: TODO_TRANSLATE
     select: Auswählen
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Vom Prototypen auswählen
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Schicke eine Kopie aller E-Mails an
     send_mails_as: Schicke E-Mail als
-    server:
+    server: TODO_TRANSLATE
     server_error: Der Server hat einen Fehler gemeldet
     settings: Einstellungen
     ship: verschicken
     ship_address: Lieferadresse
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: Lieferung
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        shipment_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        track_information: TODO_TRANSLATE
+        track_link: TODO_TRANSLATE
     shipment_state: Versandstatus
     shipment_states:
       backorder: Lieferrückstand
@@ -1097,188 +1286,212 @@ de-CH:
       pending: bevorstehend
       ready: Bereit
       shipped: Versendet
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Versand
     shipped: Ausgeliefert
     shipping: Lieferung
     shipping_address: Lieferadresse
     shipping_categories: Versandkategorien
     shipping_category: Versandkategorie
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
-    shipping_instructions:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
+    shipping_instructions: TODO_TRANSLATE
     shipping_method: Versandart
     shipping_methods: Versandarten
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "%{taxonomy} einkaufen"
     shopping_cart: Warenkorb
     show: Zeigen
-    show_active:
+    show_active: TODO_TRANSLATE
     show_deleted: Gelöschte anzeigen
     show_only_complete_orders: Nur komplette Bestellungen anzeigen
     show_only_considered_risky: Nur riskante Bestellungen anzeigen
-    show_rate_in_label:
+    show_rate_in_label: TODO_TRANSLATE
     sku: Lagerhaltungsnummer
-    skus:
-    slug:
-    source:
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
+    special_instructions: TODO_TRANSLATE
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
+    spree_gateway_error_flash_for_checkout: TODO_TRANSLATE
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Von
+    start_date: TODO_TRANSLATE
     state: Kanton
     state_based: Basierend auf Kanton
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Kantone
-    states_required:
-    status:
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    states_required: TODO_TRANSLATE
+    status: TODO_TRANSLATE
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
     stop: Bis
     store: Laden
     street_address: Strasse
     street_address_2: Strasse (Feld 2)
     subtotal: Zwischensumme
     subtract: Subtrahieren
-    success:
-    successfully_created:
-    successfully_refunded:
-    successfully_removed:
-    successfully_signed_up_for_analytics:
-    successfully_updated:
-    summary:
+    success: TODO_TRANSLATE
+    successfully_created: TODO_TRANSLATE
+    successfully_refunded: TODO_TRANSLATE
+    successfully_removed: TODO_TRANSLATE
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
+    successfully_updated: TODO_TRANSLATE
+    summary: TODO_TRANSLATE
     tax: MwSt.
     tax_categories: Steuerkategorien
     tax_category: Steuerkategorie
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Steuersätze
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxonomie
     taxon_edit: Taxonomie bearbeiten
-    taxon_placeholder:
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomien
-    taxonomy:
+    taxonomy: TODO_TRANSLATE
     taxonomy_edit: Taxonomie bearbeiten
     taxonomy_tree_error: Die angeforderte Änderung wurde nicht akzeptiert, und der Baum wurde in seinen vorherigen Zustand versetzt, bitte noch einmal versuchen!
     taxonomy_tree_instruction: "* Rechtsklick auf ein Kind im Baum öffnet das Menü zum Hinzufügen, Löschen oder Sortieren."
     taxons: Klassifizierungen
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
-        greeting:
-        message:
-        subject:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
     test_mode: Test-Modus
     thank_you_for_your_order: Vielen Dank für ihre Bestellung
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields:
-    this_order_has_already_received_a_refund:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
+    there_were_problems_with_the_following_fields: TODO_TRANSLATE
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Miniaturansicht
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: Um Varianten hinzuzufügen, müssen Sie sie erst definieren.
     total: Gesamt
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Baum
     type: Typ
-    type_to_search:
-    unable_to_connect_to_gateway:
-    unable_to_create_reimbursements:
-    under_price:
-    unlock:
-    unrecognized_card_type:
-    unshippable_items:
+    type_to_search: TODO_TRANSLATE
+    unable_to_connect_to_gateway: TODO_TRANSLATE
+    unable_to_create_reimbursements: TODO_TRANSLATE
+    under_price: TODO_TRANSLATE
+    unlock: TODO_TRANSLATE
+    unrecognized_card_type: TODO_TRANSLATE
+    unshippable_items: TODO_TRANSLATE
     update: Speichern
     updating: Aktualisiere
     usage_limit: Nutzungsbeschränkung
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Rechnungsadresse verwenden
-    use_new_cc:
-    use_s3:
+    use_existing_cc: TODO_TRANSLATE
+    use_new_cc: TODO_TRANSLATE
+    use_new_cc_or_payment_method: TODO_TRANSLATE
+    use_s3: TODO_TRANSLATE
     user: Benutzer
     user_rule:
-      choose_users:
+      choose_users: TODO_TRANSLATE
     users: Benutzer
     validation:
-      cannot_be_less_than_shipped_units:
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
-      is_too_large:
-      must_be_int:
-      must_be_non_negative:
-      unpaid_amount_not_zero:
+      cannot_be_less_than_shipped_units: TODO_TRANSLATE
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
+      is_too_large: TODO_TRANSLATE
+      must_be_int: TODO_TRANSLATE
+      must_be_non_negative: TODO_TRANSLATE
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Wert
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Varianten
-    version:
-    void:
+    version: TODO_TRANSLATE
+    void: TODO_TRANSLATE
     weight: Gewicht
     what_is_a_cvv: Was ist die (CVV) Kreditkartenprüfnummer?
     what_is_this: Was ist das?
@@ -1286,8 +1499,15 @@ de-CH:
     year: Jahr
     you_have_no_orders_yet: Sie haben noch keine Bestellungen.
     your_cart_is_empty: Ihr Warenkorb ist leer
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: PLZ
-    zipcode:
+    zipcode: TODO_TRANSLATE
     zone: Zone
     zones: Zonen
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,4 +1,6 @@
+---
 de:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ de:
         state: Bundesland
         zipcode: PLZ
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,7 +26,7 @@ de:
         name: Name
         numcode: ISO-Nummer
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Typ
         month: Monat
         name: Name
@@ -72,6 +74,7 @@ de:
         zipcode: LIeferadresse Postleitzahl
       spree/payment:
         amount: Betrag
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Name
       spree/product:
@@ -95,6 +98,7 @@ de:
         starts_at: Beginnt am
         usage_limit: Begrenztes Kontingent
       spree/promotion_category:
+        code: TODO_TRANSLATE
         name: Werbungskategorie
       spree/property:
         name: Name
@@ -105,6 +109,8 @@ de:
         amount: Anzahl
       spree/role:
         name: Name
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abkürzung
         name: Name
@@ -190,15 +196,21 @@ de:
               return_items_order_id_does_not_match: Ein oder mehrere Artikel stimmen mit der zu Erstattenden Bestellung nicht überein.
         spree/return_item:
           attributes:
-            reimbursement:
-              cannot_be_associated_unless_accepted: Muss vor der Verknüpfung akzeptiert werden.
             inventory_unit:
               other_completed_return_item_exists: "%{inventory_unit_id} wurde bereits von %{return_item_id} eingenommen"
+            reimbursement:
+              cannot_be_associated_unless_accepted: Muss vor der Verknüpfung akzeptiert werden.
         spree/store:
           attributes:
             base:
               cannot_destroy_default_store: Kann den Standard-Store nicht löschen
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adresse
         other: Adressen
@@ -263,6 +275,8 @@ de:
         one: Rückgabebewilligungsgrund
         other: Rückgabebewilligungsgründe
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Rolle
         other: Rollen
       spree/shipment:
@@ -280,12 +294,12 @@ de:
       spree/state_change:
         one: Statusänderung
         other: Statusänderungen
-      spree/stock_movement:
-        one: Lagerbewegung
-        other: Lagerbewegungen
       spree/stock_location:
         one: Lagerstätte
         other: Lagerstätten
+      spree/stock_movement:
+        one: Lagerbewegung
+        other: Lagerbewegungen
       spree/stock_transfer:
         one: Umlagerung
         other: Umlagerungen
@@ -313,16 +327,19 @@ de:
       spree/zone:
         one: Gebiet
         other: Gebiete
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Ihr Konto wurde erfolgreich bestätigt. Sie sind jetzt angemeldet.
-      send_instructions: "Sie erhalten in wenigen Minuten eine E-Mail mit Hinweisen zur Bestätigung Ihres Kontos."
+      send_instructions: Sie erhalten in wenigen Minuten eine E-Mail mit Hinweisen zur Bestätigung Ihres Kontos.
     failure:
       inactive: Ihr Konto wurde noch nicht aktiviert.
       invalid: Ungültige Email Adresse oder Passwort
       invalid_token: Ungültiges Authentifikationstoken
       locked: Ihr Konto ist gesperrt.
-      timeout: "Ihre Sitzung ist abgelaufen, bitte melden sie sich wieder an um fortzufahren."
+      timeout: Ihre Sitzung ist abgelaufen, bitte melden sie sich wieder an um fortzufahren.
       unauthenticated: Zum Fortfahren müssen Sie sich registrieren oder angemeldet sein.
       unconfirmed: Sie müssen ihr Konto bestätigen bevor sie fortfahren können.
     mailer:
@@ -333,8 +350,8 @@ de:
       unlock_instructions:
         subject: Anleitung zum Entsperren
     oauth_callbacks:
-      failure: "Sie konnten nich über %{kind} autorisiert werden, weil %{reason}."
-      success: "Erfolgreich mit %{kind} Konto autorisiert."
+      failure: Sie konnten nich über %{kind} autorisiert werden, weil %{reason}.
+      success: Erfolgreich mit %{kind} Konto autorisiert.
     unlocks:
       send_instructions: Sie erhalten in wenigen Minuten eine E-Mail mit einer Anleitung zum Entsperren Ihres Kontos.
       unlocked: Ihr Konto wurde erfolgreich entsperrt. Sie sind jetzt angemeldet.
@@ -345,12 +362,13 @@ de:
         updated: Ihr Password wurde erfolgreich geändert. SIe sind jetzt angemeldet.
     user_registrations:
       destroyed: Auf Wiedersehen! Ihr Konto wurde erfolgreich gelöscht. Wir hoffen sie bald wieder begrüßen zu dürfen.
-      inactive_signed_up: "Sie haben sich erfolgreich registriert. Wir konnten sie aber nicht anmelden, denn %{reason}."
+      inactive_signed_up: Sie haben sich erfolgreich registriert. Wir konnten sie aber nicht anmelden, denn %{reason}.
       signed_up: Willkommen! Sie haben sich erfolgreich registriert.
       updated: Sie haben ihr Konto erfolgreich aktualisiert.
     user_sessions:
       signed_in: Erfolgreich angemeldet.
       signed_out: Erfolgreich abgemeldet.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: wurde bereits bestätigt
@@ -359,14 +377,25 @@ de:
       not_saved:
         one: 'Ein Fehler hat das Speichern von %{resource} verhindert:'
         other: "%{count} Fehler haben das Speichern von %{resource} verhindert:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
-    filter: Filter
-    order_line_items: Bestellposten
-    transaction_id: Transaktion
-    role_id: Rolle
-    new_role: Neue Rolle
-    address: Adresse
-    backorder: Nachlieferung
     abbreviation: Abkürzung
     accept: Akzeptieren
     acceptance_errors: Akzeptanzfehler
@@ -406,11 +435,16 @@ de:
     add_to_cart: In den Warenkorb
     add_variant: Variante hinzufügen
     additional_item: Kosten für weiteren Artikel
+    address: Adresse
     address1: Adresse
     address2: Adresse (Zusatz)
     adjustable: Anpassbar
     adjustment: Anpassung
     adjustment_amount: Betrag
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Anpassung wurde erfolgreich geschlossen!
     adjustment_successfully_opened: Anpassung wurde erfolgreich geöffnet!
     adjustment_total: Anpassungen Gesamt
@@ -420,7 +454,7 @@ de:
         configuration: Konfiguration
         option_types: Optionen
         orders: Bestellungen
-        overview: Übersicht
+        overview: "Übersicht"
         products: Produkte
         promotions: Aktion
         properties: Eigenschaften
@@ -462,12 +496,24 @@ de:
     analytics_desc_list_4: Komplett kostenlos!
     analytics_trackers: Zugriffsstatistik Tracker
     and: und
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: Zustimmen
     approved_at: Zugestimmt am
     approver: Zustimmer
     are_you_sure: Sind Sie sicher
-    are_you_sure_delete: "Sind sie sich sicher, dass Sie diesen Eintrag löschen möchten?"
+    are_you_sure_delete: Sind sie sich sicher, dass Sie diesen Eintrag löschen möchten?
     associated_adjustment_closed: Die verknüpfte Anpassung ist geschlossen und wird nicht neu berechnet. Möchten Sie die Anpassung öffnen?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Bitte authentifizieren Sie sich.
     authorized: Autorisiert
     auto_capture: Automatisch Erfassen
@@ -476,11 +522,33 @@ de:
     avs_response: Ergebnis der Adressprüfung
     back: Zurück
     back_end: Backend
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
     back_to_payment: Zurück zur Zahlung
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
     back_to_resource_list: Zurück zur Bestellliste
     back_to_rma_reason_list: Zurück zur Rücksendeliste
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Zurück zum Shop
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Zurück zur Benutzerliste
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: Nachlieferung
     backorderable: Nachbestellbar
     backorderable_default: Nachbestellbar (standard)
     backordered: Nachbestellt
@@ -494,17 +562,17 @@ de:
     both: beides
     calculated_reimbursements: Errechnete Vergütung
     calculator: Rechner
-    calculator_settings_warning: "Wenn Sie den Berechungs-Typ ändern, müssen Sie erst speichern, bevor Sie die Berechnungs-Einstellungen bearbeiten können"
+    calculator_settings_warning: Wenn Sie den Berechungs-Typ ändern, müssen Sie erst speichern, bevor Sie die Berechnungs-Einstellungen bearbeiten können
     cancel: abbrechen
     canceled_at: Abgebrochen am
     canceler: Abgebrochen von
     cannot_create_customer_returns: Kann Rücksendung nicht durchführen.
-    cannot_create_payment_without_payment_methods: "Sie können keine Zahlung für eine Bestellung anlegen, ohne vorher eine Zahlungsmethode definiert zu haben."
-    cannot_create_returns: "Sie können diese Bestellung nicht zurückgeben, da sie noch nicht versendet wurde."
+    cannot_create_payment_without_payment_methods: Sie können keine Zahlung für eine Bestellung anlegen, ohne vorher eine Zahlungsmethode definiert zu haben.
+    cannot_create_returns: Sie können diese Bestellung nicht zurückgeben, da sie noch nicht versendet wurde.
     cannot_perform_operation: Kann diese Operation nicht durchführen.
-    cannot_set_shipping_method_without_address: "Die Versandart kann erst geändert werden, wenn die Kundendaten ausgefüllt sind."
+    cannot_set_shipping_method_without_address: Die Versandart kann erst geändert werden, wenn die Kundendaten ausgefüllt sind.
     capture: erfassen
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kartenprüfnummer
     card_number: Kartennummer
     card_type: Kartentyp
@@ -534,6 +602,7 @@ de:
     complete: komplett
     configuration: Konfiguration
     configurations: Konfigurationen
+    configure_s3: TODO_TRANSLATE
     confirm: Bestätigen
     confirm_delete: Löschen bestätigen
     confirm_password: Passwort bestätigen
@@ -593,8 +662,8 @@ de:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable: "Jirafe ist zurzeit nicht erreichbar. Spree stellt automatisch eine Verbindung her, sobald es wieder verfügbar ist."
-        explanation: "Die unten stehenden Felder sind evtl. schon ausgefüllt, wenn Sie die Registrierung mit Jirafe im Admin-Dashboard gewählt haben."
+        currently_unavailable: Jirafe ist zurzeit nicht erreichbar. Spree stellt automatisch eine Verbindung her, sobald es wieder verfügbar ist.
+        explanation: Die unten stehenden Felder sind evtl. schon ausgefüllt, wenn Sie die Registrierung mit Jirafe im Admin-Dashboard gewählt haben.
         header: Jirafe Analytics Einstellungen
         site_id: Seiten ID
         token: Token
@@ -607,10 +676,14 @@ de:
       js_format: dd.mm.yy
     date_range: Datum (von/bis)
     default: Standard
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
     default_refund_amount: Bevorzugte Gutschriftshöhe
+    default_seo_title: TODO_TRANSLATE
     default_tax: Standard Steuer
     default_tax_zone: Standard Steuergebiet
     delete: Löschen
+    delete_from_taxon: TODO_TRANSLATE
     deleted_variants_present: In dieser Bestellung sind Artikel enhalten welche nicht länger verfügbar sind.
     delivery: Versand
     depth: Tiefe
@@ -619,21 +692,36 @@ de:
     destroy: Entfernen
     details: Details
     discount_amount: Skonto
-    dismiss_banner: "Nein. Danke! Ich bin nicht interessiert, bitte diese Nachricht nicht erneut anzeigen."
+    dismiss_banner: Nein. Danke! Ich bin nicht interessiert, bitte diese Nachricht nicht erneut anzeigen.
     display: Angezeigter Wert
     display_currency: Währung anzeigen
     doesnt_track_inventory: Bestandsverfolgung ist deaktiviert
     edit: Bearbeiten
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
     editing_resource: Eintrag bearbeiten
     editing_rma_reason: Rücksendungsgrund bearbeiten
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Benutzer bearbeiten
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product: "Der Warenkorb enthält Produkt/e, welche die Zuweisung des Gutschein-Codes verhindern."
-        item_total_less_than: "Für Bestellungen unter einem Gesamtwert von %{amount} kann dieser Gutschein-Code nicht verwendet werden."
-        item_total_less_than_or_equal: "Für Bestellungen von/unter einem Gesamtwert von %{amount} kann dieser Gutschein-Code nicht verwendet werden."
-        item_total_more_than: "Der Gutschein-Code ist nur für Bestellungen mit einer Gesamtsumme bis %{amount} gültig."
-        item_total_more_than_or_equal: "Der Gutschein-Code ist nur für Bestellungen mit einer Gesamtsumme von/bis %{amount} gültig."
+        has_excluded_product: Der Warenkorb enthält Produkt/e, welche die Zuweisung des Gutschein-Codes verhindern.
+        item_total_less_than: Für Bestellungen unter einem Gesamtwert von %{amount} kann dieser Gutschein-Code nicht verwendet werden.
+        item_total_less_than_or_equal: Für Bestellungen von/unter einem Gesamtwert von %{amount} kann dieser Gutschein-Code nicht verwendet werden.
+        item_total_more_than: Der Gutschein-Code ist nur für Bestellungen mit einer Gesamtsumme bis %{amount} gültig.
+        item_total_more_than_or_equal: Der Gutschein-Code ist nur für Bestellungen mit einer Gesamtsumme von/bis %{amount} gültig.
         limit_once_per_user: Dieser Gutschein-Code ist nur einmal pro Benutzer gültig.
         missing_product: Für diesen Gutschein-Code fehlen die richtigen Produkte im Warenkorb.
         missing_taxon: Für diesen Gutschein-Code müssen die Produkte der richtigen Kategorie im Warenkorb liegen.
@@ -673,16 +761,17 @@ de:
         user:
           signup: Kundenregistrierung
     exceptions:
-      count_on_hand_setter: "Kann count_on_hand nicht manuell setzten, da es automatisch durch das recalculate_count_on_hand callback gesetzt wird. Bitte `update_column(:count_on_hand, value)` verwenden."
+      count_on_hand_setter: Kann count_on_hand nicht manuell setzten, da es automatisch durch das recalculate_count_on_hand callback gesetzt wird. Bitte `update_column(:count_on_hand, value)` verwenden.
     exchange_for: Tauschen mit
     excl: Ausschl.
     existing_shipments: Bestehende Sendungen
-    expedited_exchanges_warning: "Sämtliche Änderungen werden dem Kunden ab Speicherung sofort zugesendet. Dem Kunden wird der Gesamtwert erstattet, insofern er das bestellte Produkt innerhalb %{days_window} Tagen zurück sendet."
+    expedited_exchanges_warning: Sämtliche Änderungen werden dem Kunden ab Speicherung sofort zugesendet. Dem Kunden wird der Gesamtwert erstattet, insofern er das bestellte Produkt innerhalb %{days_window} Tagen zurück sendet.
     expiration: Verfallsdatum
     extension: Erweiterung
     failed_payment_attempts: Fehlgeschlagene Zahlversuche
     filename: Dateiname
     fill_in_customer_info: Bitte geben Sie die Kundendaten ein
+    filter: Filter
     filter_results: Ergebnisse filtern
     finalize: abschließen
     finalized: abgeschlossen
@@ -691,6 +780,7 @@ de:
     first_name: Vorname
     first_name_begins_with: Vorname beginnt mit
     flat_percent: Prozentual
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Fester Preis (pro Bestellung)
     flexible_rate: Flexible Rate
     forgot_password: Passwort vergessen?
@@ -719,26 +809,30 @@ de:
       only_incomplete: Nur unvollständige
       select_locale: Wähle Locale
       show_only: Zeige nur
+      store_translations: TODO_TRANSLATE
       supported_locales: Unterstützte Locales
       this_file_language: Deutsch (DE)
       translations: "Übersetzungen"
     icon: Symbol
     identifier: id
     image: Bild
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Bilder
-    implement_eligible_for_return: "Für den EligibilityValidator muss #eligible_for_return? implementiert sein."
-    implement_requires_manual_intervention: "Für den EligibilityValidator muss #requires_manual_intervention? implementiert sein."
+    implement_eligible_for_return: 'Für den EligibilityValidator muss #eligible_for_return? implementiert sein.'
+    implement_requires_manual_intervention: 'Für den EligibilityValidator muss #requires_manual_intervention? implementiert sein.'
     inactive: Inaktiv
     incl: inkl.
     included_in_price: Im Preis enthalten
-    included_price_validation: "Kann nicht gewählt werden, solange kein Steuergebiet gesetzt ist."
+    included_price_validation: Kann nicht gewählt werden, solange kein Steuergebiet gesetzt ist.
     incomplete: Nicht vollständig
     info_number_of_skus_not_shown:
-      one: "und ein weiteres"
-      other: "und %{count} weitere"
-    info_product_has_multiple_skus: "Dieses Produkt hat %{count} Varianten:"
+      one: und ein weiteres
+      other: und %{count} weitere
+    info_product_has_multiple_skus: 'Dieses Produkt hat %{count} Varianten:'
     instructions_to_reset_password: 'Füllen Sie das untenstehende Formular aus und folgen Sie den Anweisungen um Ihr neues Passwort per E-Mail zu erhalten:'
-    insufficient_stock: "Nicht genügend auf Lager. Nur noch %{on_hand} verbleibend."
+    insufficient_stock: Nicht genügend auf Lager. Nur noch %{on_hand} verbleibend.
     insufficient_stock_lines_present: In dieser Bestellung haben div. Artikelpositionen eine nichtvalide Stückzahl.
     intercept_email_address: Email-Adresse deaktivieren
     intercept_email_instructions: Email-Empfänger überschreiben und mit dieser Adresse ersetzen.
@@ -776,6 +870,12 @@ de:
     lifetime_stats: 'Statistiken: Lebenszyklus'
     line_item_adjustments: Anpassungen Bestellposten
     list: Liste
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Laden
     locale_changed: Sprache geändert
     location: Standort
@@ -791,8 +891,11 @@ de:
     logout: Abmelden
     logs: Logs
     look_for_similar_items: "Ähnliche Artikel"
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Gutschrift erstellen
-    make_sure_the_above_reimbursement_amount_is_correct: "Stellen Sie sicher, dass die obrige Summe der Vergütung korrekt ist!"
+    make_sure_the_above_reimbursement_amount_is_correct: Stellen Sie sicher, dass die obrige Summe der Vergütung korrekt ist!
     manage_promotion_categories: Werbungskategorien editieren.
     manage_variants: Varianten editieren
     manual_intervention_required: Manuelles eingreifen erforderlich
@@ -836,6 +939,7 @@ de:
     new_refund_reason: Rückerstattungsgrund begründen
     new_return_authorization: Neue Rückgabebewilligung
     new_rma_reason: Neue Rücksendungsbegründung
+    new_role: Neue Rolle
     new_shipment_at_location: Neue Lieferung an Adresse
     new_shipping_category: Neue Versandkategorie
     new_shipping_method: Neue Versandart
@@ -853,15 +957,21 @@ de:
     new_zone: Neues Gebiet
     next: weiter
     no_actions_added: Keine Aktionen hinzugefügt
+    no_orders_found: TODO_TRANSLATE
     no_payment_found: Keine Zahlung gefunden
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: Keine ausstehenden Zahlungen
     no_products_found: Keine Produkte gefunden
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: Keine Einträge gefunden
     no_results: Keine Ergebnisse
     no_returns_found: Keine Erstattung gefunden
     no_rules_added: Keine Regeln verfügbar
     no_shipping_method_selected: Keine Lieferungsart gewählt
+    no_shipping_methods_found: TODO_TRANSLATE
     no_state_changes: Keine Statusänderung
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Keine Informationen zur Sendungsverfolgung angegeben.
     none: kein
     none_selected: nicht gewählt
@@ -899,11 +1009,13 @@ de:
     order_details: Details der Bestellung
     order_email_resent: Bestellbestätigung erneut versendet
     order_information: Bestellinformationen
+    order_line_items: Bestellposten
     order_mailer:
       cancel_email:
-        dear_customer: "Sehr geehrte Kundin, geehrter Kunde,\n"
+        dear_customer: |
+          Sehr geehrte Kundin, geehrter Kunde,
         instructions: Ihre Bestellung wurde storniert. Bitte bewahren Sie diese Stornierung für Ihre Unterlagen auf.
-        order_summary_canceled: "Bestellzusammenfassung [STORNO]"
+        order_summary_canceled: Bestellzusammenfassung [STORNO]
         subject: Bestellung storniert
         subtotal: Zwischensumme
         total: Gesamtsumme
@@ -917,6 +1029,10 @@ de:
         total: Gesamtsumme
     order_not_found: Wir konnten Ihre Bestellung nicht finden. Bitte versuchen Sie es später noch einmal.
     order_number: Bestellnummer
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Ihre Bestellung wurde erfolgreich bearbeitet
     order_resumed: Bestellung fortgeführt
     order_state:
@@ -932,16 +1048,18 @@ de:
       resumed: wieder aufgenommen
       returned: zurück erstattet
     order_summary: Bestellübersicht
-    order_sure_want_to: "Sind Sie sicher, dass Sie diese Bestellung %{event} möchten?"
+    order_sure_want_to: Sind Sie sicher, dass Sie diese Bestellung %{event} möchten?
     order_total: Gesamtsumme
     order_updated: Bestellung aktualisiert
     orders: Bestellungen
     other_items_in_other: Andere Bestellpositionen
     out_of_stock: Ausverkauft
-    overview: Überblick
+    overview: "Überblick"
     package_from: Paket von
     pagination:
+      first: TODO_TRANSLATE
       next_page: Seite vor »
+      previous: TODO_TRANSLATE
       previous_page: "« Seite zurück"
       truncate: "…"
     password: Passwort
@@ -955,8 +1073,8 @@ de:
     payment_method: Zahlungsmethode
     payment_method_not_supported: Zahlungsmethode wird nicht unterstützt
     payment_methods: Zahlungsmethoden
-    payment_processing_failed: "Die Bezahlung konnte nicht abgeschlossen werden, bitte überprüfen Sie Ihre Angaben."
-    payment_processor_choose_banner_text: "Wenn Sie hilfe bei der Auswahl des Zahlungsabwicklers haben, bitte besuchen Sie"
+    payment_processing_failed: Die Bezahlung konnte nicht abgeschlossen werden, bitte überprüfen Sie Ihre Angaben.
+    payment_processor_choose_banner_text: Wenn Sie hilfe bei der Auswahl des Zahlungsabwicklers haben, bitte besuchen Sie
     payment_processor_choose_link: unsere Zahlungsabwickler-Seite
     payment_state: Zahlungsstatus
     payment_states:
@@ -978,6 +1096,7 @@ de:
     phone: Telefon
     place_order: Bestellung ausführen
     please_define_payment_methods: Bitte definieren Sie zuerst mindestens eine Zahlungsmethode.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Da ist etwas schief gelaufen. Bitte versuchen sie den Artikel erneut in den Warenkob zu tun.
     powered_by: Unterstützt von
     pre_tax_amount: Vorsteuer Zwischensumme
@@ -1021,11 +1140,16 @@ de:
       free_shipping:
         description: Die Lieferungen dieser Bestellung von Versandkosten befreien
         name: Versandkostenfrei
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Aktionen
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Alle Regeln müssen greifen
         any: Eine dieser Regeln muss greifen
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Werbeaktions-Regel
     promotion_rule_types:
       first_order:
@@ -1064,7 +1188,7 @@ de:
     prototype: Prototype
     prototypes: Prototypen
     provider: Anbieter
-    provider_settings_warning: "Nach einer Änderung des Anbietertyps muss erst gespeichert werden."
+    provider_settings_warning: Nach einer Änderung des Anbietertyps muss erst gespeichert werden.
     qty: Anzahl
     quantity: Anzahl
     quantity_returned: Zurückgegebene Menge
@@ -1077,6 +1201,7 @@ de:
     received: erhalten
     reception_status: Empfangsstatus
     reference: Referenz
+    reference_contains: TODO_TRANSLATE
     refund: Rückerstattung beantragen
     refund_amount_must_be_greater_than_zero: Rückerstattung muss größer 0 sein
     refund_reasons: Rückerstattungsbegründungen
@@ -1090,8 +1215,8 @@ de:
     reimbursement_mailer:
       reimbursement_email:
         days_to_send: Tage verbleibend
-        dear_customer: "Sehr geehrte/r Kunde/in"
-        exchange_summary: Übersicht Umtausch
+        dear_customer: Sehr geehrte/r Kunde/in
+        exchange_summary: "Übersicht Umtausch"
         for: für
         instructions: Anweisungen
         refund_summary: Kurzfassung Gutschrift
@@ -1110,6 +1235,7 @@ de:
     rename: Rename
     report: Bericht
     reports: Berichte
+    resellable: TODO_TRANSLATE
     resend: Neu senden
     reset_password: Mein Passwort zurücksetzen
     response_code: Rückgabewert
@@ -1121,7 +1247,8 @@ de:
     return_authorization_updated: Rückgabebewilligung aktualisiert
     return_authorizations: Rückgabebewilligungen
     return_item_inventory_unit_ineligible: Artikelposition des Warenkorbs von der Rückgabe ausgeschlossen
-    return_item_inventory_unit_reimbursed:  Artikelposition des Warenkorbs durch Rücksendung vergütet
+    return_item_inventory_unit_reimbursed: Artikelposition des Warenkorbs durch Rücksendung vergütet
+    return_item_order_not_completed: TODO_TRANSLATE
     return_item_rma_ineligible: Rückgabe des Artikels ausgeschlossen
     return_item_time_period_ineligible: Rückgabe des Artikels zeitlich ausgeschlossen
     return_items: Rücksendeartikel
@@ -1130,15 +1257,21 @@ de:
     return_quantity: Rückgabemenge
     returned: Zurückgegeben
     returns: Rücksendungen
-    review: Überprüfung
+    review: "Überprüfung"
     risk: Risiko
     risk_analysis: Risikoanalyse
     risky: Riskant
     rma_credit: Rücksendungskredit
     rma_number: Rücksendungsnummer
     rma_value: Rücksendewert
+    role_id: Rolle
     roles: Rollen
     rules: Regeln
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
     safe: Sicher
     sales_total: Gesamtumsatz
     sales_total_description: Gesamtsumme aller Bestellungen
@@ -1149,7 +1282,7 @@ de:
     say_yes: true
     scope: Bereich
     search: Suchen
-    search_results: "Suchergebnisse für '%{keywords}'"
+    search_results: Suchergebnisse für '%{keywords}'
     searching: Suche
     secure_connection_type: Sicherer Verbindungstyp
     security_settings: Sicherheitseinstellungen
@@ -1158,6 +1291,7 @@ de:
     select_a_stock_location: Lager wählen
     select_from_prototype: Von einem Prototypen
     select_stock: Lager wählen
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Schicke eine Kopie aller E-Mails an
     send_mails_as: Schicke E-Mail als
     server: Server
@@ -1169,9 +1303,11 @@ de:
     shipment: Sendung
     shipment_adjustments: Sendung anpassen
     shipment_details: Details der Sendung
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer: "Sehr geehrte/r Kunde/in,\n"
+        dear_customer: |
+          Sehr geehrte/r Kunde/in,
         instructions: Ihre Bestellung wurde versandt.
         shipment_summary: Versandzusammenfassung
         subject: Versand-Benachrichtigung
@@ -1201,8 +1337,12 @@ de:
     shipping_method: Versandart
     shipping_methods: Versandarten
     shipping_price_sack: Preis füllen
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     shipping_total: Lieferkosten gesamt
-    shop_by_taxonomy: "Nach %{taxonomy} filtern"
+    shop_by_taxonomy: Nach %{taxonomy} filtern
     shopping_cart: Warenkorb
     show: Anzeigen
     show_active: Aktive anzeigen
@@ -1213,13 +1353,25 @@ de:
     sku: Artikelnummer
     skus: Artikelnummern
     slug: Permalink
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Quelle
     special_instructions: Spezielle Anweisungen
     split: Aufteilen
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Es gab Probleme mit Ihren Zahlungsinformationen. Bitte überprüfen Sie Ihre Angaben und probieren Sie es erneut.
     ssl:
       change_protocol: Protokoll wechseln
     start: Von
+    start_date: TODO_TRANSLATE
     state: Bundesland
     state_based: Basierend auf Bundesland
     state_machine_states:
@@ -1261,11 +1413,11 @@ de:
     stock_location: Lagerstandort
     stock_location_info: Lagerstandort Info
     stock_locations: Lagerstandorte
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Lagerverwaltung
     stock_management_requires_a_stock_location: Bitte erstellen Sie einen Lagerstandort um das Lager zu verwalten.
     stock_movements: Lagerbewegungen
-    stock_movements_for_stock_location: "Lagerbewegungen für %{stock_location_name}"
+    stock_movements_for_stock_location: Lagerbewegungen für %{stock_location_name}
     stock_successfully_transferred: Lager wurde erfolgreich zwischen den Standorten transferiert
     stock_transfer: Lager Transfer
     stock_transfers: Lager Transfers
@@ -1281,7 +1433,7 @@ de:
     successfully_removed: "%{resource} wurde erfolgreich gelöscht."
     successfully_signed_up_for_analytics: Erfolgreich für Spree Analytics angemeldet
     successfully_updated: "%{resource} wurde erfolgreich aktualisiert."
-    summary: Übersicht
+    summary: "Übersicht"
     tax: Steuer
     tax_categories: Steuerkategorien
     tax_category: Steuerkategorie
@@ -1289,6 +1441,8 @@ de:
     tax_included: Inkl. Steuern
     tax_rate_amount_explanation: Steuern werden dezimal angegeben um Berechnungen zu erleichtern. (z.B. für 5% Steuern 0.05 eingeben)
     tax_rates: Steuersätze
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Produktklasse
     taxon_edit: Produktklasse bearbeiten
     taxon_placeholder: Produktklasse hinzufügen
@@ -1300,14 +1454,17 @@ de:
     taxonomies: Produktklassifizierungen
     taxonomy: Produktklassifizierung
     taxonomy_edit: Produktklassifizierung bearbeiten
-    taxonomy_tree_error: "Die angeforderte Änderung wurde nicht akzeptiert, und der Baum wurde in seinen vorherigen Zustand versetzt, bitte noch einmal versuchen!"
+    taxonomy_tree_error: Die angeforderte Änderung wurde nicht akzeptiert, und der Baum wurde in seinen vorherigen Zustand versetzt, bitte noch einmal versuchen!
     taxonomy_tree_instruction: "* Rechtsklick auf ein Kind im Baum öffnet das Menü zum Hinzufügen, Löschen oder Sortieren."
     taxons: Produktklassen
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Glückwunsch!
-        message: "Wenn Sie diese Email empfangen, sind Ihre E-Mail-Einstellungen korrekt"
+        message: Wenn Sie diese Email empfangen, sind Ihre E-Mail-Einstellungen korrekt
         subject: Spree Test E-Mail
     test_mode: Testmodus
     thank_you_for_your_order: Vielen Dank für Ihre Bestellung
@@ -1319,7 +1476,7 @@ de:
     tiered_percent: Prozentuale Staffel
     tiers: Staffelung
     time: Zeit
-    to_add_variants_you_must_first_define: "Um Varianten hinzuzufügen, müssen Sie sie erst definieren."
+    to_add_variants_you_must_first_define: Um Varianten hinzuzufügen, müssen Sie sie erst definieren.
     total: Gesamt
     total_per_item: Summe pro Artikelposition
     total_pre_tax_refund: Komplett erstattet (Vorsteuer)
@@ -1330,7 +1487,7 @@ de:
     tracking_number: Tracking Nummer
     tracking_url: Tracking URL
     tracking_url_placeholder: z.B. http://schnellepost.net/paket?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Transferformular
     transfer_stock: Transferlager
     transfer_to_location: Transferieren zu
@@ -1339,7 +1496,7 @@ de:
     type_to_search: Typ suchen
     unable_to_connect_to_gateway: Konnte nicht zur Schnitstelle verbinden.
     unable_to_create_reimbursements: Konnte Vergütung nicht erstellen.
-    under_price: "Unter %{price}"
+    under_price: Unter %{price}
     unlock: Entsperren
     unrecognized_card_type: Unbekannter Kartentyp
     unshippable_items: Nicht lieferbare Artikel
@@ -1348,7 +1505,9 @@ de:
     usage_limit: Nutzungsbeschränkung
     use_app_default: App-Standard verwenden
     use_billing_address: Rechnungsadresse verwenden
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Eine neue Karte verwenden
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Benutze Amazon S3 für Bilder
     user: Benutzer
     user_rule:
@@ -1356,12 +1515,13 @@ de:
     users: Benutzer
     validation:
       cannot_be_less_than_shipped_units: kann nicht weniger als die gelieferten Einheiten sein.
-      cannot_destroy_line_item_as_inventory_units_have_shipped: "Kann Artikelposition nicht löschen, da bereits geliefert wurde."
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: Kann Artikelposition nicht löschen, da bereits geliefert wurde.
       exceeds_available_stock: "übersteigt die verfügbaren Vorräte. Bitte sicherstellen, dass die Einzelposten eine gültige Menge haben."
       is_too_large: ist zu hoch. Der Lagerbestand kann die angefragte Menge nicht abdecken.
       must_be_int: muss eine Ganzzahl sein
       must_be_non_negative: darf keinen negativen Wert haben
-      unpaid_amount_not_zero: "Nicht vollständig bezahlt. Aussenstehend: %{amount}"
+      unpaid_amount_not_zero: 'Nicht vollständig bezahlt. Aussenstehend: %{amount}'
     value: Wert
     variant: Variante
     variant_placeholder: Variante wählen
@@ -1375,8 +1535,15 @@ de:
     year: Jahr
     you_have_no_orders_yet: Sie haben noch keine Bestellungen.
     your_cart_is_empty: Ihr Warenkorb ist leer
-    your_order_is_empty_add_product: "Ihre Bestellung ist leer, bitte wählen Sie ein Produkt und fügen es hinzu."
+    your_order_is_empty_add_product: Ihre Bestellung ist leer, bitte wählen Sie ein Produkt und fügen es hinzu.
     zip: PLZ
     zipcode: Postleitzahl
     zone: Gebiet
     zones: Gebiete
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/en-AU.yml
+++ b/config/locales/en-AU.yml
@@ -1,4 +1,6 @@
+---
 en-AU:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ en-AU:
         state: State
         zipcode: Postcode
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ en-AU:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Type
         month: Month
-        name:
+        name: TODO_TRANSLATE
         number: Number
         verification_value: Verification Value
         year: Year
@@ -42,8 +44,8 @@ en-AU:
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At
-        considered_risky:
-        coupon_code:
+        considered_risky: TODO_TRANSLATE
+        coupon_code: TODO_TRANSLATE
         created_at: Order Date
         email: Customer E-Mail
         ip_address: IP Address
@@ -71,12 +73,13 @@ en-AU:
         state: Shipping address state
         zipcode: Shipping address postcode
       spree/payment:
-        amount:
+        amount: TODO_TRANSLATE
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Name
       spree/product:
         available_on: Available On
-        cost_currency:
+        cost_currency: TODO_TRANSLATE
         cost_price: Cost Price
         description: Description
         master_price: Master Price
@@ -95,7 +98,8 @@ en-AU:
         starts_at: Starts At
         usage_limit: Usage Limit
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Name
         presentation: Presentation
@@ -105,24 +109,26 @@ en-AU:
         amount: Amount
       spree/role:
         name: Name
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abbreviation
         name: Name
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Description
         name: Name
@@ -141,7 +147,7 @@ en-AU:
         password: Password
         password_confirmation: Password Confirmation
       spree/variant:
-        cost_currency:
+        cost_currency: TODO_TRANSLATE
         cost_price: Cost Price
         depth: Depth
         height: Height
@@ -157,48 +163,54 @@ en-AU:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Address
         other: Addresses
@@ -208,41 +220,43 @@ en-AU:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
       spree/line_item:
         one: Line Item
         other: Line Items
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Order
         other: Orders
       spree/payment:
         one: Payment
         other: Payments
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Product
         other: Products
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Property
         other: Properties
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Return Authorization
         other: Return Authorizations
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Roles
         other: Roles
       spree/shipment:
@@ -251,14 +265,14 @@ en-AU:
       spree/shipping_category:
         one: Shipping Category
         other: Shipping Categories
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: State
         other: States
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Tax Category
         other: Tax Categories
@@ -271,7 +285,7 @@ en-AU:
       spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: User
         other: Users
@@ -281,331 +295,414 @@ en-AU:
       spree/zone:
         one: Zone
         other: Zones
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
-      inactive:
-      invalid:
-      invalid_token:
-      locked:
-      timeout:
-      unauthenticated:
-      unconfirmed:
+      inactive: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      invalid_token: TODO_TRANSLATE
+      locked: TODO_TRANSLATE
+      timeout: TODO_TRANSLATE
+      unauthenticated: TODO_TRANSLATE
+      unconfirmed: TODO_TRANSLATE
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abbreviation
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Account
     account_updated: Account updated!
     action: Action
     actions:
       cancel: Cancel
-      continue:
+      continue: TODO_TRANSLATE
       create: Create
       destroy: Destroy
-      edit:
+      edit: TODO_TRANSLATE
       list: List
       listing: Listing
       new: New
-      refund:
-      save:
+      refund: TODO_TRANSLATE
+      save: TODO_TRANSLATE
       update: Update
     activate: Activate
     active: Active
     add: Add
     add_action_of_type: Add action of type
     add_country: Add Country
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: TODO_TRANSLATE
     add_option_value: Add Option Value
     add_product: Add Product
     add_product_properties: Add Product Properties
     add_rule_of_type: Add rule of type
     add_state: Add State
-    add_stock:
-    add_stock_management:
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: Add To Basket
-    add_variant:
+    add_variant: TODO_TRANSLATE
     additional_item: Additional Item Cost
-    address1:
-    address2:
-    adjustable:
+    address: TODO_TRANSLATE
+    address1: TODO_TRANSLATE
+    address2: TODO_TRANSLATE
+    adjustable: TODO_TRANSLATE
     adjustment: Adjustment
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: Adjustment Total
     adjustments: Adjustments
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administration
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
     all: All
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
     all_departments: All departments
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: Alternative Text
     alternative_phone: Alternative Phone
     amount: Amount
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
     analytics_trackers: Analytics Trackers
     and: and
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Are you sure?
     are_you_sure_delete: Are you sure you want to delete this record?
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Authorisation Failure
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Available On
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Back
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Go Back To Store
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has not shipped yet.
     cannot_perform_operation: Cannot perform requested operation
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: capture
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Card Code
     card_number: Card Number
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Card type is
     cart: Basket
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categories
     category: Category
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Checkout
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: TODO_TRANSLATE
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: TODO_TRANSLATE
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
     city: Suburb / City
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clone
-    close:
-    close_all_adjustments:
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
     code: Code
-    company:
+    company: TODO_TRANSLATE
     complete: complete
     configuration: Configuration
     configurations: Configurations
+    configure_s3: TODO_TRANSLATE
     confirm: Confirm
     confirm_delete: Confirm Deletion
     confirm_password: Password Confirmation
     continue: Continue
     continue_shopping: Continue shopping
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: Cost Price
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
+    countries: TODO_TRANSLATE
     country: Country
     country_based: Country Based
-    country_name:
+    country_name: TODO_TRANSLATE
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Coupon
     coupon_code: Coupon code
-    coupon_code_already_applied:
+    coupon_code_already_applied: TODO_TRANSLATE
     coupon_code_applied: The coupon code was successfully applied to your order.
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Create
     create_a_new_account: Create a new account
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
+    credits: TODO_TRANSLATE
     currency: Currency
-    currency_decimal_mark:
+    currency_decimal_mark: TODO_TRANSLATE
     currency_settings: Currency Settings
     currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator:
+    currency_thousands_separator: TODO_TRANSLATE
     current: Current
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Customer Search
     cut: Cut
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: Date Range
     default: Default
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Delivery
     depth: Depth
     description: Description
-    destination:
+    destination: TODO_TRANSLATE
     destroy: Destroy
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Edit
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editing User
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Empty
     empty_cart: Empty Basket
     enable_mail_delivery: Enable Mail Delivery
-    end:
+    end: TODO_TRANSLATE
     ending_in: Ending in
     environment: Environment
     error: error
@@ -632,29 +729,31 @@ en-AU:
         user:
           signup: User signup
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Expiration
     extension: Extension
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Filename
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
+    filter_results: TODO_TRANSLATE
     finalize: Finalise
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: First Item Cost
     first_name: First Name
     first_name_begins_with: First Name Begins With
     flat_percent: Flat Percent
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Flat Rate (per order)
     flexible_rate: Flexible Rate
     forgot_password: Forgot Password
     free_shipping: Free Shipping
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -667,50 +766,54 @@ en-AU:
     guest_user_account: Checkout as a Guest
     has_no_shipped_units: has no shipped units
     height: Height
-    hide_cents:
+    hide_cents: TODO_TRANSLATE
     home: Home
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: English (Australia)
-      translations:
+      translations: TODO_TRANSLATE
     icon: Icon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Image
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Fill out the form below and instructions to reset your password will be emailed to you:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: is not available to shipment address
-    iso_name:
+    iso_name: TODO_TRANSLATE
     item: Item
     item_description: Item Description
     item_total: Item Total
@@ -718,26 +821,32 @@ en-AU:
       operators:
         gt: greater than
         gte: greater than or equal to
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
       path: Path
     last_name: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: List
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Loading
     locale_changed: Locale Changed
-    location:
-    lock:
-    log_entries:
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
     logged_in_as: Logged in as
     logged_in_succesfully: Logged in successfully
     logged_out: You have been logged out.
@@ -746,38 +855,41 @@ en-AU:
     login_failed: Login authentication failed.
     login_name: Login
     logout: Logout
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Look for similar items
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Make refund
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Master Price
     match_choices:
       all: All
       none: None
     max_items: Max Items
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Minimal Amount
     month: Month
     more: More
-    move_stock_between_locations:
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: My Account
     my_orders: My Orders
     name: Name
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Name or SKU
     new: New
     new_adjustment: New Adjustment
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: New Customer
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: New Image
     new_option_type: New Option Type
     new_order: New Order
@@ -786,20 +898,21 @@ en-AU:
     new_payment_method: New Payment Method
     new_product: New Product
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: New Property
     new_prototype: New Prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: New Return Authorisation
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: New Shipping Category
     new_shipping_method: New Shipping Method
     new_state: New State
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: New Tax Category
     new_tax_rate: New Tax Rate
     new_taxon: New Taxon
@@ -809,25 +922,31 @@ en-AU:
     new_variant: New Variant
     new_zone: New Zone
     next: Next
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: No products found
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: No results
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: None
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normal Amount
     not: not
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
@@ -835,47 +954,52 @@ en-AU:
       product_not_deleted: Product could not be deleted
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: On Hand
-    open:
-    open_all_adjustments:
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Option Types
     option_value: Option Value
     option_values: Option Values
-    optional:
+    optional: TODO_TRANSLATE
     options: Options
     or: or
     or_over_price: "%{price} or over"
     order: Order
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Order Details
     order_email_resent: Order Email Resent
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Dear Customer,\n
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: Cancellation of Order
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: Order Confirmation
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Thank you for your business.
-        total:
-    order_not_found:
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
     order_number: Order %{number}
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Your order has been processed successfully
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: address
       awaiting_return: awaiting return
@@ -883,7 +1007,7 @@ en-AU:
       cart: cart
       complete: complete
       confirm: confirm
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: delivery
       payment: payment
       resumed: resumed
@@ -893,12 +1017,14 @@ en-AU:
     order_total: Order Total
     order_updated: Order Updated
     orders: Orders
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Out of Stock
     overview: Overview
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
+      first: TODO_TRANSLATE
       next_page: next page »
+      previous: TODO_TRANSLATE
       previous_page: "« previous page"
       truncate: "…"
     password: Password
@@ -906,11 +1032,11 @@ en-AU:
     path: Path
     pay: pay
     payment: Payment
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Payment Information
     payment_method: Payment Method
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -928,22 +1054,23 @@ en-AU:
       void: void
     payment_updated: Payment Updated
     payments: Payments
-    pending:
-    percent:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
     percent_per_item: Percent Per Item
     permalink: Permalink
     phone: Phone
     place_order: Place Order
     please_define_payment_methods: Please define some payment methods first.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentation
     previous: Previous
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Price
     price_range: Price Range
     price_sack: Price Sack
@@ -951,14 +1078,14 @@ en-AU:
     product: Product
     product_details: Product Details
     product_has_no_description: Product has not description
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Product Properties
     product_rule:
       choose_products: Choose products
-      label:
+      label: TODO_TRANSLATE
       match_all: all
       match_any: at least one
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: From product group
         manual: Manually choose
@@ -970,19 +1097,24 @@ en-AU:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Actions
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Match any of these rules
         any: Match all of these rules
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
@@ -995,27 +1127,27 @@ en-AU:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Order includes specified product(s)
         name: Product(s)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Available only to the specified users
         name: User
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Properties
     property: Property
     prototype: Prototype
@@ -1023,50 +1155,52 @@ en-AU:
     provider: Provider
     provider_settings_warning: If you are changing the provider type, you must save first before you can edit the provider settings
     qty: Qty
-    quantity:
+    quantity: TODO_TRANSLATE
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Rate
     reason: Reason
     receive: receive
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: Received
-    reception_status:
-    reference:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
     refund: Refund
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Register as a New User
     registration: Registration
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Remember me
     remove: Remove
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: Reports
+    resellable: TODO_TRANSLATE
     resend: Resend
     reset_password: Reset my password
     response_code: Response Code
@@ -1074,34 +1208,41 @@ en-AU:
     resumed: Resumed
     return: return
     return_authorization: Return Authorisation
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Return authorisation updated
     return_authorizations: Return Authorisations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Return Quantity
     returned: Returned
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
+    role_id: TODO_TRANSLATE
     roles: Roles
     rules: Rules
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Sales Total
     sales_total_description: Sales Total For All Orders
-    sales_totals:
+    sales_totals: TODO_TRANSLATE
     save_and_continue: Save and Continue
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: false
     say_yes: true
     scope: Scope
@@ -1111,10 +1252,11 @@ en-AU:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Select
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Select From Prototype
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
     server: Server
@@ -1122,10 +1264,11 @@ en-AU:
     settings: Settings
     ship: ship
     ship_address: Ship Address
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: Shipment
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1134,126 +1277,144 @@ en-AU:
         subject: Shipment Notification
         thanks: Thank you for your business.
         track_information: 'Tracking Information: %{tracking}'
-        track_link:
+        track_link: TODO_TRANSLATE
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: partial
       pending: pending
       ready: ready
       shipped: shipped
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Shipments
     shipped: Shipped
     shipping: Delivery
     shipping_address: Delivery Address
     shipping_categories: Shipping Categories
     shipping_category: Shipping Category
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: Delivery Instructions
     shipping_method: Delivery Method
     shipping_methods: Delivery Methods
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Basket
     show: Show
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
     sku: SKU
-    skus:
-    slug:
-    source:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
     special_instructions: Special Instructions
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Start
+    start_date: TODO_TRANSLATE
     state: State
     state_based: State Based
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: States
-    states_required:
+    states_required: TODO_TRANSLATE
     status: Status
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
     stop: Stop
     store: Store
     street_address: Street Address
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal
     subtract: Subtract
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} has been successfully removed!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Tax
     tax_categories: Tax Categories
     tax_category: Tax Category
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Tax Rates
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxon
     taxon_edit: Edit Taxon
-    taxon_placeholder:
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy
@@ -1262,50 +1423,55 @@ en-AU:
     taxons: Taxons
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Congratulations!
         message: If you have received this email, then your email settings are correct.
         subject: Testmail
     test_mode: Test Mode
     thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Tree
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
-    unlock:
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: Unrecognised card type
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: Update
     updating: Updating
     usage_limit: Usage Limit
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Use Billing Address
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Use a new card
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Use Amazon S3 For Images
     user: User
     user_rule:
@@ -1313,15 +1479,16 @@ en-AU:
     users: Users
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Value
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Variants
     version: Version
     void: Void
@@ -1332,8 +1499,15 @@ en-AU:
     year: Year
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Your basket is empty
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: Postcode
     zipcode: Postcode
     zone: Zone
     zones: Zones
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1,4 +1,6 @@
+---
 en-GB:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ en-GB:
         state: County
         zipcode: Post Code
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ en-GB:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Type
         month: Month
-        name:
+        name: TODO_TRANSLATE
         number: Number
         verification_value: Verification Value
         year: Year
@@ -42,7 +44,7 @@ en-GB:
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: Coupon Code
         created_at: Order Date
         email: Customer E-Mail
@@ -72,6 +74,7 @@ en-GB:
         zipcode: Shipping address post code
       spree/payment:
         amount: Amount
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Name
       spree/product:
@@ -95,7 +98,8 @@ en-GB:
         starts_at: Starts At
         usage_limit: Usage Limit
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Name
         presentation: Presentation
@@ -105,24 +109,26 @@ en-GB:
         amount: Amount
       spree/role:
         name: Name
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abbreviation
         name: Name
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Description
         name: Name
@@ -157,48 +163,54 @@ en-GB:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: Card has expired
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Address
         other: Addresses
@@ -209,6 +221,10 @@ en-GB:
         one: Credit Card
         other: Credit Cards
       spree/customer_return:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
@@ -216,7 +232,15 @@ en-GB:
         one: Line Item
         other: Line Items
       spree/option_type:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/option_value:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/order:
         one: Order
         other: Orders
@@ -224,11 +248,23 @@ en-GB:
         one: Payment
         other: Payments
       spree/payment_method:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/product:
         one: Product
         other: Products
       spree/promotion:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/promotion_category:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/property:
         one: Property
         other: Properties
@@ -236,13 +272,31 @@ en-GB:
         one: Prototype
         other: Prototypes
       spree/refund_reason:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/reimbursement:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/reimbursement_type:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/return_authorization:
         one: Return Authorisation
         other: Return Authorisations
       spree/return_authorization_reason:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Roles
         other: Roles
       spree/shipment:
@@ -252,13 +306,31 @@ en-GB:
         one: Shipping Category
         other: Shipping Categories
       spree/shipping_method:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/state:
         one: County
         other: Counties
       spree/state_change:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/stock_location:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/stock_movement:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/stock_transfer:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/tax_category:
         one: Tax Category
         other: Tax Categories
@@ -272,6 +344,10 @@ en-GB:
         one: Taxonomy
         other: Taxonomies
       spree/tracker:
+        few: TODO_TRANSLATE
+        many: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/user:
         one: User
         other: Users
@@ -281,6 +357,9 @@ en-GB:
       spree/zone:
         one: Zone
         other: Zones
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.
@@ -319,6 +398,7 @@ en-GB:
     user_sessions:
       signed_in: Signed in successfully.
       signed_out: Signed out successfully.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: was already confirmed
@@ -327,14 +407,30 @@ en-GB:
       not_saved:
         one: '1 error prohibited with %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
-    filter: Filter
-    quick_search: Quick Search . . .
     abbreviation: Abbreviation
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Account
     account_updated: Account updated!
     action: Action
@@ -347,7 +443,7 @@ en-GB:
       list: List
       listing: Listing
       new: New
-      refund:
+      refund: TODO_TRANSLATE
       save: Save
       update: Update
     activate: Activate
@@ -355,7 +451,7 @@ en-GB:
     add: Add
     add_action_of_type: Add action of type
     add_country: Add Country
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Add New Header
     add_new_style: Add New Style
     add_one: Add One
@@ -369,11 +465,16 @@ en-GB:
     add_to_cart: Add To Basket
     add_variant: Add Variant
     additional_item: Additional Item Cost
+    address: TODO_TRANSLATE
     address1: Address
     address2: Address (contd.)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Adjustment
     adjustment_amount: Amount
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Adjustment has been successfully closed!
     adjustment_successfully_opened: Adjustment has been successfully opened!
     adjustment_total: Adjustment Total
@@ -381,35 +482,35 @@ en-GB:
     admin:
       tab:
         configuration: Configuration
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: Orders
         overview: Overview
         products: Products
         promotions: Promotions
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: Reports
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Users
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administration
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service
     all: All
     all_adjustments_closed: All adjustments successfully closed!
     all_adjustments_opened: All adjustments successfully opened!
     all_departments: All departments
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
@@ -425,70 +526,106 @@ en-GB:
     analytics_desc_list_4: It's completely free!
     analytics_trackers: Analytics Trackers
     and: and
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Are you sure
     are_you_sure_delete: Are you sure you want to delete this record?
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Authorisation Failure
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Available On
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Back
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Go Back To Store
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Back To Users List
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Backorderable
-    backorderable_default:
-    backordered:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
     backorders_allowed: backorders allowed
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has not shipped yet.
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.
     capture: capture
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Card Code
     card_number: Card Number
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Card type is
     cart: Basket
     cart_subtotal:
+      one: TODO_TRANSLATE
+      other: TODO_TRANSLATE
     categories: Categories
     category: Category
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Check for Spree alerts
     checkout: Checkout
     choose_a_customer: Choose a customer
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Choose Currency
     choose_dashboard_locale: Choose Dashboard Locale
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Town / City
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clone
     close: Close
     close_all_adjustments: Close All Adjustments
@@ -497,6 +634,7 @@ en-GB:
     complete: complete
     configuration: Configuration
     configurations: Configurations
+    configure_s3: TODO_TRANSLATE
     confirm: Confirm
     confirm_delete: Confirm Deletion
     confirm_password: Password Confirmation
@@ -505,7 +643,7 @@ en-GB:
     cost_currency: Cost Currency
     cost_price: Cost Price
     could_not_connect_to_jirafe: Could not connect to Jirafe to sync data. This will be automatically retried later.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: There was a problem saving this stock movement. Please try again.
     count_on_hand: Count On Hand
     countries: Countries
@@ -513,10 +651,10 @@ en-GB:
     country_based: Country Based
     country_name: Name
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied: The coupon code has already been applied to this order
@@ -526,17 +664,17 @@ en-GB:
     coupon_code_max_usage: Coupon code usage limit exceeded
     coupon_code_not_eligible: This coupon code is not eligible for this order
     coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Create
     create_a_new_account: Create a new account
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Created At
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
+    credits: TODO_TRANSLATE
     currency: Currency
     currency_decimal_mark: Currency decimal mark
     currency_settings: Currency Settings
@@ -547,11 +685,11 @@ en-GB:
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Customer Search
     cut: Cut
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: App ID
@@ -570,41 +708,60 @@ en-GB:
       js_format: yy/mm/dd
     date_range: Date Range
     default: Default
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Delivery
     depth: Depth
     description: Description
     destination: Destination
     destroy: Destroy
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Edit
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editing User
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Empty
     empty_cart: Empty Basket
@@ -637,28 +794,30 @@ en-GB:
           signup: User signup
     exceptions:
       count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Expiration
     extension: Extension
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Filename
     fill_in_customer_info: Please fill in customer info
+    filter: Filter
     filter_results: Filter Results
     finalize: Finalise
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: First Item Cost
     first_name: First Name
     first_name_begins_with: First Name Begins With
     flat_percent: Flat Percent
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Flat Rate (per order)
     flexible_rate: Flexible Rate
     forgot_password: Forgot Password
     free_shipping: Free Shipping
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -682,37 +841,45 @@ en-GB:
       only_incomplete: Only incomplete
       select_locale: Select locale
       show_only: Show only
+      store_translations: TODO_TRANSLATE
       supported_locales: Supported Locales
       this_file_language: English (UK)
       translations: Translations
     icon: Icon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Image
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
+    incomplete: TODO_TRANSLATE
     info_number_of_skus_not_shown:
+      one: TODO_TRANSLATE
+      other: TODO_TRANSLATE
     info_product_has_multiple_skus:
+      one: TODO_TRANSLATE
+      other: TODO_TRANSLATE
     instructions_to_reset_password: 'Fill out the form below and instructions to reset your password will be emailed to you:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Internal Name
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Invalid payment provider.
     invalid_promotion_action: Invalid promotion action.
     invalid_promotion_rule: Invalid promotion rule.
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: is not available to shipment address
     iso_name: Iso Name
     item: Item
@@ -722,26 +889,32 @@ en-GB:
       operators:
         gt: greater than
         gte: greater than or equal to
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: We are unable to ship the selected items to your shipping address. Please choose another shipping address.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: List
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Loading
     locale_changed: Locale Changed
     location: Location
     lock: Lock
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Logged in as
     logged_in_succesfully: Logged in successfully
     logged_out: You have been logged out.
@@ -750,23 +923,26 @@ en-GB:
     login_failed: Login authentication failed.
     login_name: Login
     logout: Logout
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Look for similar items
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Make refund
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Master Price
     match_choices:
       all: All
       none: None
     max_items: Max Items
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Minimal Amount
     month: Month
@@ -775,13 +951,13 @@ en-GB:
     my_account: My Account
     my_orders: My Orders
     name: Name
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Name or SKU
     new: New
     new_adjustment: New Adjustment
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: New Customer
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: New Image
     new_option_type: New Option Type
     new_order: New Order
@@ -790,14 +966,15 @@ en-GB:
     new_payment_method: New Payment Method
     new_product: New Product
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: New Property
     new_prototype: New Prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: New Return Authorisation
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: New Shipping Category
     new_shipping_method: New Shipping Method
     new_state: New State
@@ -814,24 +991,30 @@ en-GB:
     new_zone: New Zone
     next: Next
     no_actions_added: No actions added
-    no_payment_found:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: No pending payments
     no_products_found: No products found
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: No results
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: No tracking details provided.
     none: None
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normal Amount
     not: not
     not_available: N/A
     not_enough_stock: There is not enough inventory at the source location to complete this transfer.
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
@@ -839,7 +1022,7 @@ en-GB:
       product_not_deleted: Product could not be deleted
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: On Hand
     open: Open
     open_all_adjustments: Open All Adjustments
@@ -854,32 +1037,37 @@ en-GB:
     or_over_price: "%{price} or over"
     order: Order
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Order Details
     order_email_resent: Order Email Resent
     order_information: Order Information
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Dear Customer,\n
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: Cancellation of Order
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: Order Confirmation
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Thank you for your business.
-        total:
+        total: TODO_TRANSLATE
     order_not_found: We couldn't find your order. Please try that action again.
     order_number: Order %{number}
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Your order has been processed successfully
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: address
       awaiting_return: awaiting return
@@ -887,7 +1075,7 @@ en-GB:
       cart: cart
       complete: complete
       confirm: confirm
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: delivery
       payment: payment
       resumed: resumed
@@ -897,12 +1085,14 @@ en-GB:
     order_total: Order Total
     order_updated: Order Updated
     orders: Orders
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Out of Stock
     overview: Overview
     package_from: package from
     pagination:
+      first: TODO_TRANSLATE
       next_page: next page »
+      previous: TODO_TRANSLATE
       previous_page: "« previous page"
       truncate: "…"
     password: Password
@@ -910,11 +1100,11 @@ en-GB:
     path: Path
     pay: pay
     payment: Payment
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Payment Information
     payment_method: Payment Method
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -932,22 +1122,23 @@ en-GB:
       void: void
     payment_updated: Payment Updated
     payments: Payments
-    pending:
+    pending: TODO_TRANSLATE
     percent: Percent
     percent_per_item: Percent Per Item
     permalink: Permalink
     phone: Phone
     place_order: Place Order
     please_define_payment_methods: Please define some payment methods first.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentation
     previous: Previous
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Price
     price_range: Price Range
     price_sack: Price Sack
@@ -959,10 +1150,10 @@ en-GB:
     product_properties: Product Properties
     product_rule:
       choose_products: Choose products
-      label:
+      label: TODO_TRANSLATE
       match_all: all
       match_any: at least one
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: From product group
         manual: Manually choose
@@ -974,19 +1165,24 @@ en-GB:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Actions
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Match any of these rules
         any: Match all of these rules
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
@@ -999,27 +1195,27 @@ en-GB:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Order includes specified product(s)
         name: Product(s)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Available only to the specified users
         name: User
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Properties
     property: Property
     prototype: Prototype
@@ -1030,47 +1226,49 @@ en-GB:
     quantity: Quantity
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Rate
     reason: Reason
     receive: receive
     receive_stock: Receive Stock
     received: Received
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Reference
+    reference_contains: TODO_TRANSLATE
     refund: Refund
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Register as a New User
     registration: Registration
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Remember me
     remove: Remove
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: Reports
+    resellable: TODO_TRANSLATE
     resend: Resend
     reset_password: Reset my password
     response_code: Response Code
@@ -1078,34 +1276,41 @@ en-GB:
     resumed: Resumed
     return: return
     return_authorization: Return Authorisation
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Return authorisation updated
     return_authorizations: Return Authorisations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Return Quantity
     returned: Returned
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
+    role_id: TODO_TRANSLATE
     roles: Roles
     rules: Rules
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Sales Total
     sales_total_description: Sales Total For All Orders
     sales_totals: Sales Totals
     save_and_continue: Save and Continue
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: false
     say_yes: true
     scope: Scope
@@ -1115,10 +1320,11 @@ en-GB:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Select
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Select From Prototype
     select_stock: Select stock
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
     server: Server
@@ -1128,8 +1334,9 @@ en-GB:
     ship_address: Ship Address
     ship_total: Ship Total
     shipment: Shipment
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1142,13 +1349,13 @@ en-GB:
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: partial
       pending: pending
       ready: ready
       shipped: shipped
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Shipments
     shipped: Shipped
     shipping: Delivery
@@ -1162,67 +1369,83 @@ en-GB:
     shipping_method: Delivery Method
     shipping_methods: Delivery Methods
     shipping_price_sack: Price sack
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Basket
     show: Show
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Show rate in label
     sku: SKU
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Source
     special_instructions: Special Instructions
     split: Split
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Start
+    start_date: TODO_TRANSLATE
     state: County
     state_based: State Based
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Counties
     states_required: County Required
     status: Status
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Stock Location
     stock_location_info: Stock location info
     stock_locations: Stock Locations
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Stock Management
     stock_management_requires_a_stock_location: Please create a stock location in order to manage stock.
     stock_movements: Stock Movements
@@ -1236,28 +1459,30 @@ en-GB:
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal
     subtract: Subtract
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} has been successfully removed!"
     successfully_signed_up_for_analytics: Successfully signed up for Spree Analytics
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Tax
     tax_categories: Tax Categories
     tax_category: Tax Category
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
     tax_rates: Tax Rates
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxon
     taxon_edit: Edit Taxon
     taxon_placeholder: Add a Taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy
@@ -1266,6 +1491,9 @@ en-GB:
     taxons: Taxons
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Congratulations!
         message: If you have received this email, then your email settings are correct.
@@ -1274,24 +1502,24 @@ en-GB:
     thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
     there_are_no_items_for_this_order: There are no items for this order. Please add an item to the order to continue.
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Time
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Transfer From
     transfer_stock: Transfer Stock
     transfer_to_location: Transfer To
@@ -1299,7 +1527,7 @@ en-GB:
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
     unlock: Unlock
     unrecognized_card_type: Unrecognised card type
@@ -1307,9 +1535,11 @@ en-GB:
     update: Update
     updating: Updating
     usage_limit: Usage Limit
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Use Billing Address
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Use a new card
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Use Amazon S3 For Images
     user: User
     user_rule:
@@ -1317,12 +1547,13 @@ en-GB:
     users: Users
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: exceeds available stock. Please ensure line items have a valid quantity.
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Value
     variant: Variant
     variant_placeholder: Choose a variant
@@ -1341,3 +1572,10 @@ en-GB:
     zipcode: Post Code
     zone: Zone
     zones: Zones
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -1,4 +1,6 @@
+---
 en-IN:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ en-IN:
         state: State
         zipcode: Zip Code
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ en-IN:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Type
         month: Month
-        name:
+        name: TODO_TRANSLATE
         number: Number
         verification_value: Verification Value
         year: Year
@@ -42,8 +44,8 @@ en-IN:
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At
-        considered_risky:
-        coupon_code:
+        considered_risky: TODO_TRANSLATE
+        coupon_code: TODO_TRANSLATE
         created_at: Order Date
         email: Customer E-Mail
         ip_address: IP Address
@@ -72,6 +74,7 @@ en-IN:
         zipcode: Shipping address zipcode
       spree/payment:
         amount: Amount
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Name
       spree/product:
@@ -95,7 +98,8 @@ en-IN:
         starts_at: Starts At
         usage_limit: Usage Limit
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Name
         presentation: Presentation
@@ -105,24 +109,26 @@ en-IN:
         amount: Amount
       spree/role:
         name: Name
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abbreviation
         name: Name
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Description
         name: Name
@@ -157,48 +163,54 @@ en-IN:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Address
         other: Addresses
@@ -208,41 +220,43 @@ en-IN:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
       spree/line_item:
         one: Line Item
         other: Line Items
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Order
         other: Orders
       spree/payment:
         one: Payment
         other: Payments
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Product
         other: Products
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Property
         other: Properties
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Return Authorization
         other: Return Authorizations
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Roles
         other: Roles
       spree/shipment:
@@ -251,14 +265,14 @@ en-IN:
       spree/shipping_category:
         one: Shipping Category
         other: Shipping Categories
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: State
         other: States
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Tax Category
         other: Tax Categories
@@ -271,7 +285,7 @@ en-IN:
       spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: User
         other: Users
@@ -281,6 +295,9 @@ en-IN:
       spree/zone:
         one: Zone
         other: Zones
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.
@@ -319,6 +336,7 @@ en-IN:
     user_sessions:
       signed_in: Signed in successfully.
       signed_out: Signed out successfully.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: was already confirmed
@@ -327,12 +345,30 @@ en-IN:
       not_saved:
         one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abbreviation
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Account
     account_updated: Account updated!
     action: Action
@@ -345,7 +381,7 @@ en-IN:
       list: List
       listing: Listing
       new: New
-      refund:
+      refund: TODO_TRANSLATE
       save: Save
       update: Update
     activate: Activate
@@ -353,7 +389,7 @@ en-IN:
     add: Add
     add_action_of_type: Add action of type
     add_country: Add Country
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Add New Header
     add_new_style: Add New Style
     add_one: Add One
@@ -367,47 +403,52 @@ en-IN:
     add_to_cart: Add To Basket
     add_variant: Add Variant
     additional_item: Additional Item Cost
+    address: TODO_TRANSLATE
     address1: Address
     address2: Address (contd.)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Adjustment
     adjustment_amount: Amount
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Adjustment has been successfully closed!
     adjustment_successfully_opened: Adjustment has been successfully opened!
     adjustment_total: Adjustment Total
     adjustments: Adjustments
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administration
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service
     all: All
     all_adjustments_closed: All adjustments successfully closed!
     all_adjustments_opened: All adjustments successfully opened!
     all_departments: All departments
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
@@ -423,70 +464,104 @@ en-IN:
     analytics_desc_list_4: It's completely free!
     analytics_trackers: Analytics Trackers
     and: and
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Are you sure
     are_you_sure_delete: Are you sure you want to delete this record?
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Authorization Failure
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Available On
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Back
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Go Back To Store
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Back To Users List
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Backorderable
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has not shipped yet.
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided
     capture: capture
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Card Code
     card_number: Card Number
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Card type is
     cart: Basket
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categories
     category: Category
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Check for Spree alerts
     checkout: Checkout
     choose_a_customer: Choose a customer
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Choose Currency
     choose_dashboard_locale: Choose Dashboard Locale
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Town / City
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clone
     close: Close
     close_all_adjustments: Close All Adjustments
@@ -495,6 +570,7 @@ en-IN:
     complete: complete
     configuration: Configuration
     configurations: Configurations
+    configure_s3: TODO_TRANSLATE
     confirm: Confirm
     confirm_delete: Confirm Deletion
     confirm_password: Password Confirmation
@@ -503,7 +579,7 @@ en-IN:
     cost_currency: Cost Currency
     cost_price: Cost Price
     could_not_connect_to_jirafe: Could not connect to Jirafe to sync data. This will be automatically retried later.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: There was a problem saving this stock movement. Please try again.
     count_on_hand: Count On Hand
     countries: Countries
@@ -511,10 +587,10 @@ en-IN:
     country_based: Country Based
     country_name: Name
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied: The coupon code has already been applied to this order
@@ -524,17 +600,17 @@ en-IN:
     coupon_code_max_usage: Coupon code usage limit exceeded
     coupon_code_not_eligible: This coupon code is not eligible for this order
     coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Create
     create_a_new_account: Create a new account
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Created At
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
+    credits: TODO_TRANSLATE
     currency: Currency
     currency_decimal_mark: Currency decimal mark
     currency_settings: Currency Settings
@@ -545,16 +621,16 @@ en-IN:
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Customer Search
     cut: Cut
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable:
+        currently_unavailable: TODO_TRANSLATE
         explanation: The fields below may already be populated if you chose to register with Jirafe from the admin dashboard.
         header: Jirafe Analytics Settings
         site_id: Site ID
@@ -563,46 +639,65 @@ en-IN:
     date: Date
     date_completed: Date Completed
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
     date_range: Date Range
     default: Default
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Delivery
     depth: Depth
     description: Description
     destination: Destination
     destroy: Destroy
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Edit
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editing User
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Empty
     empty_cart: Empty Basket
@@ -635,28 +730,30 @@ en-IN:
           signup: User signup
     exceptions:
       count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Expiration
     extension: Extension
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Filename
     fill_in_customer_info: Please fill in customer info
+    filter: TODO_TRANSLATE
     filter_results: Filter Results
     finalize: Finalize
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: First Item Cost
     first_name: First Name
     first_name_begins_with: First Name Begins With
     flat_percent: Flat Percent
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Flat Rate (per order)
     flexible_rate: Flexible Rate
     forgot_password: Forgot Password
     free_shipping: Free Shipping
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -672,45 +769,49 @@ en-IN:
     hide_cents: Hide cents
     home: Home
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: English (UK)
-      translations:
+      translations: TODO_TRANSLATE
     icon: Icon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Image
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Fill out the form below and instructions to reset your password will be emailed to you:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Invalid payment provider.
     invalid_promotion_action: Invalid promotion action.
     invalid_promotion_rule: Invalid promotion rule.
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: is not available to shipment address
     iso_name: ISO Name
     item: Item
@@ -720,26 +821,32 @@ en-IN:
       operators:
         gt: greater than
         gte: greater than or equal to
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: List
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Loading
     locale_changed: Locale Changed
     location: Location
     lock: Lock
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Logged in as
     logged_in_succesfully: Logged in successfully
     logged_out: You have been logged out.
@@ -748,23 +855,26 @@ en-IN:
     login_failed: Login authentication failed.
     login_name: Login
     logout: Logout
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Look for similar items
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Make refund
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Master Price
     match_choices:
       all: All
       none: None
     max_items: Max Items
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Minimal Amount
     month: Month
@@ -773,13 +883,13 @@ en-IN:
     my_account: My Account
     my_orders: My Orders
     name: Name
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Name or SKU
     new: New
     new_adjustment: New Adjustment
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: New Customer
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: New Image
     new_option_type: New Option Type
     new_order: New Order
@@ -788,14 +898,15 @@ en-IN:
     new_payment_method: New Payment Method
     new_product: New Product
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: New Property
     new_prototype: New Prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: New Return Authorization
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: New Shipping Category
     new_shipping_method: New Shipping Method
     new_state: New State
@@ -812,24 +923,30 @@ en-IN:
     new_zone: New Zone
     next: Next
     no_actions_added: No actions added
-    no_payment_found:
-    no_pending_payments:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: No products found
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: No results
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: No tracking details provided.
     none: None
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normal Amount
     not: not
     not_available: N/A
     not_enough_stock: There is not enough inventory at the source location to complete this transfer.
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
@@ -837,12 +954,12 @@ en-IN:
       product_not_deleted: Product could not be deleted
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: On Hand
     open: Open
     open_all_adjustments: Open All Adjustments
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Option Types
     option_value: Option Value
     option_values: Option Values
@@ -852,32 +969,37 @@ en-IN:
     or_over_price: "%{price} or over"
     order: Order
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Order Details
     order_email_resent: Order Email Resent
     order_information: Order Information
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Dear Customer,\n
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: Cancellation of Order
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: Order Confirmation
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Thank you for your business.
-        total:
+        total: TODO_TRANSLATE
     order_not_found: We couldn't find your order. Please try that action again.
-    order_number:
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Your order has been processed successfully
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: address
       awaiting_return: awaiting return
@@ -885,7 +1007,7 @@ en-IN:
       cart: cart
       complete: complete
       confirm: confirm
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: delivery
       payment: payment
       resumed: resumed
@@ -895,12 +1017,14 @@ en-IN:
     order_total: Order Total
     order_updated: Order Updated
     orders: Orders
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Out of Stock
     overview: Overview
     package_from: package from
     pagination:
+      first: TODO_TRANSLATE
       next_page: next page »
+      previous: TODO_TRANSLATE
       previous_page: "« previous page"
       truncate: "…"
     password: Password
@@ -908,11 +1032,11 @@ en-IN:
     path: Path
     pay: pay
     payment: Payment
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Payment Information
     payment_method: Payment Method
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -930,22 +1054,23 @@ en-IN:
       void: void
     payment_updated: Payment Updated
     payments: Payments
-    pending:
+    pending: TODO_TRANSLATE
     percent: Percent
     percent_per_item: Percent Per Item
     permalink: Permalink
     phone: Phone
     place_order: Place Order
     please_define_payment_methods: Please define some payment methods first.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentation
     previous: Previous
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Price
     price_range: Price Range
     price_sack: Price Sack
@@ -957,10 +1082,10 @@ en-IN:
     product_properties: Product Properties
     product_rule:
       choose_products: Choose products
-      label:
+      label: TODO_TRANSLATE
       match_all: all
       match_any: at least one
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: From product group
         manual: Manually choose
@@ -972,19 +1097,24 @@ en-IN:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Actions
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Match any of these rules
         any: Match all of these rules
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
@@ -997,27 +1127,27 @@ en-IN:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Order includes specified product(s)
         name: Product(s)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Available only to the specified users
         name: User
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Properties
     property: Property
     prototype: Prototype
@@ -1028,47 +1158,49 @@ en-IN:
     quantity: Quantity
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Rate
     reason: Reason
     receive: receive
     receive_stock: Receive Stock
     received: Received
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Reference
+    reference_contains: TODO_TRANSLATE
     refund: Refund
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Register as a New User
     registration: Registration
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Remember me
     remove: Remove
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: Reports
+    resellable: TODO_TRANSLATE
     resend: Resend
     reset_password: Reset my password
     response_code: Response Code
@@ -1076,34 +1208,41 @@ en-IN:
     resumed: Resumed
     return: return
     return_authorization: Return Authorization
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Return authorization updated
     return_authorizations: Return Authorizations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Return Quantity
     returned: Returned
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
+    role_id: TODO_TRANSLATE
     roles: Roles
     rules: Rules
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Sales Total
     sales_total_description: Sales Total For All Orders
     sales_totals: Sales Totals
     save_and_continue: Save and Continue
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: false
     say_yes: true
     scope: Scope
@@ -1113,10 +1252,11 @@ en-IN:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Select
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Select From Prototype
     select_stock: Select stock
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
     server: Server
@@ -1126,8 +1266,9 @@ en-IN:
     ship_address: Ship Address
     ship_total: Ship Total
     shipment: Shipment
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1140,13 +1281,13 @@ en-IN:
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: partial
       pending: pending
       ready: ready
       shipped: shipped
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Shipments
     shipped: Shipped
     shipping: Delivery
@@ -1160,69 +1301,85 @@ en-IN:
     shipping_method: Delivery Method
     shipping_methods: Delivery Methods
     shipping_price_sack: Price sack
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Basket
     show: Show
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Show rate in label
     sku: SKU
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Source
     special_instructions: Special Instructions
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Start
+    start_date: TODO_TRANSLATE
     state: County
     state_based: State Based
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Counties
     states_required: States Required
     status: Status
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Stock Location
     stock_location_info: Stock location info
     stock_locations: Stock Locations
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Stock Management
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
     stock_movements: Stock Movements
     stock_movements_for_stock_location: Stock Movements for %{stock_location_name}
     stock_successfully_transferred: Stock was successfully transferred between locations.
@@ -1234,28 +1391,30 @@ en-IN:
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal
     subtract: Subtract
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} has been successfully removed!"
     successfully_signed_up_for_analytics: Successfully signed up for Spree Analytics
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Tax
     tax_categories: Tax Categories
     tax_category: Tax Category
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
     tax_rates: Tax Rates
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxon
     taxon_edit: Edit Taxon
     taxon_placeholder: Add a Taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy
@@ -1264,32 +1423,35 @@ en-IN:
     taxons: Taxons
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Congratulations!
         message: If you have received this email, then your email settings are correct.
         subject: Testmail
     test_mode: Test Mode
     thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Time
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Transfer From
     transfer_stock: Transfer Stock
     transfer_to_location: Transfer To
@@ -1297,7 +1459,7 @@ en-IN:
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
     unlock: Unlock
     unrecognized_card_type: Unrecognized card type
@@ -1305,9 +1467,11 @@ en-IN:
     update: Update
     updating: Updating
     usage_limit: Usage Limit
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Use Billing Address
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Use a new card
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Use Amazon S3 For Images
     user: User
     user_rule:
@@ -1315,15 +1479,16 @@ en-IN:
     users: Users
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: exceeds available stock. Please ensure line items have a valid quantity.
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Value
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Variants
     version: Version
     void: Void
@@ -1339,3 +1504,10 @@ en-IN:
     zipcode: Zip Code
     zone: Zone
     zones: Zones
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -1,4 +1,6 @@
+---
 en-NZ:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ en-NZ:
         state: Region
         zipcode: Postcode
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ en-NZ:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Type
         month: Month
-        name:
+        name: TODO_TRANSLATE
         number: Number
         verification_value: Verification Value
         year: Year
@@ -42,7 +44,7 @@ en-NZ:
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: Coupon Code
         created_at: Order Date
         email: Customer E-Mail
@@ -72,6 +74,7 @@ en-NZ:
         zipcode: Shipping address zipcode
       spree/payment:
         amount: Amount
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Name
       spree/product:
@@ -95,7 +98,8 @@ en-NZ:
         starts_at: Starts At
         usage_limit: Usage Limit
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Name
         presentation: Presentation
@@ -105,24 +109,26 @@ en-NZ:
         amount: Amount
       spree/role:
         name: Name
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abbreviation
         name: Name
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Description
         name: Name
@@ -157,48 +163,54 @@ en-NZ:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: Card has expired
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Address
         other: Addresses
@@ -208,41 +220,43 @@ en-NZ:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
       spree/line_item:
         one: Line Item
         other: Line Items
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Order
         other: Orders
       spree/payment:
         one: Payment
         other: Payments
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Product
         other: Products
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Property
         other: Properties
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Return Authorisation
         other: Return Authorisations
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Roles
         other: Roles
       spree/shipment:
@@ -251,14 +265,14 @@ en-NZ:
       spree/shipping_category:
         one: Shipping Category
         other: Shipping Categories
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: State
         other: States
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Tax Category
         other: Tax Categories
@@ -271,7 +285,7 @@ en-NZ:
       spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: User
         other: Users
@@ -281,6 +295,9 @@ en-NZ:
       spree/zone:
         one: Zone
         other: Zones
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.
@@ -304,308 +321,388 @@ en-NZ:
       failure: Could not authorise you from %{kind} because %{reason}.
       success: Successfully authorised from %{kind} account.
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abbreviation
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Account
     account_updated: Account updated!
     action: Action
     actions:
       cancel: Cancel
-      continue:
+      continue: TODO_TRANSLATE
       create: Create
       destroy: Destroy
-      edit:
+      edit: TODO_TRANSLATE
       list: List
       listing: Listing
       new: New
-      refund:
-      save:
+      refund: TODO_TRANSLATE
+      save: TODO_TRANSLATE
       update: Update
     activate: Activate
     active: Active
     add: Add
     add_action_of_type: Add action of type
     add_country: Add Country
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: TODO_TRANSLATE
     add_option_value: Add Option Value
     add_product: Add Product
     add_product_properties: Add Product Properties
     add_rule_of_type: Add rule of type
     add_state: Add Region
-    add_stock:
-    add_stock_management:
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: Add To Cart
-    add_variant:
+    add_variant: TODO_TRANSLATE
     additional_item: Additional Item Cost
-    address1:
-    address2:
-    adjustable:
+    address: TODO_TRANSLATE
+    address1: TODO_TRANSLATE
+    address2: TODO_TRANSLATE
+    adjustable: TODO_TRANSLATE
     adjustment: Adjustment
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: Adjustment Total
     adjustments: Adjustments
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administration
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
     all: All
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
     all_departments: All departments
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: Alternative Text
     alternative_phone: Alternative Phone
     amount: Amount
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
     analytics_trackers: Analytics Trackers
     and: and
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Are you sure
     are_you_sure_delete: Are you sure you want to delete this record?
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Authorisation Failure
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Available On
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Back
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Go Back To Store
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Bill Address
     billing: Billing
     billing_address: Billing Address
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has no shipped units.
     cannot_perform_operation: Cannot perform requested operation
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: Capture
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Card Code
     card_number: Card Number
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Card type is
     cart: Cart
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categories
     category: Category
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Checkout
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: TODO_TRANSLATE
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: TODO_TRANSLATE
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
     city: Town / City
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clone
-    close:
-    close_all_adjustments:
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
     code: Code
-    company:
+    company: TODO_TRANSLATE
     complete: complete
     configuration: Configuration
     configurations: Configurations
+    configure_s3: TODO_TRANSLATE
     confirm: Confirm
     confirm_delete: Confirm Deletion
     confirm_password: Password Confirmation
     continue: Continue
     continue_shopping: Continue shopping
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: Cost Price
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
+    countries: TODO_TRANSLATE
     country: Country
     country_based: Country Based
-    country_name:
+    country_name: TODO_TRANSLATE
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Coupon
     coupon_code: Coupon code
-    coupon_code_already_applied:
+    coupon_code_already_applied: TODO_TRANSLATE
     coupon_code_applied: The coupon code was successfully applied to your order.
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Create
     create_a_new_account: Create a new account
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
     credit: Credit
     credit_card: Credit Card
     credit_cards: Credit Cards
     credit_owed: Credit Owed
-    credits:
+    credits: TODO_TRANSLATE
     currency: Currency
-    currency_decimal_mark:
+    currency_decimal_mark: TODO_TRANSLATE
     currency_settings: Currency Settings
     currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator:
+    currency_thousands_separator: TODO_TRANSLATE
     current: Current
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Customer Search
     cut: Cut
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: Date Range
     default: Default
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
     delete: Delete
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Delivery
     depth: Depth
     description: Description
-    destination:
+    destination: TODO_TRANSLATE
     destroy: Destroy
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Discount Amount
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Edit
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editing User
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Empty
     empty_cart: Empty Cart
     enable_mail_delivery: Enable Mail Delivery
-    end:
+    end: TODO_TRANSLATE
     ending_in: Ending in
     environment: Environment
     error: error
@@ -632,29 +729,31 @@ en-NZ:
         user:
           signup: User signup
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Expiration
     extension: Extension
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Filename
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
+    filter_results: TODO_TRANSLATE
     finalize: Finalise
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: First Item Cost
     first_name: First Name
     first_name_begins_with: First Name Begins With
     flat_percent: Flat Percent
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Flat Rate (per order)
     flexible_rate: Flexible Rate
     forgot_password: Forgot Password?
     free_shipping: Free Delivery
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -667,50 +766,54 @@ en-NZ:
     guest_user_account: Checkout as a Guest
     has_no_shipped_units: has no shipped units
     height: Height
-    hide_cents:
+    hide_cents: TODO_TRANSLATE
     home: Home
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: English (New Zealand)
-      translations:
+      translations: TODO_TRANSLATE
     icon: Icon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Image
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Fill out the form below and instructions to reset your password will be emailed to you:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: is not available to delivery address
-    iso_name:
+    iso_name: TODO_TRANSLATE
     item: Item
     item_description: Item Description
     item_total: Item Total
@@ -718,26 +821,32 @@ en-NZ:
       operators:
         gt: greater than
         gte: greater than or equal to
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
       path: Path
     last_name: Last Name
     last_name_begins_with: Last Name Begins With
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: List
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Loading
     locale_changed: Locale Changed
-    location:
-    lock:
-    log_entries:
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
     logged_in_as: Logged in as
     logged_in_succesfully: Logged in successfully
     logged_out: You have been logged out.
@@ -746,38 +855,41 @@ en-NZ:
     login_failed: Login authentication failed.
     login_name: Login
     logout: Logout
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Look for similar items
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Make refund
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Master Price
     match_choices:
       all: All
       none: None
     max_items: Max Items
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Minimal Amount
     month: Month
     more: More
-    move_stock_between_locations:
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: My Account
     my_orders: My Orders
     name: Name
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Name or SKU (enter at least first 4 characters of product name)
     new: New
     new_adjustment: New Adjustment
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: New Customer
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: New Image
     new_option_type: New Option Type
     new_order: New Order
@@ -786,20 +898,21 @@ en-NZ:
     new_payment_method: New Payment Method
     new_product: New Product
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: New Property
     new_prototype: New Prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: New Return Authorisation
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: New Shipping Category
     new_shipping_method: New Delivery Method
     new_state: New Region
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: New Tax Category
     new_tax_rate: New Tax Rate
     new_taxon: New Taxon
@@ -809,25 +922,31 @@ en-NZ:
     new_variant: New Variant
     new_zone: New Zone
     next: Next
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: No products found
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: No results
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: None
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normal Amount
     not: not
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
@@ -835,47 +954,52 @@ en-NZ:
       product_not_deleted: Product could not be deleted
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: On Hand
-    open:
-    open_all_adjustments:
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Option Types
     option_value: Option Value
     option_values: Option Values
-    optional:
+    optional: TODO_TRANSLATE
     options: Options
     or: or
     or_over_price: "%{price} or over"
     order: Order
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Order Details
     order_email_resent: Order Email Resent
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Dear Customer,\n
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: Cancellation of Order
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: Order Confirmation
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Thank you for your business.
-        total:
-    order_not_found:
-    order_number:
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Your order has been processed successfully
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: address
       awaiting_return: awaiting return
@@ -883,7 +1007,7 @@ en-NZ:
       cart: cart
       complete: complete
       confirm: confirm
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: delivery
       payment: payment
       resumed: resumed
@@ -893,12 +1017,14 @@ en-NZ:
     order_total: Order Total
     order_updated: Order Updated
     orders: Orders
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Out of Stock
     overview: Overview
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
+      first: TODO_TRANSLATE
       next_page: next page »
+      previous: TODO_TRANSLATE
       previous_page: "« previous page"
       truncate: "…"
     password: Password
@@ -906,11 +1032,11 @@ en-NZ:
     path: Path
     pay: pay
     payment: Payment
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Payment Information
     payment_method: Payment Method
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -928,22 +1054,23 @@ en-NZ:
       void: void
     payment_updated: Payment Updated
     payments: Payments
-    pending:
-    percent:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
     percent_per_item: Percent Per Item
     permalink: Permalink
     phone: Phone
     place_order: Place Order
     please_define_payment_methods: Please define some payment methods first.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentation
     previous: Previous
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Price
     price_range: Price Range
     price_sack: Price Sack
@@ -951,14 +1078,14 @@ en-NZ:
     product: Product
     product_details: Product Details
     product_has_no_description: This product has no description
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Product Properties
     product_rule:
       choose_products: Choose products
-      label:
+      label: TODO_TRANSLATE
       match_all: all
       match_any: at least one
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: From product group
         manual: Manually choose
@@ -970,19 +1097,24 @@ en-NZ:
         description: Creates a promotion credit adjustment on the order
         name: Create adjustment
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Populates the cart with the specified variants and quantities
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Actions
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Match all of these rules
         any: Match any of these rules
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
@@ -995,27 +1127,27 @@ en-NZ:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Order includes specified product(s)
         name: Product(s)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Available only to the specified users
         name: User
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Properties
     property: Property
     prototype: Prototype
@@ -1023,50 +1155,52 @@ en-NZ:
     provider: Provider
     provider_settings_warning: If you are changing the provider type, you must save first before you can edit the provider settings
     qty: Qty
-    quantity:
+    quantity: TODO_TRANSLATE
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Rate
     reason: Reason
     receive: receive
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: Received
-    reception_status:
-    reference:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
     refund: Refund
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Register as a New User
     registration: Registration
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Remember me
     remove: Remove
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: Reports
+    resellable: TODO_TRANSLATE
     resend: Resend
     reset_password: Reset my password
     response_code: Response Code
@@ -1074,34 +1208,41 @@ en-NZ:
     resumed: Resumed
     return: return
     return_authorization: Return Authorisation
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Return authorisation updated
     return_authorizations: Return Authorisations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Return Quantity
     returned: Returned
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
+    role_id: TODO_TRANSLATE
     roles: Roles
     rules: Rules
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Sales Total
     sales_total_description: Sales Total For All Orders
-    sales_totals:
+    sales_totals: TODO_TRANSLATE
     save_and_continue: Save and Continue
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: false
     say_yes: true
     scope: Scope
@@ -1111,10 +1252,11 @@ en-NZ:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Select
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Select From Prototype
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
     server: Server
@@ -1122,10 +1264,11 @@ en-NZ:
     settings: Settings
     ship: ship
     ship_address: Delivery Address
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: Shipment
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1134,126 +1277,144 @@ en-NZ:
         subject: Shipment Notification
         thanks: Thank you for your business.
         track_information: 'Tracking Information: %{tracking}'
-        track_link:
+        track_link: TODO_TRANSLATE
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: partial
       pending: pending
       ready: ready
       shipped: shipped
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Shipments
     shipped: Shipped
     shipping: Delivery
     shipping_address: Delivery Address
     shipping_categories: Shipping Categories
     shipping_category: Shipping Category
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: Delivery Instructions
     shipping_method: Delivery Method
     shipping_methods: Delivery Methods
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Cart
     show: Show
     show_active: Show Active
     show_deleted: Show Deleted
     show_only_complete_orders: Only show complete orders
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
     sku: SKU
-    skus:
-    slug:
-    source:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
     special_instructions: Special Instructions
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Start
+    start_date: TODO_TRANSLATE
     state: Region
     state_based: Region Based
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Regions
-    states_required:
+    states_required: TODO_TRANSLATE
     status: Status
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
     stop: Stop
     store: Store
     street_address: Street Address
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal
     subtract: Subtract
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} has been successfully removed!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Tax
     tax_categories: Tax Categories
     tax_category: Tax Category
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Tax Rates
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxon
     taxon_edit: Edit Taxon
-    taxon_placeholder:
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy
@@ -1262,50 +1423,55 @@ en-NZ:
     taxons: Taxons
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Congratulations!
         message: If you have received this email, then your email settings are correct.
         subject: Testmail
     test_mode: Test Mode
     thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Tree
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
-    unlock:
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: Unrecognised card type
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: Update
     updating: Updating
     usage_limit: Usage Limit
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Use Billing Address
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Use a new card
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Use Amazon S3 For Images
     user: User
     user_rule:
@@ -1313,15 +1479,16 @@ en-NZ:
     users: Users
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Value
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Variants
     version: Version
     void: Void
@@ -1332,8 +1499,15 @@ en-NZ:
     year: Year
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Your cart is empty
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: Postcode
-    zipcode:
+    zipcode: TODO_TRANSLATE
     zone: Zone
     zones: Zones
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -1,4 +1,6 @@
+---
 es-CL:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -27,10 +29,10 @@ es-CL:
         base: Base
         cc_type: Tipo
         month: Mes
+        name: Nombre
         number: Número
         verification_value: Código de verificación (CVV)
         year: Año
-        name: Nombre
       spree/inventory_unit:
         state: Estado
       spree/line_item:
@@ -42,6 +44,7 @@ es-CL:
       spree/order:
         checkout_complete: Pedido completo
         completed_at: Completado En
+        considered_risky: Arriesgado
         coupon_code: Código Cupón
         created_at: Fecha del Pedido
         email: E-Mail del Cliente
@@ -53,7 +56,6 @@ es-CL:
         special_instructions: Instrucciones especiales
         state: Estado
         total: Total
-        considered_risky: Arriesgado
       spree/order/bill_address:
         address1: Calle dirección de facturación
         city: Ciudad dirección de facturación
@@ -96,6 +98,7 @@ es-CL:
         starts_at: Empieza en
         usage_limit: Límite de uso
       spree/promotion_category:
+        code: TODO_TRANSLATE
         name: Nombre
       spree/property:
         name: Nombre
@@ -113,19 +116,19 @@ es-CL:
         name: Nombre
       spree/state_change:
         state_changes: Cambio de estados
-        type: Tipo
         state_from: Estado inicial
         state_to: Estado final
-        user: Usuario
         timestamp: Fecha del cambio
+        type: Tipo
         updated: Actualizado
+        user: Usuario
       spree/store:
-        url: URL
+        mail_from_address: Dirección de email de envío
         meta_description: Meta descripción
         meta_keywords: Meta palabras claves
-        seo_title: Título SEO
         name: Nombre de la Tienda
-        mail_from_address: Dirección de email de envío
+        seo_title: Título SEO
+        url: URL
       spree/tax_category:
         description: Descripción
         name: Nombre
@@ -155,7 +158,59 @@ es-CL:
       spree/zone:
         description: Descripción
         name: Nombre
+    errors:
+      models:
+        spree/calculator/tiered_flat_rate:
+          attributes:
+            base:
+              keys_should_be_positive_number: Tier keys should all be numbers larger than 0
+            preferred_tiers:
+              should_be_hash: should be a hash
+        spree/calculator/tiered_percent:
+          attributes:
+            base:
+              keys_should_be_positive_number: Tier keys should all be numbers larger than 0
+              values_should_be_percent: Tier values should all be percentages between 0% and 100%
+            preferred_tiers:
+              should_be_hash: should be a hash
+        spree/classification:
+          attributes:
+            taxon_id:
+              already_linked: is already linked to this product
+        spree/credit_card:
+          attributes:
+            base:
+              card_expired: Card has expired
+              expiry_invalid: Card expiration is invalid
+        spree/line_item:
+          attributes:
+            currency:
+              must_match_order_currency: Must match order currency
+        spree/refund:
+          attributes:
+            amount:
+              greater_than_allowed: is greater than the allowed amount.
+        spree/reimbursement:
+          attributes:
+            base:
+              return_items_order_id_does_not_match: One or more of the return items specified do not belong to the same order as the reimbursement.
+        spree/return_item:
+          attributes:
+            inventory_unit:
+              other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
+            reimbursement:
+              cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
+        spree/store:
+          attributes:
+            base:
+              cannot_destroy_default_store: Cannot destroy the default Store.
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Dirección
         other: Direcciones
@@ -220,6 +275,8 @@ es-CL:
         one: Razón de la Autorización de devolución
         other: Razónes de las Autorización de devolución
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Rol
         other: Roles
       spree/shipment:
@@ -237,12 +294,12 @@ es-CL:
       spree/state_change:
         one: Cambio de estado
         other: Cambio de estados
-      spree/stock_movement:
-        one: Movimiento de Stock
-        other: Movimientos de Stock
       spree/stock_location:
         one: Ubicación de Stock
         other: Ubicaciones de Stock
+      spree/stock_movement:
+        one: Movimiento de Stock
+        other: Movimientos de Stock
       spree/stock_transfer:
         one: Transferencia de Stock
         other: Transferencias de Stock
@@ -270,53 +327,9 @@ es-CL:
       spree/zone:
         one: Zona
         other: Zonas
-    errors:
-      models:
-        spree/calculator/tiered_flat_rate:
-          attributes:
-            base:
-              keys_should_be_positive_number: "Tier keys should all be numbers larger than 0"
-            preferred_tiers:
-              should_be_hash: "should be a hash"
-        spree/calculator/tiered_percent:
-          attributes:
-            base:
-              keys_should_be_positive_number: "Tier keys should all be numbers larger than 0"
-              values_should_be_percent: "Tier values should all be percentages between 0% and 100%"
-            preferred_tiers:
-              should_be_hash: "should be a hash"
-        spree/classification:
-          attributes:
-            taxon_id:
-              already_linked: "is already linked to this product"
-        spree/credit_card:
-          attributes:
-            base:
-              card_expired: "Card has expired"
-              expiry_invalid: "Card expiration is invalid"
-        spree/line_item:
-          attributes:
-            currency:
-              must_match_order_currency: "Must match order currency"
-        spree/refund:
-          attributes:
-            amount:
-              greater_than_allowed: is greater than the allowed amount.
-        spree/reimbursement:
-          attributes:
-            base:
-              return_items_order_id_does_not_match: One or more of the return items specified do not belong to the same order as the reimbursement.
-        spree/return_item:
-          attributes:
-            reimbursement:
-              cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
-            inventory_unit:
-              other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
-        spree/store:
-          attributes:
-            base:
-              cannot_destroy_default_store: Cannot destroy the default Store.
-
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Tu cuenta fue confirmada satisfactoriamente. Ya estás registrado.
@@ -326,7 +339,7 @@ es-CL:
       invalid: E-Mail o contraseña inválida.
       invalid_token: Cadena de autenticación no válida.
       locked: Tu cuenta está bloqueada.
-      timeout: 'Tu sesión expiró, por favor inicia sesión nuevamente para continuar.'
+      timeout: Tu sesión expiró, por favor inicia sesión nuevamente para continuar.
       unauthenticated: Necesitas registrarte o activar tu cuenta antes de continuar.
       unconfirmed: Tienes que confirmar tu cuenta antes de continuar.
     mailer:
@@ -355,26 +368,38 @@ es-CL:
     user_sessions:
       signed_in: Has iniciado sesión satisfactoriamente.
       signed_out: Sesión finalizada satisfactoriamente.
-
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: fue ya confirmada.
       not_found: no encontrado
       not_locked: no estaba bloqueada
       not_saved:
-        one: '1 error evitó que este %{resource} fuese grabado.'
+        one: 1 error evitó que este %{resource} fuese grabado.
         other: "%{count} errores evitaron que este %{resource} fuese grabado:"
-
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
   number:
     percentage:
       format:
         precision: 1
-
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abreviación
     accept: Aceptar
-    acceptance_status: Estado de aceptación
     acceptance_errors: Errores de aceptación
+    acceptance_status: Estado de aceptación
     accepted: Aceptado
     account: Cuenta
     account_updated: Cuenta actualizada
@@ -406,6 +431,7 @@ es-CL:
     add_rule_of_type: Agregar regla de tipo
     add_state: Agregar Estado
     add_stock: Agregar Stock
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: Agregar al carrito
     add_variant: Agregar variante
     additional_item: Artículo adicional
@@ -417,8 +443,8 @@ es-CL:
     adjustment_amount: Valor
     adjustment_labels:
       tax_rates:
-        including_tax: '%{name}%{amount} (Incluido en el precio)'
-        excluding_tax: '%{name}%{amount}'
+        excluding_tax: "%{name}%{amount}"
+        including_tax: "%{name}%{amount} (Incluido en el precio)"
     adjustment_successfully_closed: El ajuste ha sido cerrado satisfactoriamente
     adjustment_successfully_opened: El ajuste ha sido abierto satisfactoriamente
     adjustment_total: Total del ajuste
@@ -443,7 +469,7 @@ es-CL:
         items: Artículos
         items_purchased: Artículos comprados
         order_history: Historial de pedidos
-        order_num: "Pedido #"
+        order_num: 'Pedido #'
         orders: Pedidos
         user_information: Información del usuario
     administration: Administración
@@ -455,6 +481,9 @@ es-CL:
     all_adjustments_opened: Todos los ajustes abiertos satisfactoriamente
     all_departments: Todas las Categorías
     all_items_have_been_returned: Todos los artículos se han devuelto
+    allow_ssl_in_development_and_test: TODO_TRANSLATE
+    allow_ssl_in_production: TODO_TRANSLATE
+    allow_ssl_in_staging: TODO_TRANSLATE
     already_signed_up_for_analytics: Ya te encuentras registrado en Spree Analytics
     alt_text: Texto alternativo
     alternative_phone: Teléfono alternativo
@@ -467,12 +496,24 @@ es-CL:
     analytics_desc_list_4: Es completamente gratuito!
     analytics_trackers: Analytics Trackers
     and: y
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: Aprobar
     approved_at: Aprobado en
     approver: Aprobado
     are_you_sure: "¿Estás seguro?"
     are_you_sure_delete: "¿Estás seguro de que quieres borrar este registro?"
     associated_adjustment_closed: El ajuste asociado está cerrado y no será recalculado. ¿Quieres abrirlo?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Fallo en la autorización
     authorized: Autorizado
     auto_capture: Captura automática
@@ -481,14 +522,36 @@ es-CL:
     avs_response: AVS Response
     back: Volver
     back_end: Backend
-    backordered: Pedido pendiente
-    back_to_resource_list: 'Volver al listado de %{resource}'
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
     back_to_payment: Volver al pago
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: Volver al listado de %{resource}
     back_to_rma_reason_list: Volver al listado de razones RMA
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Volver a la Tienda
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Volver al Listado de Usuarios
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: backorderable
     backorderable_default: Backorderable default
+    backordered: Pedido pendiente
     backorders_allowed: Permitida la Devolución
     balance_due: Saldo adeudado
     base_amount: Valor base
@@ -499,12 +562,12 @@ es-CL:
     both: Ambos
     calculated_reimbursements: Los reembolsos calculados
     calculator: Calculador
-    calculator_settings_warning: 'Si cambias el tipo de calculador, debes guardar primero antes de editar las preferencias del calculador'
+    calculator_settings_warning: Si cambias el tipo de calculador, debes guardar primero antes de editar las preferencias del calculador
     cancel: cancelar
-    canceler: Candelado
     canceled_at: Cancelado en
-    cannot_create_payment_without_payment_methods: No puedes crear un pago para un pedido sin antes definir un medio de pago
+    canceler: Candelado
     cannot_create_customer_returns: No se puede crear devoluciones para el cliente ya que este pedido no ha enviado artículos.
+    cannot_create_payment_without_payment_methods: No puedes crear un pago para un pedido sin antes definir un medio de pago
     cannot_create_returns: No puedes crear devoluciones para un pedido que no tiene unidades enviadas.
     cannot_perform_operation: No se pudo realizar la operación solicitada.
     cannot_set_shipping_method_without_address: No se puede establecer el método de envío hasta que no se proporcionen los detalles del cliente.
@@ -516,15 +579,15 @@ es-CL:
     card_type_is: El tipo de tarjeta es
     cart: Carrito
     cart_subtotal:
-      one: 'Subtotal (1 artículo)'
-      other: 'Subtotal (%{count} artículos)'
+      one: Subtotal (1 artículo)
+      other: Subtotal (%{count} artículos)
     categories: Categorías
     category: Categoría
     charged: Cargado
     check_for_spree_alerts: Comprobar alertas
     checkout: Realizar pedido
     choose_a_customer: Seleccione un cliente
-    choose_a_taxon_to_sort_products_for: "Elegir una Clasificación para ordenar productos por"
+    choose_a_taxon_to_sort_products_for: Elegir una Clasificación para ordenar productos por
     choose_currency: Seleccione moneda
     choose_dashboard_locale: Seleccione idioma del Dashboard
     choose_location: Seleccione Ubicación
@@ -541,6 +604,7 @@ es-CL:
     complete: Completar
     configuration: Configuración
     configurations: Configuraciones
+    configure_s3: TODO_TRANSLATE
     confirm: Confirmar
     confirm_delete: Confimar borrado
     confirm_password: Confirmación de Contraseña
@@ -577,12 +641,15 @@ es-CL:
     create_reimbursement: Crear reembolso
     created_at: Creado el
     credit: Crédito
-    credits: Créditos
     credit_card: Tarjeta de Crédito
     credit_cards: Tarjetas de Crédito
     credit_owed: Crédito adeudado
+    credits: Créditos
     currency: Moneda
+    currency_decimal_mark: TODO_TRANSLATE
     currency_settings: Parámetros de moneda
+    currency_symbol_position: TODO_TRANSLATE
+    currency_thousands_separator: TODO_TRANSLATE
     current: Actual
     current_promotion_usage: 'Uso actual: %{count}'
     customer: Cliente
@@ -611,7 +678,10 @@ es-CL:
       js_format: dd/mm/yy
     date_range: Rango de fechas
     default: Por defecto
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
     default_refund_amount: Valor por defecto del reembolso
+    default_seo_title: TODO_TRANSLATE
     default_tax: Impuesto por defecto
     default_tax_zone: Zona de impuesto por defecto
     delete: Borrar
@@ -619,18 +689,34 @@ es-CL:
     deleted_variants_present: Algunos artículos de este pedido ya no están disponibles.
     delivery: Entregar
     depth: Profundidad
-    details: Detalles
     description: Descripción
     destination: Destino
     destroy: Eliminar
+    details: Detalles
     discount_amount: Valor del descuento
     dismiss_banner: No. Gracias! No estoy interesado. no mostrar este mensaje otra vez
     display: Mostrar
+    display_currency: TODO_TRANSLATE
     doesnt_track_inventory: No realizar el siguiente de inventario
     edit: Editar
-    editing_resource: 'Editando %{resource}'
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: Editando %{resource}
     editing_rma_reason: Editando razón RMA
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editando Usuario
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
         has_excluded_product: Su carrito contiene un producto que evita que se aplique el cupón.
@@ -652,11 +738,13 @@ es-CL:
     enable_mail_delivery: Habilitar envío de e-mail
     end: Fin
     ending_in: Termina en
+    environment: TODO_TRANSLATE
     error: error
     errors:
       messages:
         could_not_create_taxon: No pude crear la Clasificación
-        no_shipping_methods_available: 'No hay métodos de envió disponibles para la localización seleccionada, por favor cambia tu dirección e inténtalo de nuevo'
+        no_payment_methods_available: TODO_TRANSLATE
+        no_shipping_methods_available: No hay métodos de envió disponibles para la localización seleccionada, por favor cambia tu dirección e inténtalo de nuevo
     errors_prohibited_this_record_from_being_saved:
       one: 1 error impidió que pudiera guardarse el registro
       other: "%{count} errores impidieron que pudiera guardarse el registro"
@@ -675,25 +763,26 @@ es-CL:
         user:
           signup: Registrar Usuario
     exceptions:
-      count_on_hand_setter: "No se pudo establecer count_on_hand manualmente, ya que está establecido automáticamente por la callback recalculate_count_on_hand. Por favor utiliza `update_column(:count_on_hand, value)` en vez de ello."
+      count_on_hand_setter: No se pudo establecer count_on_hand manualmente, ya que está establecido automáticamente por la callback recalculate_count_on_hand. Por favor utiliza `update_column(:count_on_hand, value)` en vez de ello.
     exchange_for: Intercambio de
-    expedited_exchanges_warning: "Cualquier cambio especificado serán entregado al cliente. Al cliente se le cargará el importe total del artículo si no devuelve en %{days_window} days_window días."
     excl: excl.
+    existing_shipments: Enví existentes
+    expedited_exchanges_warning: Cualquier cambio especificado serán entregado al cliente. Al cliente se le cargará el importe total del artículo si no devuelve en %{days_window} days_window días.
     expiration: Vencimiento
     extension: Extensión
-    existing_shipments: Enví existentes
     failed_payment_attempts: Intentos fallidos de pago
     filename: Nombre de Archivo
     fill_in_customer_info: Por favor rellena información del cliente
     filter: Filtro
     filter_results: Filtrar resultados
     finalize: Finalizar
-    find_a_taxon: Encontrar una Clasificación
     finalized: Finalizado
+    find_a_taxon: Encontrar una Clasificación
     first_item: Primer artículo
     first_name: Nombre
     first_name_begins_with: Nombre comienza por
     flat_percent: Porcentaje fijo
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Tarifa plana (por pedido)
     flexible_rate: Tarifa flexible
     forgot_password: "¿Olvidaste la Contraseña?"
@@ -701,6 +790,7 @@ es-CL:
     free_shipping_amount: "-"
     front_end: Front End
     gateway: Gateway
+    gateway_config_unavailable: TODO_TRANSLATE
     gateway_error: Error en Gateway
     general: General
     general_settings: Preferencias en general
@@ -710,6 +800,7 @@ es-CL:
     guest_user_account: Comprobación como invitado
     has_no_shipped_units: No tiene unidades enviadas
     height: Altura
+    hide_cents: TODO_TRANSLATE
     home: Inicio
     i18n:
       available_locales: Locales Disponibles
@@ -720,24 +811,28 @@ es-CL:
       only_incomplete: Sólo incompletas
       select_locale: Seleccionar Localización
       show_only: Sólo mostrar
-      store_translations:
+      store_translations: TODO_TRANSLATE
       supported_locales: Localizaciónes Soportadas
       this_file_language: Español (Chile)
       translations: Traducciones
     icon: Icono
+    identifier: TODO_TRANSLATE
     image: Imagen
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Imágenes
-    implement_eligible_for_return: "Debe implementar #eligible_for_return? para su EligibilityValidator."
-    implement_requires_manual_intervention: "Debe implmentar #requires_manual_intervention? para su EligibilityValidator."
+    implement_eligible_for_return: 'Debe implementar #eligible_for_return? para su EligibilityValidator.'
+    implement_requires_manual_intervention: 'Debe implmentar #requires_manual_intervention? para su EligibilityValidator.'
     inactive: Inactivo
     incl: incl.
     included_in_price: Incluido en el precio
     included_price_validation: No puede ser seleccionado a menos que establezcas una Zona de Impuesto por defecto
     incomplete: Incompleto
-    info_product_has_multiple_skus: "Este producto tiene %{count} variantes:"
     info_number_of_skus_not_shown:
-      one: "y otro"
-      other: "y %{count} otros"
+      one: y otro
+      other: y %{count} otros
+    info_product_has_multiple_skus: 'Este producto tiene %{count} variantes:'
     instructions_to_reset_password: Por favor ingresa tu e-mail en el siguiente formulario
     insufficient_stock: Stock insuficiente, sólo %{on_hand} restante
     insufficient_stock_lines_present: Algunos artículos de este pedido no tienen la cantidad suficiente.
@@ -766,8 +861,8 @@ es-CL:
         lte: Menor o igual que
     items_cannot_be_shipped: No es posible enviar los elementos seleccionados a su dirección de entrega. Por favor indica otra dirección de entrega.
     items_in_rmas: Artículos de devolución autorizados
-    items_to_be_reimbursed: Los productos que se reembolsarán
     items_reimbursed: Artículos Reembolsados
+    items_to_be_reimbursed: Los productos que se reembolsarán
     jirafe: Jirafe
     landing_page_rule:
       path: Ruta
@@ -775,14 +870,19 @@ es-CL:
     last_name_begins_with: Apellido comienza con
     learn_more: Aprender más
     lifetime_stats: Estadísticas de por vida
-    line_item_adjustments: "Line item adjustments"
+    line_item_adjustments: Line item adjustments
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Cargando
     locale_changed: Idioma cambiado
     location: Localización
     lock: Bloquear
-    log_entries: "Registros de entrada"
-    logs: Registros
+    log_entries: Registros de entrada
     logged_in_as: Identificado como
     logged_in_succesfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
@@ -791,12 +891,16 @@ es-CL:
     login_failed: No se ha podido iniciar la sesión, error de autenticación.
     login_name: E-Mail
     logout: Cerrar sesión
+    logs: Registros
     look_for_similar_items: Buscar artículos similares
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Realizar devolución
     make_sure_the_above_reimbursement_amount_is_correct: Asegúrese de que el valor del reembolso de arriba es correcto
     manage_promotion_categories: Administrar las categorías de promoción
-    manual_intervention_required: Requiere intervención manual
     manage_variants: Administrar Variantes
+    manual_intervention_required: Requiere intervención manual
     master_price: Precio principal
     match_choices:
       all: Todos
@@ -819,9 +923,9 @@ es-CL:
     name_or_sku: Nombre o SKU (introducir al menos los 4 primeros caracteres o nombre del producto)
     new: Nuevo
     new_adjustment: Nuevo Ajuste
+    new_country: Nuevo País
     new_customer: Nuevo Cliente
     new_customer_return: Nueva devolución del cliente
-    new_country: Nuevo País
     new_image: Nueva Imagen
     new_option_type: Nuevo Tipo de Opción
     new_order: Nuevo Pedido
@@ -835,12 +939,12 @@ es-CL:
     new_prototype: Nuevo prototipo
     new_refund: Nuevo reembolso
     new_refund_reason: Nueva razón de reembolso
-    new_rma_reason: Nueva razón de RMA
     new_return_authorization: Nueva autorización de devolución
+    new_rma_reason: Nueva razón de RMA
     new_role: Nuevo Rol
+    new_shipment_at_location: Nueva Ubicación de envío
     new_shipping_category: Nueva categoría de envío
     new_shipping_method: Nueva forma de envío
-    new_shipment_at_location: Nueva Ubicación de envío
     new_state: Nuevo estado
     new_stock_location: Nueva localización de stock
     new_stock_movement: Nuevo movimiento de stock
@@ -855,20 +959,26 @@ es-CL:
     new_zone: Nueva Zona
     next: Siguiente
     no_actions_added: No hay acciones añadidas
+    no_orders_found: TODO_TRANSLATE
     no_payment_found: No hay pagos encontrados
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: No hay pagos pendientes
     no_products_found: No se encontraron productos
-    no_results: Sin resultados
-    no_rules_added: No se añadieron reglas
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: No se encontraron %{resource}
-    no_returns_found:  No se encontraron reembolsos
+    no_results: Sin resultados
+    no_returns_found: No se encontraron reembolsos
+    no_rules_added: No se añadieron reglas
     no_shipping_method_selected: Ningún método de envío seleccionado.
+    no_shipping_methods_found: TODO_TRANSLATE
     no_state_changes: Ningún estado cambia todavía.
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: No se proporcionaron detalles del tracking
     none: Ninguno
     none_selected: Ninguno seleccionado
     normal_amount: Valor normal
-    not: No
+    not: false
     not_available: No disponible
     not_enough_stock: No hay suficiente stock en la Ubicación para completar esta transferencia
     not_found: No se encontró %{resource}
@@ -920,6 +1030,10 @@ es-CL:
         total: 'Total Pedido:'
     order_not_found: No pudimos encontrar tu pedido. Por favor intenta esta acción de nuevo
     order_number: Pedido %{number}
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Tu pedido ha sido procesado con éxito
     order_resumed: Resumen del pedido
     order_state:
@@ -927,9 +1041,9 @@ es-CL:
       awaiting_return: esperando devolución
       canceled: cancelada
       cart: carrito
-      considered_risky: Considerado riesgoso
       complete: completado
       confirm: Confirmada
+      considered_risky: Considerado riesgoso
       delivery: Entrega
       payment: Pago
       resumed: reanudado
@@ -944,7 +1058,9 @@ es-CL:
     overview: Overview
     package_from: paquete desde
     pagination:
+      first: TODO_TRANSLATE
       next_page: siguiente página »
+      previous: TODO_TRANSLATE
       previous_page: "« página anterior"
       truncate: "…"
     password: Contraseña
@@ -953,10 +1069,11 @@ es-CL:
     pay: pagar
     payment: Pago
     payment_could_not_be_created: El pago no se ha podido crear.
+    payment_identifier: TODO_TRANSLATE
     payment_information: Información del Pago
     payment_method: Medio de Pago
-    payment_methods: Medios de Pago
     payment_method_not_supported: Medio de Pago no soportado, por favo seleccione otro.
+    payment_methods: Medios de Pago
     payment_processing_failed: El pago no pudo ser procesado, por favor comprueba los detalles que has ingresado
     payment_processor_choose_banner_text: Si necesitas ayuda a la hora de escojer un procesador de pago, por favor visita
     payment_processor_choose_link: nuestra pagina de pagos
@@ -973,23 +1090,23 @@ es-CL:
       void: anular
     payment_updated: Pago actualizado
     payments: Pagos
+    pending: Pendiente
     percent: Porcentaje
     percent_per_item: Porcentaje por artículo
     permalink: Permalink
-    pending: Pendiente
     phone: Teléfono
     place_order: Realizar Pedido
     please_define_payment_methods: Por favor define algún medio de pago primero
     please_enter_reasonable_quantity: Por favor introduzca una cantidad razonable.
     populate_get_error: Se produjo un error. Por favor intenta añadir el artículo otra vez.
     powered_by: Desarrollado por
-    pre_tax_refund_amount: Pre-Tax Valor devolución
     pre_tax_amount: Pre-Tax Valor
+    pre_tax_refund_amount: Pre-Tax Valor devolución
     pre_tax_total: Pre-Tax Total
     preferred_reimbursement_type: Tipo preferido de Reembolso
     presentation: Presentación
     previous: Anterior
-    previous_state_missing: "n/a"
+    previous_state_missing: n/a
     price: Precio
     price_range: Rango de precios
     price_sack: Precio Sack
@@ -1010,7 +1127,6 @@ es-CL:
         manual: Escoje manualmente
     products: Productos
     promotion: Promoción
-    promotionable: Promocionable
     promotion_action: Acción de promoción
     promotion_action_types:
       create_adjustment:
@@ -1025,13 +1141,16 @@ es-CL:
       free_shipping:
         description: Envío Gratis
         name: Envío Gratis
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Acciones
     promotion_category: Categoría de promoción
     promotion_form:
       match_policies:
         all: Cumple todas estas reglas
         any: Cumple cualquiera de estas reglas
-    promotion_label: 'Promoción (%{name})'
+    promotion_label: Promoción (%{name})
     promotion_rule: Regla de promoción
     promotion_rule_types:
       first_order:
@@ -1052,17 +1171,18 @@ es-CL:
       product:
         description: El pedido incluye productos específicos
         name: Producto(s)
+      taxon:
+        description: Pedido incluye productos de una clasificación(es) especifica(s)
+        name: Taxón
       user:
         description: Disponible solamente a usuarios específicos
         name: Usuario
       user_logged_in:
         description: Disponible solamente a usuarios registrados
         name: Usuario registrado
-      taxon:
-        description: Pedido incluye productos de una clasificación(es) especifica(s)
-        name: Taxón
-    promotions: Promociones
     promotion_uses: Usos de promoción
+    promotionable: Promocionable
+    promotions: Promociones
     propagate_all_variants: Propagar todas las Variantes
     properties: Propiedades
     property: Propiedad
@@ -1093,7 +1213,17 @@ es-CL:
     reimburse: Reembolsar
     reimbursed: Reembolsado
     reimbursement: Reembolso
-    reimbursement_perform_failed: "El reembolso no pudo realizarse.  Error: %{error}"
+    reimbursement_mailer:
+      reimbursement_email:
+        days_to_send: "'Usted tiene %{days} días para devolver cualquier artículo que esperé cambiar.'"
+        dear_customer: Estimado cliente,
+        exchange_summary: Resumen del Cambio
+        for: para
+        instructions: Su reembolso ha sido procesado.
+        refund_summary: Resumen de Reembolso
+        subject: Notificación de Reembolso
+        total_refunded: "'Total Reembolsado: %{total}'"
+    reimbursement_perform_failed: 'El reembolso no pudo realizarse.  Error: %{error}'
     reimbursement_status: Estado del reembolso
     reimbursement_type: Tipo reembolso
     reimbursement_type_override: Tipo de anulación de reembolso
@@ -1114,7 +1244,7 @@ es-CL:
     resumed: Resumido
     return: Volver
     return_authorization: Autorización para devolución
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Autorización para devolución actualizada
     return_authorizations: Autorizaciones para devolución
     return_item_inventory_unit_ineligible: Return item's inventory unit must be shipped
@@ -1124,16 +1254,6 @@ es-CL:
     return_item_time_period_ineligible: Return item is outside the eligible time period
     return_items: Artículos devueltos
     return_items_cannot_be_associated_with_multiple_orders: Los artículos de vuelta no se pueden asociar con varios pedidos.
-    reimbursement_mailer:
-      reimbursement_email:
-        days_to_send: "'Usted tiene %{days} días para devolver cualquier artículo que esperé cambiar.'"
-        dear_customer: Estimado cliente,
-        exchange_summary: Resumen del Cambio
-        for: para
-        instructions: Su reembolso ha sido procesado.
-        refund_summary: Resumen de Reembolso
-        subject: Notificación de Reembolso
-        total_refunded: "'Total Reembolsado: %{total}'"
     return_number: Número devolución
     return_quantity: Cantidad de devolución
     returned: Devuelto
@@ -1148,17 +1268,22 @@ es-CL:
     role_id: Role ID
     roles: Roles
     rules: Reglas
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
     safe: Seguro
     sales_total: Total de venta
     sales_total_description: Total de ventas de todos los pedidos
     sales_totals: Totales de ventas
     save_and_continue: Guardar y Continuar
     save_my_address: Guardar mi dirección
-    say_no: No
+    say_no: false
     say_yes: Si
     scope: Alcance
     search: Buscar
-    search_results: "Resultados para las búsqueda de '%{keywords}'"
+    search_results: Resultados para las búsqueda de '%{keywords}'
     searching: Buscando
     secure_connection_type: Tipo de conexión segura
     security_settings: Configuración de seguridad
@@ -1167,7 +1292,7 @@ es-CL:
     select_a_stock_location: Seleccione una ubicación de stock
     select_from_prototype: Seleccionar desde el prototipo
     select_stock: Seleccionar Stock
-    selected_quantity_not_available: 'El artículo %{item} no está disponible.'
+    selected_quantity_not_available: El artículo %{item} no está disponible.
     send_copy_of_all_mails_to: Enviar copia de todos los emails a
     send_mails_as: Enviar emails como
     server: Servidor
@@ -1177,8 +1302,9 @@ es-CL:
     ship_address: Dirección de envío
     ship_total: Total de envío
     shipment: Envío
-    shipment_adjustments: "Ajustes de envío"
-    shipment_details: "Desde %{stock_location} por %{shipping_method}"
+    shipment_adjustments: Ajustes de envío
+    shipment_details: Desde %{stock_location} por %{shipping_method}
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Estimado Cliente,\n
@@ -1196,8 +1322,8 @@ es-CL:
       pending: Pendiente
       ready: Listo
       shipped: Enviado
-    shipment_transfer_success: 'Transferido con éxito'
-    shipment_transfer_error: 'Hubo un error al transferir'
+    shipment_transfer_error: Hubo un error al transferir
+    shipment_transfer_success: Transferido con éxito
     shipments: Envíos
     shipped: Enviado
     shipping: Envío
@@ -1213,8 +1339,8 @@ es-CL:
     shipping_price_sack: Precio empaque
     shipping_rates:
       display_price:
-        including_tax: "%{price} (incl. %{tax_amount} %{tax_rate_name})"
         excluding_tax: "%{price} (+ %{tax_amount} %{tax_rate_name})"
+        including_tax: "%{price} (incl. %{tax_amount} %{tax_rate_name})"
     shipping_total: Total envío
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrito de compra
@@ -1227,16 +1353,27 @@ es-CL:
     sku: SKU
     skus: SKUs
     slug: Slug
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Fuente
     special_instructions: Instrucciones especiales
     split: Dividir
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Hubo un problema con tu información de pago. Por favor revisa tu información e intentado de nuevo
     ssl:
-      change_protocol: "Por favor cambia a HTTP (en lugar de HTTPS) y vuelve a intentar."
+      change_protocol: Por favor cambia a HTTP (en lugar de HTTPS) y vuelve a intentar.
     start: Empezar
+    start_date: TODO_TRANSLATE
     state: Estado
     state_based: Estado basado
-    states: Estados
     state_machine_states:
       accepted: Aceptado
       address: Dirección
@@ -1244,22 +1381,22 @@ es-CL:
       awaiting: Esperando
       awaiting_return: Esperando devolución
       backordered: Pendiente de entrega
-      cart: Carrito
       canceled: Cancelado
+      cart: Carrito
       checkout: Revisar
-      confirm: Confirmar
+      closed: Cerrado
       complete: Completo
       completed: Completado
-      closed: Cerrado
+      confirm: Confirmar
       delivery: Entrega
       errored: Con errores
       failed: Fracasado
       given_to_customer: Entregado al cliente
       invalid: Inválido
       manual_intervention_required: Requiere intervención manual
+      on_hand: En mano
       open: Abierto
       order: Pedido
-      on_hand: En mano
       payment: Pago
       pending: Pendiente
       processing: Processing
@@ -1269,6 +1406,7 @@ es-CL:
       returned: Devuelto
       shipped: Transportado
       void: Vacío
+    states: Estados
     states_required: Provincias requeridas
     status: Estado
     stock: Stock
@@ -1289,7 +1427,7 @@ es-CL:
     street_address_2: Calle de referencia
     subtotal: Subtotal
     subtract: Restar
-    success: Éxito
+    success: "Éxito"
     successfully_created: "%{resource} ha sido creado con éxito"
     successfully_refunded: "%{resource} ha sido devuelto con éxito"
     successfully_removed: "%{resource} ha sido eliminado con éxito"
@@ -1297,12 +1435,14 @@ es-CL:
     successfully_updated: "%{resource} ha sido actualizado con éxito"
     summary: Resumen
     tax: Impuesto
-    tax_included: "Impuesto (incl.)"
     tax_categories: Categorías de impuestos
     tax_category: Categoría impuesto
     tax_code: Código de impuesto
-    tax_rate_amount_explanation: "Las tarifas de impuestos son numeros decimales (p. ej. si la tarifa de impuesto es del 5%, introducir 0.05)"
+    tax_included: Impuesto (incl.)
+    tax_rate_amount_explanation: Las tarifas de impuestos son numeros decimales (p. ej. si la tarifa de impuesto es del 5%, introducir 0.05)
     tax_rates: Tarifas de impuesto
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Clasificación
     taxon_edit: Editar Clasificación
     taxon_placeholder: Añadir Clasificación
@@ -1319,6 +1459,9 @@ es-CL:
     taxons: Clasificaciónes
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Felicidades!
         message: Si has recibido este email, entonces tus preferencias de email son correctas
@@ -1348,7 +1491,7 @@ es-CL:
     transfer_from_location: Transferido desde
     transfer_stock: Transferencia de Stock
     transfer_to_location: Transferido a
-    tree: Árbol
+    tree: "Árbol"
     type: Tipo
     type_to_search: Tipo a buscar
     unable_to_connect_to_gateway: No es posible la conexión a la pasarela
@@ -1371,13 +1514,14 @@ es-CL:
       choose_users: Escoje Usuarios
     users: Usuarios
     validation:
-      unpaid_amount_not_zero: "La cantidad no fue totalmente reembolsada. Aún así: % {amount}"
       cannot_be_less_than_shipped_units: no puede ser menor que el número de unidades enviadas.
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       cannot_destroy_line_item_as_inventory_units_have_shipped: No se puede eliminar artículo ya que algunas unidades se han enviado.
       exceeds_available_stock: excede el stock disponible. Por favor asegúrate que los artículos tienen un cantidad válida.
       is_too_large: demasiado grande -- el stock disponible no puede cubrir la cantidad solicitada
       must_be_int: debe ser un número entero
       must_be_non_negative: debe ser un valor positivo
+      unpaid_amount_not_zero: 'La cantidad no fue totalmente reembolsada. Aún así: % {amount}'
     value: Valor
     variant: Variante
     variant_placeholder: Escoje una variante
@@ -1396,9 +1540,10 @@ es-CL:
     zipcode: Código Postal
     zone: Zona
     zones: Zonas
+  update: TODO_TRANSLATE
   views:
     pagination:
       first: Primera
-      previous: Anterior
+      last: "Última"
       next: Siguiente
-      last: Última
+      previous: Anterior

--- a/config/locales/es-EC.yml
+++ b/config/locales/es-EC.yml
@@ -1,4 +1,6 @@
+---
 es-EC:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ es-EC:
         state: Provincia ó Estado
         zipcode: Código Postal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ es-EC:
         name: Nombre
         numcode: Código ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tipo
         month: Mes
-        name:
+        name: TODO_TRANSLATE
         number: Número
         verification_value: Valor verificación
         year: Año
@@ -42,7 +44,7 @@ es-EC:
       spree/order:
         checkout_complete: Completar Pedido
         completed_at: Completado En
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: Código Cupón
         created_at: Fecha del Pedido
         email: Email del Cliente
@@ -72,6 +74,7 @@ es-EC:
         zipcode: Código postal dirección envío
       spree/payment:
         amount: Cuantía
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nombre
       spree/product:
@@ -95,7 +98,8 @@ es-EC:
         starts_at: Empieza en
         usage_limit: Limite de Uso
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Nombre
         presentation: Presentación
@@ -105,24 +109,26 @@ es-EC:
         amount: Cuantía
       spree/role:
         name: Nombre
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abreviatura
         name: Nombre
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Descripción
         name: Nombre
@@ -157,48 +163,54 @@ es-EC:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: La Tarjeta ha expirado
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Dirección.
         other: Direcciones
@@ -208,43 +220,45 @@ es-EC:
       spree/credit_card:
         one: Tarjeta de Crédito.
         other: Tarjetas de Crédito
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Unidad de inventario.
         other: Unidades de inventario
       spree/line_item:
         one: Línea de pedido
         other: Líneas de pedido
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Pedido
         other: Pedidos
       spree/payment:
         one: Pago
         other: Pagos
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Producto
         other: Productos
       spree/promotion:
         one: Promoción
         other: Promociones
-      spree/promotion_category:
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Propiedad
         other: Propiedades
       spree/prototype:
         one: Prototipo
         other: Propotipos
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Autorización para devolución
         other: Autorizaciones para devolución
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Función
         other: Funciones
       spree/shipment:
@@ -253,14 +267,14 @@ es-EC:
       spree/shipping_category:
         one: Categoría de envío
         other: Categorías de envío
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Provincia
         other: Provincias
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Categoría fiscal
         other: Categorías fiscales
@@ -273,7 +287,7 @@ es-EC:
       spree/taxonomy:
         one: Categoría
         other: Categorías
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Usuario
         other: Usuarios
@@ -283,6 +297,9 @@ es-EC:
       spree/zone:
         one: Zona
         other: Zonas
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Tu cuenta fue confirmada satisfactoriamente. Ya estás registrado.
@@ -321,6 +338,7 @@ es-EC:
     user_sessions:
       signed_in: Registrado satisfactoriamente.
       signed_out: Abandonado satisfactoriamente.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: fue ya confirmada.
@@ -329,12 +347,30 @@ es-EC:
       not_saved:
         one: 1 error evitó que este %{resource} fuese grabado.
         other: "%{count} errores evitaron que este %{resource} fuese grabado:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abreviatura
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Cuenta
     account_updated: Cuenta actualizada
     action: Acción
@@ -347,7 +383,7 @@ es-EC:
       list: Listar
       listing: Listando
       new: Nuevo
-      refund:
+      refund: TODO_TRANSLATE
       save: Guardar
       update: Actualizar
     activate: Activar
@@ -355,7 +391,7 @@ es-EC:
     add: Añadir
     add_action_of_type: Añadir acción del tipo
     add_country: Añadir País
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Añadir nueva cabecera
     add_new_style: Añadir nuevo estilo
     add_one: Añadir uno
@@ -369,11 +405,16 @@ es-EC:
     add_to_cart: Añadir al carrito
     add_variant: Añadir variante
     additional_item: Coste de artículo adicional
+    address: TODO_TRANSLATE
     address1: Dirección
     address2: Dirección (cont.)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Ajuste
     adjustment_amount: Cuantía
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: El ajuste ha sido cerrado satisfactoriamente
     adjustment_successfully_opened: El ajuste ha sido abierto satisfactoriamente
     adjustment_total: Total del ajuste
@@ -381,35 +422,35 @@ es-EC:
     admin:
       tab:
         configuration: Configuración
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: Pedidos
         overview: Visión general
         products: Productos
         promotions: Promociones
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: Informes
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Usuarios
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administración
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: De acuerdo con la politica de privacidad.
     agree_to_terms_of_service: De acuerdo con las condiciones de uso
     all: Todos
     all_adjustments_closed: Todos los ajustes cerrados satisfactoriamente
     all_adjustments_opened: Todos los ajustes abiertos satisfactoriamente
     all_departments: Todos los departamentos
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Permitir SSL en modo desarrollo y pruebas
     allow_ssl_in_production: Permitir SSL en producción
     allow_ssl_in_staging: Permitir SSL en modo staging
@@ -425,70 +466,104 @@ es-EC:
     analytics_desc_list_4: Es completamente gratuito!
     analytics_trackers: Analytics Trackers
     and: y
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: "¿Estás seguro?"
     are_you_sure_delete: "¿Estás seguro de que quieres borrar este registro?"
     associated_adjustment_closed: El ajuste asociado está cerrado y no será recalculado. ¿Quieres abrirlo?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Fallo en la autorización
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Disponible
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Volver
     back_end: Parte interna
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Volver a la Tienda
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Volver a Listado de Usuarios
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Devuelto
-    backorderable_default:
-    backordered:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
     backorders_allowed: Permitida la Devolucion
     balance_due: Saldo adeudado
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Dirección de facturación
     billing: Facturación
     billing_address: Dirección de facturación
     both: Ambos
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculador
     calculator_settings_warning: Si cambias el tipo de calculador, debes guardar primero antes de editar las preferencias del calculador
     cancel: Cancelar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: No puedes crear un pago para un pedido sin antes definir un método de pago
     cannot_create_returns: No puedes crear devoluciones para un pedido que no tiene unidades enviadas
     cannot_perform_operation: No se pudo realizar la operación solicitada
     cannot_set_shipping_method_without_address: No se puede establecer el método de envío hasta que no se proporcionen los detalles del cliente.
     capture: Captura
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Código de tarjeta
     card_number: Número de tarjeta
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Tipo de tarjeta es
     cart: Carrito
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categorías
     category: Categoría
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Comprobar alertas de Spre
     checkout: Realizar pedido
     choose_a_customer: Escoge un cliente
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Escoge moneda
     choose_dashboard_locale: Escoge idioma del Panel de Instrumentos
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Ciudad
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clonar
     close: Cerrar
     close_all_adjustments: Cerrar todos los ajustes
@@ -497,6 +572,7 @@ es-EC:
     complete: Completar
     configuration: Configuración
     configurations: Configuraciones
+    configure_s3: TODO_TRANSLATE
     confirm: Confirmar
     confirm_delete: Confimar borrado
     confirm_password: Confirmación del Password
@@ -505,7 +581,7 @@ es-EC:
     cost_currency: Moneda de costo
     cost_price: Precio de costo
     could_not_connect_to_jirafe: No se pudo conectar a Jirafe para sincronizar los datos. Se intentará más tarde automáticamente.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Hubo un problema grabando este movimiento de stock. Por favor inténtalo otra vez.
     count_on_hand: Disponible
     countries: Países
@@ -513,10 +589,10 @@ es-EC:
     country_based: País base
     country_name: Nombre
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Cupón
     coupon_code: Código Cupón
     coupon_code_already_applied: El código del cupón ya ha sido aplicado a este pedido
@@ -526,17 +602,17 @@ es-EC:
     coupon_code_max_usage: Excedido el limite de uso del código del cupón
     coupon_code_not_eligible: Este código de cupón no es elegible para este pedido
     coupon_code_not_found: El código del cupón que has introducido no existe. Inténtalo de nuevo.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Crear
     create_a_new_account: Crear una nueva cuenta
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Creada
     credit: Crédito
     credit_card: Tarjeta de Crédito
     credit_cards: Tarjetas de Crédito
     credit_owed: Crédito adeudado
-    credits:
+    credits: TODO_TRANSLATE
     currency: Moneda
     currency_decimal_mark: Marca decimal de moneda
     currency_settings: Parámetros de moneda
@@ -547,11 +623,11 @@ es-EC:
     customer: Cliente
     customer_details: Detalles del Cliente
     customer_details_updated: Detalles del Cliente actualizado
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Búsqueda del Cliente
     cut: Cortar
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: ID App
@@ -570,41 +646,60 @@ es-EC:
       js_format: dd/mm/yy
     date_range: Rango de fechas
     default: Por defecto
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Tasa por defecto
     default_tax_zone: Zona de tasa por defecto
     delete: Borrar
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Entregar
     depth: Ancho
     description: Descripción
     destination: Destino
     destroy: Eliminar
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Cuantía descuento
     dismiss_banner: No. Gracias! No estoy interesado, no mostrar este mensaje otra vez
     display: Mostrar
     display_currency: Moneda a mostrar
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Editar
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editando Usuario
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Vacío
     empty_cart: Carrito vacío
@@ -637,28 +732,30 @@ es-EC:
           signup: Dar de alta Usuario
     exceptions:
       count_on_hand_setter: No se pudo establecer count_on_hand manualmente, ya que está establecido automáticamente por la callback recalculate_count_on_hand. Por favor utiliza `update_column(:count_on_hand, value)` en vez de ello.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Vencimiento
     extension: Extensión
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Nombre de Fichero
     fill_in_customer_info: Por favor rellena información del cliente
+    filter: TODO_TRANSLATE
     filter_results: Filtrar resultados
     finalize: Finalizar
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Coste del primer artículo
     first_name: Nombre
     first_name_begins_with: Nombre comienza por
     flat_percent: Porcentaje fijo
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Tarifa plana (por pedido)
     flexible_rate: Tarifa flexible
     forgot_password: "¿Olvidaste el password?"
     free_shipping: Envío gratuito
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Parte delantera
     gateway: Pasarela
     gateway_config_unavailable: Pasarela no disponible para entorno
@@ -682,37 +779,41 @@ es-EC:
       only_incomplete: Sólo incompletos
       select_locale: Seleccionar Locale
       show_only: Sólo mostrar
+      store_translations: TODO_TRANSLATE
       supported_locales: Locales Soportados
       this_file_language: Español
       translations: Traducciones
     icon: Icono
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Imagen
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Imágenes
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Incluido en el precio
     included_price_validation: No puede ser seleccionado a menos que establezcas una Zona de Tasa por defecto
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: Por favor introduce tu nombre en el siguiente formulario
     insufficient_stock: Stock disponible insuficiente, sólo %{on_hand} restante
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Interceptar Dirección Email
     intercept_email_instructions: Sobrescribe correo electrónico del destinatario y reemplázalo con esta dirección.
     internal_name: Nombre interno
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Proveedor de pago inválido
     invalid_promotion_action: Acción de promoción inválida
     invalid_promotion_rule: Regla de promoción inválida
     inventory: Inventario
     inventory_adjustment: Ajuste de inventario
     inventory_error_flash_for_insufficient_quantity: Un artículo de tu carrito ha dejado de estar disponible.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: no está disponible para la dirección de envío
     iso_name: Nombre ISO
     item: Artículo
@@ -722,26 +823,32 @@ es-EC:
       operators:
         gt: Mayor que
         gte: Mayor que o igual a
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: No es posible enviar los elementos seleccionados a su dirección de entrega. Por favor indica otra dirección de entrega.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Ruta
     last_name: Apellidos
     last_name_begins_with: Apellido comienza con
     learn_more: Aprender más
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Carga
     locale_changed: Idioma cambiado
     location: Localización
     lock: Bloquear
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Identificado como
     logged_in_succesfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
@@ -750,23 +857,26 @@ es-EC:
     login_failed: No se ha podido iniciar la sesión, error de autenticación.
     login_name: Validación
     logout: Cerrar sesión
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Buscar artículos similares
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Realizar devolución
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Precio principal
     match_choices:
       all: Todos
       none: Ninguno
     max_items: Máximo Artículos
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Descripción Meta
     meta_keywords: Keywords Meta
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Cuantía mínima
     month: Mes
@@ -775,13 +885,13 @@ es-EC:
     my_account: Mi Cuenta
     my_orders: Mis Pedidos
     name: Nombre
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Nombre o SKU (introducir al menos los 4 primeros caracteres o nombre del producto)
     new: Nuevo
     new_adjustment: Nuevo Ajuste
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Nuevo Cliente
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nueva Imagen
     new_option_type: Nuevo Tipo de Opción
     new_order: Nuevo Pedido
@@ -790,14 +900,15 @@ es-EC:
     new_payment_method: Nueva forma de pago
     new_product: Nuevo producto
     new_promotion: Nueva promoción
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nueva propiedad
     new_prototype: Nuevo prototipo
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Nueva autorización de devolución
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Nueva categoría de envío
     new_shipping_method: Nueva forma de envío
     new_state: Nueva provincia
@@ -814,24 +925,30 @@ es-EC:
     new_zone: Nueva Zona
     next: Siguiente
     no_actions_added: No acciones añadidas
-    no_payment_found:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: No hay pagos pendientes
     no_products_found: No se encontraron productos
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: No se encontraron %{resource}
     no_results: sin resultados
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: No se añadieron reglas
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: No se proporcionaron detalles del tracking
     none: Ninguno
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Cuantía normal
     not: false
     not_available: No disponible
     not_enough_stock: No hay suficiente inventario en la localización fuente para completar esta transferencia
     not_found: No se encontró %{resource}
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: El producto ha sido clonado
       product_deleted: El producto ha sido borrado
@@ -839,7 +956,7 @@ es-EC:
       product_not_deleted: El producto no pudo ser borrado
       variant_deleted: La Variante ha sido borrada
       variant_not_deleted: La Variante no pudo ser borrada
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Disponible
     open: Abrir
     open_all_adjustments: Abrir todos los ajustes
@@ -854,32 +971,37 @@ es-EC:
     or_over_price: "%{price} ó más"
     order: Pedido
     order_adjustments: Ajustes de pedido
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Detalles del pedido
     order_email_resent: Email de pedido reenviado
     order_information: Información del pedido
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Estimado cliente,\n
         instructions: Tu pedido ha sido CANCELADO. Por favor conserva esta información de cancelación para tus registros.
         order_summary_canceled: Resumen de pedido [CANCELADO]
         subject: Cancelación de pedido
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Estimado Cliente,\n
         instructions: Por favor, revisa y conserva la siguiente información del pedido de tus registros.
         order_summary: Resumen del pedido
         subject: Confirmación del pedido
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: "¡Gracias por su compra!"
-        total:
+        total: TODO_TRANSLATE
     order_not_found: No pudimos encontrar tu pedido. Por favor intenta esta acción de nuevo
-    order_number:
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Tu pedido ha sido procesado con éxito
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: Dirección
       awaiting_return: Esperando devolución
@@ -887,7 +1009,7 @@ es-EC:
       cart: Carrito
       complete: completado
       confirm: Confirmada
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: Entrega
       payment: Pago
       resumed: reanudado
@@ -897,12 +1019,14 @@ es-EC:
     order_total: Total Pedido
     order_updated: Pedido actualizado
     orders: Pedidos
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Fuera de stock
     overview: Visión de conjunto
     package_from: paquete desde
     pagination:
+      first: TODO_TRANSLATE
       next_page: siguiente página »
+      previous: TODO_TRANSLATE
       previous_page: "« página anterior"
       truncate: "…"
     password: Password
@@ -910,11 +1034,11 @@ es-EC:
     path: Ruta
     pay: pagar
     payment: Pago
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Información del Pago
     payment_method: Método de Pago
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Métodos de Pago
     payment_processing_failed: El pago no pudo ser procesado, por favor comprueba los detalles que has introducido
     payment_processor_choose_banner_text: Si necesitas ayuda a la hora de escoger un procesador de pago, por favor visita
@@ -932,22 +1056,23 @@ es-EC:
       void: anular
     payment_updated: Pago actualizado
     payments: Pagos
-    pending:
+    pending: TODO_TRANSLATE
     percent: Porcentaje
     percent_per_item: Porcentaje por artículo
     permalink: Permalink
     phone: Teléfono
     place_order: Ponga el pedido
     please_define_payment_methods: Por favor define algún método de pago primero
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Algo fue mal. Por favor intenta añadir el artículo otra vez.
     powered_by: Desarrollado por
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentación
     previous: Previo
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Precio
     price_range: Rango de precios
     price_sack: Saco de precios
@@ -959,10 +1084,10 @@ es-EC:
     product_properties: Propiedades del producto
     product_rule:
       choose_products: Escoge productos
-      label:
+      label: TODO_TRANSLATE
       match_all: Todos
       match_any: al menos uno
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Desde grupo de producto
         manual: Escoge manualmente
@@ -974,19 +1099,24 @@ es-EC:
         description: Crea un ajuste de crédito en la promoción en el pedido
         name: Crear ajuste
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Rellena el carrito con la cuantía especificada de la variante
         name: Crea líneas de artículos
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Acciones
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Cumple todas estas reglas
         any: Cumple cualquiera de estas reglas
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Regla de promoción
     promotion_rule_types:
       first_order:
@@ -999,27 +1129,27 @@ es-EC:
         description: El ciente debe haber visitado la página especificada
         name: Página de destino
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: El pedido incluye productos específicos
         name: Producto(s)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Disponible solamente a usuarios específicos
         name: Usuario
       user_logged_in:
         description: Disponible solamente a usuarios autorizados
         name: Usuario autorizado
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promociones
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Propiedades
     property: Propiedad
     prototype: Prototipo
@@ -1030,47 +1160,49 @@ es-EC:
     quantity: Cantidad
     quantity_returned: Cantidad devuelta
     quantity_shipped: Cantidad enviada
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Tarifa
     reason: Razón
     receive: recibir
     receive_stock: Recibir Stock
     received: Recibido
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Referencia
+    reference_contains: TODO_TRANSLATE
     refund: Devolución
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registrar
     registration: Registro
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Recuérdame
     remove: Quitar
     rename: Renombrar
-    report:
+    report: TODO_TRANSLATE
     reports: Informes
+    resellable: TODO_TRANSLATE
     resend: Reenviar
     reset_password: Reinicializar password
     response_code: Código de respuesta
@@ -1078,34 +1210,41 @@ es-EC:
     resumed: Resumido
     return: Volver
     return_authorization: Autorización para devolución
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Autorización para devolución actualizada
     return_authorizations: Autorizaciones para devolución
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Cantidad de devolución
     returned: Devuelto
-    returns:
+    returns: TODO_TRANSLATE
     review: Revisar
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: Crédito RMA
     rma_number: Número RMA
     rma_value: Valor RMA
+    role_id: TODO_TRANSLATE
     roles: Funciones
     rules: Reglas
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Total de ventas
     sales_total_description: Total de ventas de todos los pedidos
     sales_totals: Totales de ventas
     save_and_continue: Guardar y continuar
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: false
     say_yes: Si
     scope: Alcance
@@ -1115,10 +1254,11 @@ es-EC:
     secure_connection_type: Tipo de conexión segura
     security_settings: Preferencias de seguridad
     select: Seleccionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Seleccionar desde el prototipo
     select_stock: Seleccionar Stock
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Enviar copia de todos los emails a
     send_mails_as: Enviar emails como
     server: Servidor
@@ -1128,8 +1268,9 @@ es-EC:
     ship_address: Dirección de envío
     ship_total: Total de envío
     shipment: Envío
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Estimado Cliente,\n
@@ -1142,13 +1283,13 @@ es-EC:
     shipment_state: Estado del envío
     shipment_states:
       backorder: Pedido pendiente de existencias
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: Parcial
       pending: Pendiente
       ready: Listo
       shipped: Enviado
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Envíos
     shipped: Enviado
     shipping: Envío
@@ -1162,67 +1303,83 @@ es-EC:
     shipping_method: Método de Envío
     shipping_methods: Métodos de Envío
     shipping_price_sack: Saco de Precio
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrito de la Compra
     show: Mostrar
     show_active: Mostrar Activo
     show_deleted: Mostrar Borrado
     show_only_complete_orders: Mostrar solamente Pedidos completos
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Mostrar tarifa en la etiqueta
     sku: Referencia
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Fuente
     special_instructions: Instrucciones especiales
     split: Dividir
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Hubo un problema con tu información de pago. Por favor revisa tu información e intentado de nuevo
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Empezar
+    start_date: TODO_TRANSLATE
     state: Provincia
     state_based: Estado basado
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Provincias
     states_required: Provincias requeridas
     status: Estatus
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Localización de stock
     stock_location_info: Info localización de stock
     stock_locations: Localizaciones de Stock
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Gestión de Stock
     stock_management_requires_a_stock_location: Por favor crea una localización de stock para gestionarlo.
     stock_movements: Movimientos del Stock
@@ -1236,28 +1393,30 @@ es-EC:
     street_address_2: Calle (cont.)
     subtotal: Subtotal
     subtract: Restar
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} ha sido creado con éxito"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} ha sido eliminado con éxito"
     successfully_signed_up_for_analytics: Dado de alta con éxito en Spree Analytics
     successfully_updated: "%{resource} ha sido actualizado con éxito"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Tasa
     tax_categories: Categorías fiscales
     tax_category: Categoría Fiscal
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Las tasas de impuestos son numeros decimales para ayudar en los calculos, (p. ej. si la tasa de impuesto es del 5%, introducir 0.05)
     tax_rates: Tasas de impuestos
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxon
     taxon_edit: Editar Taxon
     taxon_placeholder: Añadir Taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomías
     taxonomy: Taxonomía
     taxonomy_edit: Editar Taxonomía
@@ -1266,6 +1425,9 @@ es-EC:
     taxons: Taxons
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Felicidades!
         message: Si has recibido este email, entonces tus preferencias de email son correctas
@@ -1274,24 +1436,24 @@ es-EC:
     thank_you_for_your_order: Gracias por tu compra. Por favor imprime una copia de esta página de confirmación para tus archivos.
     there_are_no_items_for_this_order: El pedido no contiene artículos. Por favor, añade un artículo al pedido para continuar.
     there_were_problems_with_the_following_fields: Hubo un problema con los siguientes campos
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Hora
     to_add_variants_you_must_first_define: Para añadir variantes, debes definir primero
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
     tracking_number: Número de Tracking
     tracking_url: URL de Tracking
     tracking_url_placeholder: p. ej. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Transferido desde
     transfer_stock: Transferencia de Stock
     transfer_to_location: Transferido a
@@ -1299,7 +1461,7 @@ es-EC:
     type: Tipo
     type_to_search: Tipo a buscar
     unable_to_connect_to_gateway: No es posible la conexión a la pasarela
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Bajo %{price}
     unlock: Desbloqueado
     unrecognized_card_type: Tipo de tarjeta no reconocida
@@ -1307,9 +1469,11 @@ es-EC:
     update: Actualizar
     updating: Actualizando
     usage_limit: Límite de Uso
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Usa la Dirección de Facturación
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Usa una nueva tarjeta
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Usa Amazon S3 para las Imágenes
     user: Usuario
     user_rule:
@@ -1317,12 +1481,13 @@ es-EC:
     users: Usuarios
     validation:
       cannot_be_less_than_shipped_units: no puede ser menor que el número de unidades enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: excede el stock disponible. Por favor asegúrate que los artículos tienen un cantidad válida.
       is_too_large: demasiado grande -- el stock disponible no puede cubrir la cantidad solicitada
       must_be_int: debe ser un número entero
       must_be_non_negative: debe ser un valor no negativo
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Valor
     variant: Variante
     variant_placeholder: Escoge una variante
@@ -1341,3 +1506,10 @@ es-EC:
     zipcode: Código Postal
     zone: Zona
     zones: Zonas
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -1,4 +1,6 @@
+---
 es-MX:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ es-MX:
         state: Estado / Provincia
         zipcode: Código Postal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ es-MX:
         name: Nombre
         numcode: Código ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tipo
         month: Mes
-        name:
+        name: TODO_TRANSLATE
         number: Número
         verification_value: Código de Verificación
         year: Año
@@ -42,7 +44,7 @@ es-MX:
       spree/order:
         checkout_complete: Flujo de Compra Completado
         completed_at: Completado el
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: Cupón
         created_at: Fecha de pedido
         email: E-Mail del cliente
@@ -72,6 +74,7 @@ es-MX:
         zipcode: Código Postal (Dirección de Envíos)
       spree/payment:
         amount: Monto
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nombre
       spree/product:
@@ -95,7 +98,8 @@ es-MX:
         starts_at: Comienza
         usage_limit: Límite de Uso
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Nombre
         presentation: Presentación
@@ -105,24 +109,26 @@ es-MX:
         amount: Monto
       spree/role:
         name: Nombre
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abreviación
         name: Nombre
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Descripción
         name: Nombre
@@ -157,48 +163,54 @@ es-MX:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: La tarjeta ha expirado.
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Dirección
         other: Direcciones
@@ -208,41 +220,43 @@ es-MX:
       spree/credit_card:
         one: Tarjeta de Crédito
         other: Tarjetas de Crédito
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Unidad de Inventario
         other: Unidades de Inventario
       spree/line_item:
         one: Artículo
         other: Artículos
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Pedido
         other: Pedidos
       spree/payment:
         one: Pago
         other: Pagos
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Producto
         other: Productos
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Propiedad
         other: Propiedades
       spree/prototype:
         one: Prototipo
         other: Prototipos
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Autorización de Devolución
         other: Autorizaciones de Devolución
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Rol
         other: Roles
       spree/shipment:
@@ -251,14 +265,14 @@ es-MX:
       spree/shipping_category:
         one: Categoría de Envío
         other: Categorías de Envíos
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Estado
         other: Estados
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Categoría de Impuesto
         other: Categorías de Impuesto
@@ -271,7 +285,7 @@ es-MX:
       spree/taxonomy:
         one: Taxonomía
         other: Taxonomías
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Usuario
         other: Usuarios
@@ -281,6 +295,9 @@ es-MX:
       spree/zone:
         one: Zona
         other: Zonas
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Su cuenta fue confirmada correctamente. Ahora está conectado.
@@ -319,6 +336,7 @@ es-MX:
     user_sessions:
       signed_in: Conectado exitosamente
       signed_out: Desconectado exitosamente.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: Ya ha sido confirmado
@@ -327,12 +345,30 @@ es-MX:
       not_saved:
         one: '1 error impidió guardar este(a) %{resource}:'
         other: "%{count} errores impidieron guardar este(a) %{resource}:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abreviatura
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Cuenta
     account_updated: Cuenta actualizada
     action: Acción
@@ -345,7 +381,7 @@ es-MX:
       list: Listar
       listing: Listado
       new: Nueva
-      refund:
+      refund: TODO_TRANSLATE
       save: Guardar
       update: Actualizar
     activate: Activar
@@ -353,7 +389,7 @@ es-MX:
     add: Añadir
     add_action_of_type: Añadir tipo de acción
     add_country: Añadir País
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Añadir nuevo encabezado
     add_new_style: Añadir nuevo estilo
     add_one: Añadir uno
@@ -367,11 +403,16 @@ es-MX:
     add_to_cart: Añadir al carrito
     add_variant: Añadir variante
     additional_item: Costo adicional por elemento
+    address: TODO_TRANSLATE
     address1: Dirección
     address2: Dirección (continuación)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Ajuste
     adjustment_amount: Monto
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Ajustes cerrados exitosamente
     adjustment_successfully_opened: Ajustes abiertos exitosamente
     adjustment_total: Ajuste total
@@ -379,35 +420,35 @@ es-MX:
     admin:
       tab:
         configuration: Configuración
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: Ordenes
         overview: Visión general
         products: Productos
         promotions: Promociones
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: Reportes
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Usuarios
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administración
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Aceptar política de privacidad.
     agree_to_terms_of_service: Aceptar términos del servicio.
     all: Todos
     all_adjustments_closed: "¡Todos los ajustes se han cerrado con éxito!"
     all_adjustments_opened: Todos los ajustes abiertos exitosamente!
     all_departments: Todos los departamentos
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Permitir que SSL sea usado en modos de prueba y desarrollo
     allow_ssl_in_production: Permitir que SSL sea usado en modo de producción
     allow_ssl_in_staging: Permitir que SSL sea usado en modo de staging
@@ -423,70 +464,104 @@ es-MX:
     analytics_desc_list_4: "¡Es completamente gratuito!"
     analytics_trackers: Trackers de Google Analytics
     and: y
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: "¿Está seguro?"
     are_you_sure_delete: "¿Está seguro de que quiere eliminar esta entrada?"
     associated_adjustment_closed: El ajuste relacionado está cerrado, y no será recalculado. ¿Deseas abrirlo?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Fallo de autorización
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Disponible en
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Atrás
     back_end: Parte Intera
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Regresar a la tienda
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Regresar a la Lista de Usuarios
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Disponible para apartado
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Saldo pendiente
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Dirección de facturación
     billing: Facturación
     billing_address: Dirección de facturación
     both: ambos
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculadora
     calculator_settings_warning: Si está cambiando el tipo de calculadora, debe guardar su selección antes de editar su configuración
     cancel: Cancelar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: No puedes crear un pago para una orden que no tiene métodos de pago definidos
     cannot_create_returns: No puede crearse la devolución ya que este pedido aún no ha sido enviado.
     cannot_perform_operation: No puede realizarse la operación requerida
     cannot_set_shipping_method_without_address: No es posible asignar un método de envío hasta tener los detalles del cliente.
     capture: captura
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Código de la tarjeta
     card_number: Número de tarjeta
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Tipo de tarjeta
     cart: Carrito
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categorías
     category: Categoría
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Verificar alertas de Spree
     checkout: Pagar
     choose_a_customer: Elegir cliente
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Elegir Moneda
     choose_dashboard_locale: Escoger Idioma del Panel de Control
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Ciudad
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clonar
     close: Cerrar
     close_all_adjustments: Cerrar todos los ajustes
@@ -495,6 +570,7 @@ es-MX:
     complete: completar
     configuration: Configuración
     configurations: Configuraciones
+    configure_s3: TODO_TRANSLATE
     confirm: Confirmar
     confirm_delete: Confirmar borrado
     confirm_password: Confirme la contraseña
@@ -503,7 +579,7 @@ es-MX:
     cost_currency: Moneda de costo
     cost_price: Precio del Costo
     could_not_connect_to_jirafe: No se pudo conectar con Jirafe para sincronizar datos. Se intentará de nuevo automáticamente más tarde .
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Hubo un problema guardando este movimiento de existencias. Por favor intente de nuevo.
     count_on_hand: Contar manualmente.
     countries: Países
@@ -511,10 +587,10 @@ es-MX:
     country_based: País base
     country_name: Nombre
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Cupón
     coupon_code: Código de cupón
     coupon_code_already_applied: El código del cupón ya ha sido aplicado en esta orden
@@ -524,17 +600,17 @@ es-MX:
     coupon_code_max_usage: Se ha excedido el límite de uso del código del cupón
     coupon_code_not_eligible: Este código del cupón no puede ser usado para esta orden
     coupon_code_not_found: El código del cupón que introdujiste no existe. Por favor intenta de nuevo
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Crear
     create_a_new_account: Crear una nueva cuenta
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Creado en
     credit: Crédito
     credit_card: Tarjeta de crédito
     credit_cards: Tarjetas de crédito
     credit_owed: Crédito disponible
-    credits:
+    credits: TODO_TRANSLATE
     currency: Moneda
     currency_decimal_mark: Marca de decimales de moneda
     currency_settings: Configuraciones de moneda
@@ -545,11 +621,11 @@ es-MX:
     customer: Cliente
     customer_details: Detalles del cliente
     customer_details_updated: Detalles del cliente actualizados
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Búsqueda de clientes
     cut: Corte
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: ID de aplicación
@@ -563,46 +639,65 @@ es-MX:
     date: Fecha
     date_completed: Fecha completada
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: Año/mes/día
       js_format: aa/mm/dd
     date_range: Rango de Fecha
     default: Por omisión
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Impuesto por defecto
     default_tax_zone: Zona de impuestos por defecto
     delete: Eliminar
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Envío
     depth: Profundidad
     description: Descripción
     destination: Destino
     destroy: Eliminar
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Importe del descuento
     dismiss_banner: No. ¡Gracias!. No estoy interesado, no muestres este mensaje de nuevo
     display: Mostrar
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Editar
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editando usuario
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Vacío
     empty_cart: Vaciar carrito
@@ -635,28 +730,30 @@ es-MX:
           signup: User signup
     exceptions:
       count_on_hand_setter: No se puede usar count_on_hand manualmente, debido a que se activa automáticamente por el callback recalculate_count_hand. Por favor utilice 'update_column(:count_on_hand, value)'
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Caducidad
     extension: Extensión
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Nombre de archivo
     fill_in_customer_info: Por favor complete la información del cliente
+    filter: TODO_TRANSLATE
     filter_results: Filtrar resultados
     finalize: Finalizar
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Costo del primer elemento
     first_name: Nombre
     first_name_begins_with: Nombre comienza por
     flat_percent: Porcentaje simple
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Cantidad fija (por pedido)
     flexible_rate: Cantidad variable
     forgot_password: "¿Olvidaste tu contraseña?"
     free_shipping: Gastos de envío gratuitos
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Sistema Interno
     gateway: Pasarela
     gateway_config_unavailable: Pasarela no disponible por configuración
@@ -680,37 +777,41 @@ es-MX:
       only_incomplete: Solo incompletas
       select_locale: Escoge traducción
       show_only: Mostrar solo
+      store_translations: TODO_TRANSLATE
       supported_locales: Traducciones soportadas
-      this_file_language:
+      this_file_language: TODO_TRANSLATE
       translations: Traducciones
     icon: Icono
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Imagen
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Imágenes
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Incluido en el precio
     included_price_validation: No puede ser seleccionado a menos que hayas elegido una zona de impuestos por defecto
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: Ingresa tu correo en el formulario a continuación
     insufficient_stock: No hay inventario suficiente, sólo %{on_hand} disponibles
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Interceptar dirección de Email
     intercept_email_instructions: Sustituir el receptor del email con ésta dirección.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Proveedor de pago no válido
     invalid_promotion_action: Acción de promoción inválida
     invalid_promotion_rule: Regla de promoción no válida
     inventory: Inventario
     inventory_adjustment: Ajuste de inventario
     inventory_error_flash_for_insufficient_quantity: Un artículo en tu carro ya no está disponible
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: No se encuentra disponible para la dirección de envío
     iso_name: Nombre ISO
     item: artículo
@@ -720,26 +821,32 @@ es-MX:
       operators:
         gt: mayor que
         gte: mayor o igual que
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Ruta
     last_name: Apellidos
     last_name_begins_with: Apellido comienza por
     learn_more: Aprender más
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Cargando
     locale_changed: Idioma cambiado
     location: Localización
     lock: Bloquear
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Conectado como
     logged_in_succesfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
@@ -748,23 +855,26 @@ es-MX:
     login_failed: Falló el inicio de sesión
     login_name: Iniciar sesión
     logout: Cerrar sesión
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Buscar artículos similares
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Realizar devolución
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Precio principal
     match_choices:
       all: Todos
       none: Ninguno
     max_items: Máximo de elementos
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta descripción
     meta_keywords: Meta palabras clave
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadatos
     minimal_amount: Cantidad mínima
     month: Mes
@@ -773,13 +883,13 @@ es-MX:
     my_account: Mi cuenta
     my_orders: Mis pedidos
     name: Nombre
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Nombre o código de producto
     new: Nuevo
     new_adjustment: nuevo ajuste
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Nuevo cliente
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nueva Imagen
     new_option_type: Nuevo tipo de opción
     new_order: Nuevo pedido
@@ -788,14 +898,15 @@ es-MX:
     new_payment_method: Nueva forma de pago
     new_product: Nuevo producto
     new_promotion: Nueva promoción
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nueva propiedad
     new_prototype: Nuevo prototipo
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Nueva autorización de devolución
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Nueva categoría de envío
     new_shipping_method: Nueva forma de envío
     new_state: Nuevo estado
@@ -812,24 +923,30 @@ es-MX:
     new_zone: Nueva zona
     next: siguiente
     no_actions_added: No se agregaron acciones
-    no_payment_found:
-    no_pending_payments:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: No se han encontrado productos
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Sin resultados
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: No se han añadido nuevas reglas
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: No hay detalles de ubicación provistos.
     none: Ninguno
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Cantidad normal
     not: false
     not_available: N/A
     not_enough_stock: No hay suficiente inventario en la ubicación fuente para completar esta transferencia.
     not_found: "%{resource} no encontrado"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: El producto ha sido clonado
       product_deleted: El producto ha sido elminado
@@ -837,12 +954,12 @@ es-MX:
       product_not_deleted: No ha podido eliminarse el producto
       variant_deleted: La variante ha sido eliminada
       variant_not_deleted: La variante no ha podido eliminarse
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Disponible
     open: Abrir
     open_all_adjustments: Abrir todos los ajustes
     option_type: Tipo de opción
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Tipos de opción
     option_value: Valor de la opción
     option_values: Valores de la opción
@@ -852,33 +969,38 @@ es-MX:
     or_over_price: "%{price} o más"
     order: Pedido
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Detalles del pedido
     order_email_resent: Email de pedido reenviado
     order_information: Información del pedido
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Querido cliente,\n
         instructions: Su orden ha sido CANCELADA. Por favor mantenga esta información de cancelación para sus registros
         order_summary_canceled: Resumen del pedido [CANCELADO]
         subject: Cancelación de pedido
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: |
           Querido cliente,
         instructions: Por favor revise y mantenga la siguiente información del pedido para sus registros
         order_summary: Resumen del pedido
         subject: Confirmación de pedido
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Gracias por su negocio
-        total:
+        total: TODO_TRANSLATE
     order_not_found: No pudimos encontrar su orden. Por favor inténtalo de nuevo
-    order_number:
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Su pedido se ha procesado correctamente
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: dirección
       awaiting_return: esperando respuesta
@@ -886,7 +1008,7 @@ es-MX:
       cart: carrito
       complete: completado
       confirm: confirmado
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: envío
       payment: pago
       resumed: reanudado
@@ -896,12 +1018,14 @@ es-MX:
     order_total: Total del pedido
     order_updated: Pedido actualizado
     orders: Pedidos
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Fuera de Inventario
     overview: General
     package_from: Paquete desde
     pagination:
+      first: TODO_TRANSLATE
       next_page: Página siguiente »
+      previous: TODO_TRANSLATE
       previous_page: "« Página anterior"
       truncate: "…"
     password: Contraseña
@@ -909,11 +1033,11 @@ es-MX:
     path: Ruta
     pay: Pagar
     payment: Pago
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Información del pago
     payment_method: Método de pago
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Métodos de pago
     payment_processing_failed: El pago no ha podido ser procesado, por favor revise los datos proporcionados.
     payment_processor_choose_banner_text: Si necesitas ayuda eligiendo un procesador de pagos, por favor visita
@@ -931,22 +1055,23 @@ es-MX:
       void: vacío
     payment_updated: Pago actualizado
     payments: Pagos
-    pending:
+    pending: TODO_TRANSLATE
     percent: Porcentaje
     percent_per_item: Porcentaje por artículo
     permalink: Enlace permanente
     phone: Teléfono
     place_order: Hacer pedido
     please_define_payment_methods: Por favor primero defina algunos métodos de pago
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Algo salió mal. Por favor intente agregando el artículo de nuevo
     powered_by: Hecho con
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentación
     previous: Anterior
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Precio
     price_range: Rango de precio
     price_sack: Price Sack
@@ -958,10 +1083,10 @@ es-MX:
     product_properties: Propiedades del producto
     product_rule:
       choose_products: Elija productos
-      label:
+      label: TODO_TRANSLATE
       match_all: todos
       match_any: al menos uno de
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Del grupo de productos
         manual: Elegir manualmente
@@ -973,19 +1098,24 @@ es-MX:
         description: Creates a promotion credit adjustment on the order
         name: Crear ajuste
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Llene el carrito con la cantidad específica de variantes
         name: Crear artículos de línea
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Acciones
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Coincide con todas las siguientes reglas
         any: Coincide con alguna de estas reglas
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Regla de promoción
     promotion_rule_types:
       first_order:
@@ -998,27 +1128,27 @@ es-MX:
         description: El cliente debió haber visitado la página específica
         name: Página de inicio
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: El pedido incluye los siguientes productos
         name: Producto(s)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Disponible sólo para los siguientes clientes
         name: Usuario
       user_logged_in:
         description: Disponible sólo para usuarios con sesión iniciada
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promociones
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Propiedades
     property: Propiedad
     prototype: Prototipo
@@ -1029,47 +1159,49 @@ es-MX:
     quantity: Cantidad
     quantity_returned: Cantidad devuelta
     quantity_shipped: Cantidad enviada
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Tarifa
     reason: Razón
     receive: recibir
     receive_stock: Recibir inventario
     received: Recibido
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Referencia
+    reference_contains: TODO_TRANSLATE
     refund: Devolver
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registrar
     registration: Registro
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Recuerdame
     remove: Eliminar
     rename: Renombrar
-    report:
+    report: TODO_TRANSLATE
     reports: Informes
+    resellable: TODO_TRANSLATE
     resend: Volver a enviar
     reset_password: Reiniciar mi contraseña
     response_code: Código de respuesta
@@ -1077,34 +1209,41 @@ es-MX:
     resumed: Reanudado
     return: volver
     return_authorization: Autorización para devolución
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Devolver autorización actualizada
     return_authorizations: Autorizaciones para devoluciones
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Devolver cantidad
     returned: regresó
-    returns:
+    returns: TODO_TRANSLATE
     review: Revisar
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: Crédito RMA
     rma_number: Número RMA
     rma_value: Valor RMA
+    role_id: TODO_TRANSLATE
     roles: Funciones
     rules: Reglas
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Total de ventas
     sales_total_description: Total de ventas de todos los pedidos
     sales_totals: Total de Ventas
     save_and_continue: Guardar y continuar
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: false
     say_yes: Sí
     scope: Alcance
@@ -1114,10 +1253,11 @@ es-MX:
     secure_connection_type: Tipo de conexión segura
     security_settings: Configuraciones de seguridad
     select: Seleccionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Seleccionar desde prototipo
     select_stock: Elegir inventario
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Envia una copia de todos los correos a
     send_mails_as: Enviar correos como
     server: Servidor
@@ -1127,8 +1267,9 @@ es-MX:
     ship_address: Dirección de envío
     ship_total: Envío Total
     shipment: Envío
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Querido cliente,\n
@@ -1141,13 +1282,13 @@ es-MX:
     shipment_state: Estado del envío
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: parcial
       pending: pendiente
       ready: listo
       shipped: enviado
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Envíos
     shipped: Enviado
     shipping: Envío
@@ -1161,69 +1302,85 @@ es-MX:
     shipping_method: Método de envío
     shipping_methods: Métodos de envío
     shipping_price_sack: Monedero
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrito de compras
     show: Mostrar
     show_active: mostrar activos
     show_deleted: Mostrar eliminados
     show_only_complete_orders: Mostrar sólo los pedidos completados
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Mostrar tarifa en etiqueta
     sku: Código
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Origen
     special_instructions: Instrucciones especiales
     split: Dividir
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: hubo un problema con su información de pago. Por favor, revísela e inténtelo de nuevo.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Inicio
+    start_date: TODO_TRANSLATE
     state: Estado
     state_based: Estado base
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Provincias
     states_required: Estados Requeridos
     status: Estado
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Ubicación de Inventario
     stock_location_info: Información sobre Ubicación de Inventario
     stock_locations: Ubicación de Inventario
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Manejo de Inventario
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
     stock_movements: Movimientos de Inventario
     stock_movements_for_stock_location: Movimientos de inventario para %{stock_location_name}
     stock_successfully_transferred: El Stock fue transferido exitosamente entre ubicaciones.
@@ -1235,28 +1392,30 @@ es-MX:
     street_address_2: Dirección (continuación)
     subtotal: Subtotal
     subtract: Restar
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "¡%{resource} ha sido creado con éxito"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} ha sido borrado con éxito"
     successfully_signed_up_for_analytics: Registrado exitosamente para Spree Analytics
     successfully_updated: "%{resource} ha sido actualizado con éxito"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Impuestos
     tax_categories: Categorías de impuestos
     tax_category: Categoría de impuestos
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Las tasas de impuesto son una cantidad decimal para ayudar en el cálculo (por ejemplo, si la tasa de impuesto es 5% entonces introduce 0.05)
     tax_rates: Tasas de impuestos
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Categoría
     taxon_edit: Editar categoría
     taxon_placeholder: Agregar taxón
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Categorías
     taxonomy: Taxonomy
     taxonomy_edit: Editar categorías
@@ -1265,32 +1424,35 @@ es-MX:
     taxons: Categorías
     test: Prueba
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: "¡Felicitaciones!"
         message: Si has recibido este correo, las configuraciones de correo son correctas
         subject: Testmail
     test_mode: Modo de Prueba
     thank_you_for_your_order: Gracias por su pedido. Por favor imprima una copia de esta información para sus registros
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: 'Hubo problemas con los siguientes campos:'
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Miniatura
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Tiempo
     to_add_variants_you_must_first_define: Para agregar variantes, primero debe definir
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Seguimiento
     tracking_number: Número de Rastreo
     tracking_url: URL de Rastreo
     tracking_url_placeholder: por ejemplo http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Transferir desde
     transfer_stock: Transferencia de inventario
     transfer_to_location: Transferir a
@@ -1298,7 +1460,7 @@ es-MX:
     type: Tipo
     type_to_search: Tipo a buscar
     unable_to_connect_to_gateway: No ha sido posible conectarse a la pasarela.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Bajo %{price}
     unlock: Desbloquear
     unrecognized_card_type: Tipo de tarjeta desconocido
@@ -1306,9 +1468,11 @@ es-MX:
     update: Actualizar
     updating: Actualizando
     usage_limit: Límite de uso
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Usar la dirección de facturación
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Usar una tarjeta diferente
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Usar Amazon S3 para imágenes
     user: Usuario
     user_rule:
@@ -1316,12 +1480,13 @@ es-MX:
     users: Usuarios
     validation:
       cannot_be_less_than_shipped_units: no puede ser menos que el número de unidades enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: Excede el inventario disponible. Por favor asegúrate de que los artículos tengan una cantidad válida
       is_too_large: es demasiado grande -- no hay suficientes productos disponibles para ésa cantidad
       must_be_int: debe ser un entero
       must_be_non_negative: debe ser un valor no negativo
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: valor
     variant: Variante
     variant_placeholder: Selecciona una variante
@@ -1340,3 +1505,10 @@ es-MX:
     zipcode: Código Postal
     zone: Zona
     zones: Zonas
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,6 @@
+---
 es:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ es:
         state: Provincia ó Estado
         zipcode: Código Postal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,7 +26,7 @@ es:
         name: Nombre
         numcode: Código ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tipo
         month: Mes
         name: Nombre
@@ -72,6 +74,7 @@ es:
         zipcode: Código postal dirección envío
       spree/payment:
         amount: Cuantía
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nombre
       spree/product:
@@ -95,6 +98,7 @@ es:
         starts_at: Empieza en
         usage_limit: Limite de Uso
       spree/promotion_category:
+        code: TODO_TRANSLATE
         name: Nombre
       spree/property:
         name: Nombre
@@ -105,24 +109,26 @@ es:
         amount: Cuantía
       spree/role:
         name: Nombre
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abreviatura
         name: Nombre
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Descripción
         name: Nombre
@@ -157,48 +163,54 @@ es:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: La Tarjeta ha expirado
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Dirección.
         other: Direcciones
@@ -208,43 +220,45 @@ es:
       spree/credit_card:
         one: Tarjeta de Crédito.
         other: Tarjetas de Crédito
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Unidad de inventario.
         other: Unidades de inventario
       spree/line_item:
         one: Línea de pedido
         other: Líneas de pedido
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Pedido
         other: Pedidos
       spree/payment:
         one: Pago
         other: Pagos
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Producto
         other: Productos
       spree/promotion:
         one: Promoción
         other: Promociones
-      spree/promotion_category:
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Propiedad
         other: Propiedades
       spree/prototype:
         one: Prototipo
         other: Propotipos
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Autorización para devolución
         other: Autorizaciones para devolución
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Función
         other: Funciones
       spree/shipment:
@@ -253,14 +267,14 @@ es:
       spree/shipping_category:
         one: Categoría de envío
         other: Categorías de envío
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Provincia
         other: Provincias
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Categoría fiscal
         other: Categorías fiscales
@@ -273,7 +287,7 @@ es:
       spree/taxonomy:
         one: Categoría
         other: Categorías
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Usuario
         other: Usuarios
@@ -283,6 +297,9 @@ es:
       spree/zone:
         one: Zona
         other: Zonas
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Tu cuenta fue confirmada satisfactoriamente. Ya estás registrado.
@@ -321,6 +338,7 @@ es:
     user_sessions:
       signed_in: Registrado satisfactoriamente.
       signed_out: Abandonado satisfactoriamente.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: fue ya confirmada.
@@ -329,12 +347,30 @@ es:
       not_saved:
         one: 1 error evitó que este %{resource} fuese grabado.
         other: "%{count} errores evitaron que este %{resource} fuese grabado:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abreviatura
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Cuenta
     account_updated: Cuenta actualizada
     action: Acción
@@ -347,7 +383,7 @@ es:
       list: Listar
       listing: Listando
       new: Nuevo
-      refund:
+      refund: TODO_TRANSLATE
       save: Guardar
       update: Actualizar
     activate: Activar
@@ -355,7 +391,7 @@ es:
     add: Añadir
     add_action_of_type: Añadir acción del tipo
     add_country: Añadir País
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Añadir nueva cabecera
     add_new_style: Añadir nuevo estilo
     add_one: Añadir uno
@@ -369,11 +405,16 @@ es:
     add_to_cart: Añadir al carrito
     add_variant: Añadir variante
     additional_item: Coste de artículo adicional
+    address: TODO_TRANSLATE
     address1: Dirección
     address2: Dirección (cont.)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Ajuste
     adjustment_amount: Cuantía
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: El ajuste ha sido cerrado satisfactoriamente
     adjustment_successfully_opened: El ajuste ha sido abierto satisfactoriamente
     adjustment_total: Total del ajuste
@@ -381,35 +422,35 @@ es:
     admin:
       tab:
         configuration: Configuración
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: Pedidos
         overview: Visión general
         products: Productos
         promotions: Promociones
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: Informes
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Usuarios
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administración
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: De acuerdo con la politica de privacidad.
     agree_to_terms_of_service: De acuerdo con las condiciones de uso
     all: Todos
     all_adjustments_closed: Todos los ajustes cerrados satisfactoriamente
     all_adjustments_opened: Todos los ajustes abiertos satisfactoriamente
     all_departments: Todos los departamentos
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Permitir SSL en modo desarrollo y pruebas
     allow_ssl_in_production: Permitir SSL en producción
     allow_ssl_in_staging: Permitir SSL en modo staging
@@ -425,65 +466,99 @@ es:
     analytics_desc_list_4: Es completamente gratuito!
     analytics_trackers: Analytics Trackers
     and: y
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: aprobar
     approved_at: Aprobado en
     approver: Aprobador
     are_you_sure: "¿Estás seguro?"
     are_you_sure_delete: "¿Estás seguro de que quieres borrar este registro?"
     associated_adjustment_closed: El ajuste asociado está cerrado y no será recalculado. ¿Quieres abrirlo?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Fallo en la autorización
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Disponible
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Volver
     back_end: Parte interna
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Volver a la Tienda
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Volver a Listado de Usuarios
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Devuelto
-    backorderable_default:
-    backordered:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
     backorders_allowed: Permitida la Devolucion
     balance_due: Saldo adeudado
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Dirección de facturación
     billing: Facturación
     billing_address: Dirección de facturación
     both: Ambos
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculador
     calculator_settings_warning: Si cambias el tipo de calculador, debes guardar primero antes de editar las preferencias del calculador
     cancel: Cancelar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: No puedes crear un pago para un pedido sin antes definir un método de pago
     cannot_create_returns: No puedes crear devoluciones para un pedido que no tiene unidades enviadas
     cannot_perform_operation: No se pudo realizar la operación solicitada
     cannot_set_shipping_method_without_address: No se puede establecer el método de envío hasta que no se proporcionen los detalles del cliente.
     capture: Captura
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Código de tarjeta
     card_number: Número de tarjeta
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Tipo de tarjeta es
     cart: Carrito
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categorías
     category: Categoría
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Comprobar alertas de Spre
     checkout: Realizar pedido
     choose_a_customer: Escoge un cliente
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Escoge moneda
     choose_dashboard_locale: Escoge idioma del Panel de Instrumentos
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Ciudad
     clear_cache: Limpiar caché
     clear_cache_ok: Caché limpiado
@@ -497,6 +572,7 @@ es:
     complete: Completar
     configuration: Configuración
     configurations: Configuraciones
+    configure_s3: TODO_TRANSLATE
     confirm: Confirmar
     confirm_delete: Confimar borrado
     confirm_password: Confirmación del Password
@@ -513,10 +589,10 @@ es:
     country_based: País base
     country_name: Nombre
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Cupón
     coupon_code: Código Cupón
     coupon_code_already_applied: El código del cupón ya ha sido aplicado a este pedido
@@ -526,17 +602,17 @@ es:
     coupon_code_max_usage: Excedido el limite de uso del código del cupón
     coupon_code_not_eligible: Este código de cupón no es elegible para este pedido
     coupon_code_not_found: El código del cupón que has introducido no existe. Inténtalo de nuevo.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Crear
     create_a_new_account: Crear una nueva cuenta
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Creada
     credit: Crédito
     credit_card: Tarjeta de Crédito
     credit_cards: Tarjetas de Crédito
     credit_owed: Crédito adeudado
-    credits:
+    credits: TODO_TRANSLATE
     currency: Moneda
     currency_decimal_mark: Marca decimal de moneda
     currency_settings: Parámetros de moneda
@@ -547,11 +623,11 @@ es:
     customer: Cliente
     customer_details: Detalles del Cliente
     customer_details_updated: Detalles del Cliente actualizado
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Búsqueda del Cliente
     cut: Cortar
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: ID App
@@ -570,41 +646,60 @@ es:
       js_format: dd/mm/yy
     date_range: Rango de fechas
     default: Por defecto
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Tasa por defecto
     default_tax_zone: Zona de tasa por defecto
     delete: Borrar
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Entregar
     depth: Ancho
     description: Descripción
     destination: Destino
     destroy: Eliminar
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Cuantía descuento
     dismiss_banner: No. Gracias! No estoy interesado, no mostrar este mensaje otra vez
     display: Mostrar
     display_currency: Moneda a mostrar
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Editar
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editando Usuario
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Vacío
     empty_cart: Carrito vacío
@@ -637,28 +732,30 @@ es:
           signup: Dar de alta Usuario
     exceptions:
       count_on_hand_setter: No se pudo establecer count_on_hand manualmente, ya que está establecido automáticamente por la callback recalculate_count_on_hand. Por favor utiliza `update_column(:count_on_hand, value)` en vez de ello.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Vencimiento
     extension: Extensión
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Nombre de Fichero
     fill_in_customer_info: Por favor rellena información del cliente
+    filter: TODO_TRANSLATE
     filter_results: Filtrar resultados
     finalize: Finalizar
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Coste del primer artículo
     first_name: Nombre
     first_name_begins_with: Nombre comienza por
     flat_percent: Porcentaje fijo
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Tarifa plana (por pedido)
     flexible_rate: Tarifa flexible
     forgot_password: "¿Olvidaste el password?"
     free_shipping: Envío gratuito
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Parte delantera
     gateway: Pasarela
     gateway_config_unavailable: Pasarela no disponible para entorno
@@ -682,37 +779,41 @@ es:
       only_incomplete: Sólo incompletos
       select_locale: Seleccionar Locale
       show_only: Sólo mostrar
+      store_translations: TODO_TRANSLATE
       supported_locales: Locales Soportados
       this_file_language: Español
       translations: Traducciones
     icon: Icono
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Imagen
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Imágenes
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Incluido en el precio
     included_price_validation: No puede ser seleccionado a menos que establezcas una Zona de Tasa por defecto
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: Por favor introduce tu nombre en el siguiente formulario
     insufficient_stock: Stock disponible insuficiente, sólo %{on_hand} restante
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Interceptar Dirección Email
     intercept_email_instructions: Sobrescribe correo electrónico del destinatario y reemplázalo con esta dirección.
     internal_name: Nombre interno
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Proveedor de pago inválido
     invalid_promotion_action: Acción de promoción inválida
     invalid_promotion_rule: Regla de promoción inválida
     inventory: Inventario
     inventory_adjustment: Ajuste de inventario
     inventory_error_flash_for_insufficient_quantity: Un artículo de tu carrito ha dejado de estar disponible.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: no está disponible para la dirección de envío
     iso_name: Nombre ISO
     item: Artículo
@@ -725,9 +826,9 @@ es:
         lt: Menor que
         lte: Menor que o igual a
     items_cannot_be_shipped: No es posible enviar los elementos seleccionados a su dirección de entrega. Por favor indica otra dirección de entrega.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Ruta
@@ -737,11 +838,17 @@ es:
     lifetime_stats: Histórico de estadísticas
     line_item_adjustments: Ajustes de línea de pedido
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Carga
     locale_changed: Idioma cambiado
     location: Localización
     lock: Bloquear
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Identificado como
     logged_in_succesfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
@@ -750,20 +857,23 @@ es:
     login_failed: No se ha podido iniciar la sesión, error de autenticación.
     login_name: Validación
     logout: Cerrar sesión
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Buscar artículos similares
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Realizar devolución
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Precio principal
     match_choices:
       all: Todos
       none: Ninguno
     max_items: Máximo Artículos
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Descripción Meta
     meta_keywords: Keywords Meta
     meta_title: Título Meta
@@ -790,14 +900,15 @@ es:
     new_payment_method: Nueva forma de pago
     new_product: Nuevo producto
     new_promotion: Nueva promoción
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nueva propiedad
     new_prototype: Nuevo prototipo
     new_refund: Nuevo reembolso
-    new_refund_reason:
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Nueva autorización de devolución
     new_rma_reason: Nueva razón RMA
-    new_shipment_at_location:
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Nueva categoría de envío
     new_shipping_method: Nueva forma de envío
     new_state: Nueva provincia
@@ -814,18 +925,24 @@ es:
     new_zone: Nueva Zona
     next: Siguiente
     no_actions_added: No acciones añadidas
+    no_orders_found: TODO_TRANSLATE
     no_payment_found: No se encontro pago
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: No hay pagos pendientes
     no_products_found: No se encontraron productos
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: No se encontraron %{resource}
     no_results: sin resultados
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: No se añadieron reglas
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: No se proporcionaron detalles del tracking
     none: Ninguno
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Cuantía normal
     not: false
     not_available: No disponible
@@ -854,32 +971,37 @@ es:
     or_over_price: "%{price} ó más"
     order: Pedido
     order_adjustments: Ajustes de pedido
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Detalles del pedido
     order_email_resent: Email de pedido reenviado
     order_information: Información del pedido
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Estimado cliente,\n
         instructions: Tu pedido ha sido CANCELADO. Por favor conserva esta información de cancelación para tus registros.
         order_summary_canceled: Resumen de pedido [CANCELADO]
         subject: Cancelación de pedido
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Estimado Cliente,\n
         instructions: Por favor, revisa y conserva la siguiente información del pedido de tus registros.
         order_summary: Resumen del pedido
         subject: Confirmación del pedido
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: "¡Gracias por su compra!"
-        total:
+        total: TODO_TRANSLATE
     order_not_found: No pudimos encontrar tu pedido. Por favor intenta esta acción de nuevo
-    order_number:
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Tu pedido ha sido procesado con éxito
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: Dirección
       awaiting_return: Esperando devolución
@@ -902,7 +1024,9 @@ es:
     overview: Visión de conjunto
     package_from: paquete desde
     pagination:
+      first: TODO_TRANSLATE
       next_page: siguiente página »
+      previous: TODO_TRANSLATE
       previous_page: "« página anterior"
       truncate: "…"
     password: Password
@@ -910,8 +1034,8 @@ es:
     path: Ruta
     pay: pagar
     payment: Pago
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Información del Pago
     payment_method: Método de Pago
     payment_method_not_supported: Método de Pago no soportado
@@ -939,15 +1063,16 @@ es:
     phone: Teléfono
     place_order: Ponga el pedido
     please_define_payment_methods: Por favor define algún método de pago primero
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Algo salió mal. Por favor intenta añadir el artículo otra vez.
     powered_by: Desarrollado por
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentación
     previous: Previo
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Precio
     price_range: Rango de precios
     price_sack: Saco de precios
@@ -959,10 +1084,10 @@ es:
     product_properties: Propiedades del producto
     product_rule:
       choose_products: Escoge productos
-      label:
+      label: TODO_TRANSLATE
       match_all: Todos
       match_any: al menos uno
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Desde grupo de producto
         manual: Escoge manualmente
@@ -974,19 +1099,24 @@ es:
         description: Crea un ajuste de crédito en la promoción en el pedido
         name: Crear ajuste
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Rellena el carrito con la cuantía especificada de la variante
         name: Crea líneas de artículos
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Acciones
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Cumple todas estas reglas
         any: Cumple cualquiera de estas reglas
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Regla de promoción
     promotion_rule_types:
       first_order:
@@ -1016,10 +1146,10 @@ es:
       user_logged_in:
         description: Disponible solamente a usuarios autorizados
         name: Usuario autorizado
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promociones
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Propiedades
     property: Propiedad
     prototype: Prototipo
@@ -1030,18 +1160,19 @@ es:
     quantity: Cantidad
     quantity_returned: Cantidad devuelta
     quantity_shipped: Cantidad enviada
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Tarifa
     reason: Razón
     receive: recibir
     receive_stock: Recibir Stock
     received: Recibido
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Referencia
+    reference_contains: TODO_TRANSLATE
     refund: Devolución
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
     refunds: Reembolsos
     register: Registrar
     registration: Registro
@@ -1050,27 +1181,28 @@ es:
     reimbursement: Reembolso
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Recuérdame
     remove: Quitar
     rename: Renombrar
-    report:
+    report: TODO_TRANSLATE
     reports: Informes
+    resellable: TODO_TRANSLATE
     resend: Reenviar
     reset_password: Reinicializar password
     response_code: Código de respuesta
@@ -1078,19 +1210,20 @@ es:
     resumed: Reanudado
     return: Volver
     return_authorization: Autorización para devolución
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Autorización para devolución actualizada
     return_authorizations: Autorizaciones para devolución
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Cantidad de devolución
     returned: Devuelto
-    returns:
+    returns: TODO_TRANSLATE
     review: Revisar
     risk: Riesgo
     risk_analysis: Análisis arriesgado
@@ -1098,9 +1231,15 @@ es:
     rma_credit: Crédito RMA
     rma_number: Número RMA
     rma_value: Valor RMA
+    role_id: TODO_TRANSLATE
     roles: Funciones
     rules: Reglas
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Total de ventas
     sales_total_description: Total de ventas de todos los pedidos
     sales_totals: Totales de ventas
@@ -1115,10 +1254,11 @@ es:
     secure_connection_type: Tipo de conexión segura
     security_settings: Preferencias de seguridad
     select: Seleccionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Seleccionar desde el prototipo
     select_stock: Seleccionar Stock
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Enviar copia de todos los emails a
     send_mails_as: Enviar emails como
     server: Servidor
@@ -1128,8 +1268,9 @@ es:
     ship_address: Dirección de envío
     ship_total: Total de envío
     shipment: Envío
-    shipment_adjustments: 
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Estimado Cliente,\n
@@ -1147,8 +1288,8 @@ es:
       pending: Pendiente
       ready: Listo
       shipped: Enviado
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Envíos
     shipped: Enviado
     shipping: Envío
@@ -1162,7 +1303,11 @@ es:
     shipping_method: Método de Envío
     shipping_methods: Métodos de Envío
     shipping_price_sack: Saco de Precio
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrito de Compras
     show: Mostrar
@@ -1172,57 +1317,69 @@ es:
     show_only_considered_risky: Mostrar solamente Pedidos arriesgados
     show_rate_in_label: Mostrar tarifa en la etiqueta
     sku: Referencia
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Fuente
     special_instructions: Instrucciones especiales
     split: Dividir
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Hubo un problema con tu información de pago. Por favor revisa tu información e intentado de nuevo
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Empezar
+    start_date: TODO_TRANSLATE
     state: Provincia
     state_based: Estado basado
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Provincias
     states_required: Provincias requeridas
     status: Estatus
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Localización de stock
     stock_location_info: Info localización de stock
     stock_locations: Localizaciones de Stock
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Gestión de Stock
     stock_management_requires_a_stock_location: Por favor crea una localización de stock para gestionarlo.
     stock_movements: Movimientos del Stock
@@ -1236,28 +1393,30 @@ es:
     street_address_2: Calle (cont.)
     subtotal: Subtotal
     subtract: Restar
-    success: Éxito
+    success: "Éxito"
     successfully_created: "%{resource} ha sido creado con éxito"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} ha sido eliminado con éxito"
     successfully_signed_up_for_analytics: Dado de alta con éxito en Spree Analytics
     successfully_updated: "%{resource} ha sido actualizado con éxito"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Tasa
     tax_categories: Categorías fiscales
     tax_category: Categoría Fiscal
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Las tasas de impuestos son numeros decimales para ayudar en los cálculos, (p. ej. si la tasa de impuesto es del 5%, introducir 0.05)
     tax_rates: Tasas de impuestos
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxon
     taxon_edit: Editar Taxon
     taxon_placeholder: Añadir Taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomías
     taxonomy: Taxonomía
     taxonomy_edit: Editar Taxonomía
@@ -1266,6 +1425,9 @@ es:
     taxons: Taxons
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Felicidades!
         message: Si has recibido este email, entonces tus preferencias de email son correctas
@@ -1274,24 +1436,24 @@ es:
     thank_you_for_your_order: Gracias por tu compra. Por favor imprime una copia de esta página de confirmación para tus archivos.
     there_are_no_items_for_this_order: El pedido no contiene artículos. Por favor, añade un artículo al pedido para continuar.
     there_were_problems_with_the_following_fields: Hubo un problema con los siguientes campos
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Hora
     to_add_variants_you_must_first_define: Para añadir variantes, debes definir primero
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
     tracking_number: Número de Tracking
     tracking_url: URL de Tracking
     tracking_url_placeholder: p. ej. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Transferido desde
     transfer_stock: Transferencia de Stock
     transfer_to_location: Transferido a
@@ -1299,7 +1461,7 @@ es:
     type: Tipo
     type_to_search: Tipo a buscar
     unable_to_connect_to_gateway: No es posible la conexión a la pasarela
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Bajo %{price}
     unlock: Desbloqueado
     unrecognized_card_type: Tipo de tarjeta no reconocida
@@ -1307,9 +1469,11 @@ es:
     update: Actualizar
     updating: Actualizando
     usage_limit: Límite de Uso
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Usa la Dirección de Facturación
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Usa una nueva tarjeta
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Usa Amazon S3 para las Imágenes
     user: Usuario
     user_rule:
@@ -1317,12 +1481,13 @@ es:
     users: Usuarios
     validation:
       cannot_be_less_than_shipped_units: no puede ser menor que el número de unidades enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: excede el stock disponible. Por favor asegúrate que los artículos tienen un cantidad válida.
       is_too_large: demasiado grande -- el stock disponible no puede cubrir la cantidad solicitada
       must_be_int: debe ser un número entero
       must_be_non_negative: debe ser un valor no negativo
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Valor
     variant: Variante
     variant_placeholder: Escoge una variante
@@ -1341,3 +1506,10 @@ es:
     zipcode: Código Postal
     zone: Zona
     zones: Zonas
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1,4 +1,6 @@
+---
 et:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ et:
         state: Maakond
         zipcode: Postiindeks
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,59 +26,60 @@ et:
         name: Name
         numcode: ISO Code
       spree/credit_card:
-        base:
-        cc_type:
-        month:
-        name:
-        number:
-        verification_value:
-        year:
+        base: TODO_TRANSLATE
+        cc_type: TODO_TRANSLATE
+        month: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        number: TODO_TRANSLATE
+        verification_value: TODO_TRANSLATE
+        year: TODO_TRANSLATE
       spree/inventory_unit:
-        state:
+        state: TODO_TRANSLATE
       spree/line_item:
-        price:
-        quantity:
+        price: TODO_TRANSLATE
+        quantity: TODO_TRANSLATE
       spree/option_type:
-        name:
-        presentation:
+        name: TODO_TRANSLATE
+        presentation: TODO_TRANSLATE
       spree/order:
-        checkout_complete:
+        checkout_complete: TODO_TRANSLATE
         completed_at: Esitatud
-        considered_risky:
-        coupon_code:
+        considered_risky: TODO_TRANSLATE
+        coupon_code: TODO_TRANSLATE
         created_at: Tellimuse kuupäev
         email: Kliendi e-post
         ip_address: IP Aadress
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
+        item_total: TODO_TRANSLATE
+        number: TODO_TRANSLATE
+        payment_state: TODO_TRANSLATE
+        shipment_state: TODO_TRANSLATE
+        special_instructions: TODO_TRANSLATE
+        state: TODO_TRANSLATE
         total: Kokku
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/payment:
         amount: Summa
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nimetus
       spree/product:
         available_on: Saadaval alates
-        cost_currency:
+        cost_currency: TODO_TRANSLATE
         cost_price: Cost Price
         description: Kirjeldus
         master_price: Hind
@@ -85,17 +88,18 @@ et:
         shipping_category: Tarnekategooria
         tax_category: Maksukategooria
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: TODO_TRANSLATE
+        code: TODO_TRANSLATE
+        description: TODO_TRANSLATE
+        event_name: TODO_TRANSLATE
+        expires_at: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        path: TODO_TRANSLATE
+        starts_at: TODO_TRANSLATE
+        usage_limit: TODO_TRANSLATE
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Nimetus
         presentation: Presentation
@@ -105,24 +109,26 @@ et:
         amount: Kogus
       spree/role:
         name: Nimetus
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
-        abbr:
-        name:
+        abbr: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Kirjeldus
         name: Nimetus
@@ -141,14 +147,14 @@ et:
         password: Salasõna
         password_confirmation: Salasõna kordus
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        depth: TODO_TRANSLATE
+        height: TODO_TRANSLATE
+        price: TODO_TRANSLATE
+        sku: TODO_TRANSLATE
+        weight: TODO_TRANSLATE
+        width: TODO_TRANSLATE
       spree/zone:
         description: Kirjeldus
         name: Nimetus
@@ -157,48 +163,54 @@ et:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: Kaart on aegunud
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Aadress
         other: Adaressid
@@ -206,63 +218,86 @@ et:
         one: Riik
         other: Riigid
       spree/credit_card:
-      spree/customer_return:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/line_item:
-      spree/option_type:
-      spree/option_value:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Tellimus
         other: Tellimused
       spree/payment:
         one: Makse
         other: Maksed
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Toode
         other: Tooted
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
-      spree/return_authorization_reason:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipment:
         one: Tarne
         other: Tarned
       spree/shipping_category:
         one: Tarnekategooria
         other: Tarnekategooriad
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Maakond
         other: Maakonnad
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Maksukategooria
         other: Maksukategooriad
       spree/tax_rate:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxon:
         one: Takson
         other: Taksonid
       spree/taxonomy:
         one: Taksonoomia
         other: Taksonoomiad
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Kasutaja
         other: Kasutajad
       spree/variant:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/zone:
         one: Zone
         other: Zones
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Sinu konto on edukalt kinnitatud. Sa oled nüüd sisse logitud.
@@ -301,6 +336,7 @@ et:
     user_sessions:
       signed_in: Edukalt sisse logitud.
       signed_out: Edukalt välja logitud.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: on juba kinnitatud
@@ -309,12 +345,30 @@ et:
       not_saved:
         one: '1 viga takistas salvestamast objekti %{resource}:'
         other: "%{count} viga takistasid salvestamast objekti %{resource}:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Lühend
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Konto
     account_updated: Konto uuendatud
     action: Toiming
@@ -327,7 +381,7 @@ et:
       list: Loetelu
       listing: Loetelu
       new: Uus
-      refund:
+      refund: TODO_TRANSLATE
       save: Salvesta
       update: Uuendus
     activate: Activate
@@ -335,257 +389,316 @@ et:
     add: Lisa
     add_action_of_type: Lisa toimingu tüüp
     add_country: Lisa riik
-    add_coupon_code:
-    add_new_header:
-    add_new_style:
+    add_coupon_code: TODO_TRANSLATE
+    add_new_header: TODO_TRANSLATE
+    add_new_style: TODO_TRANSLATE
     add_one: Lisa üks
     add_option_value: Lisa variatsionitüübi variante
     add_product: Lisa toode
     add_product_properties: Lisa toote omadusi
-    add_rule_of_type:
+    add_rule_of_type: TODO_TRANSLATE
     add_state: Lisa maakond
-    add_stock:
-    add_stock_management:
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: Lisa ostukorvi
     add_variant: Lisa variant
     additional_item: Iga järgneva toote summa
+    address: TODO_TRANSLATE
     address1: Aadress
     address2: Aadress (jätkub)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Täiendus
     adjustment_amount: Kogus
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: Adjustment Total
     adjustments: Täiendused
     admin:
       tab:
         configuration: Seadistus
-        option_types:
-        orders:
-        overview:
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
         products: Tooted
-        promotions:
-        properties:
-        prototypes:
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: Raportid
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Kasutajad
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administreerimisliides
-    advertise:
-    agree_to_privacy_policy:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
     agree_to_terms_of_service: Nõustu Kasutustingimustega
     all: Kõik
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
     all_departments: Kõik osakonnad
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    all_items_have_been_returned: TODO_TRANSLATE
+    allow_ssl_in_development_and_test: TODO_TRANSLATE
+    allow_ssl_in_production: TODO_TRANSLATE
+    allow_ssl_in_staging: TODO_TRANSLATE
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: Alternatiivne tekst
     alternative_phone: Teine telefoninumber
     amount: Summa
     analytics_desc_header_1: Spree Analüütika
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
     analytics_desc_list_4: See on täiesti tasuta!
     analytics_trackers: Google Analytics
-    and:
-    approve:
-    approved_at:
-    approver:
+    and: TODO_TRANSLATE
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Kas oled kindel?
     are_you_sure_delete: Kas oled kindel, et soovid seda kirjet kustutada?
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Tõrge autoriseerimisel
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Saadaval alates
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Tagasi
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_end: TODO_TRANSLATE
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Mine tagasi poodi
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Tasuda jäänud
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Arve saaja aadress
     billing: Arve esitamine
     billing_address: Arve saaja aadress
     both: Mõlemad
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Kalkulaator
     calculator_settings_warning: Kalkulaatoritüübi ja -seadete muutmiseks pead kõigepealt salvestama.
     cancel: Tühista
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
+    cannot_create_payment_without_payment_methods: TODO_TRANSLATE
     cannot_create_returns: Tellimust ei saa tagastada, kuna seda pole veel väljastatud.
-    cannot_perform_operation:
-    cannot_set_shipping_method_without_address:
+    cannot_perform_operation: TODO_TRANSLATE
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: Lõpeta makse
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kaardikood
     card_number: Kaardi number
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Kaarditüüp on
     cart: Ostukorv
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Katergooriad
     category: Kategooria
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Vormista tellimus
     choose_a_customer: Vali klient
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: TODO_TRANSLATE
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
     city: Linn
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Võta aluseks
     close: Sulge
-    close_all_adjustments:
+    close_all_adjustments: TODO_TRANSLATE
     code: Kood
     company: Ettevõte
     complete: Esitatud
     configuration: Konfiguratsioon
     configurations: Konfiguratsioon
+    configure_s3: TODO_TRANSLATE
     confirm: Kinnita
     confirm_delete: Kinnita kustutamine
     confirm_password: Kinnita salasõna
     continue: Jätka
     continue_shopping: Jätka ostlemist
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: Omahind
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
     countries: Riigid
     country: Riik
     country_based: Riigipõhine
     country_name: Nimi
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon:
-    coupon_code:
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
+    coupon: TODO_TRANSLATE
+    coupon_code: TODO_TRANSLATE
+    coupon_code_already_applied: TODO_TRANSLATE
+    coupon_code_applied: TODO_TRANSLATE
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Loo kasutajakonto
     create_a_new_account: Loo uus konto
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Loodud
     credit: Krediit
     credit_card: Krediitkaart
-    credit_cards:
+    credit_cards: TODO_TRANSLATE
     credit_owed: Krediit võlgu
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credits: TODO_TRANSLATE
+    currency: TODO_TRANSLATE
+    currency_decimal_mark: TODO_TRANSLATE
+    currency_settings: TODO_TRANSLATE
+    currency_symbol_position: TODO_TRANSLATE
+    currency_thousands_separator: TODO_TRANSLATE
     current: Praegune
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Klient
     customer_details: Kliendi andmed
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Kliendi otsing
-    cut:
-    cvv_response:
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
     date: Kuupäev
-    date_completed:
+    date_completed: TODO_TRANSLATE
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: Vali vahemik
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default: TODO_TRANSLATE
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
     delete: Kustuta
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Delivery
     depth: Sügavus
     description: Kirjeldus
-    destination:
+    destination: TODO_TRANSLATE
     destroy: Kustuta
-    details:
-    discount_amount:
-    dismiss_banner:
+    details: TODO_TRANSLATE
+    discount_amount: TODO_TRANSLATE
+    dismiss_banner: TODO_TRANSLATE
     display: Kuvatav väärtus
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: TODO_TRANSLATE
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Muuda
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Muuda kasutajakonto andmeid
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
+    email: TODO_TRANSLATE
     empty: Tühi
     empty_cart: Tühjenda ostukorv
     enable_mail_delivery: Luba e-mailide saatmine
@@ -595,51 +708,55 @@ et:
     error: Viga
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
+        could_not_create_taxon: TODO_TRANSLATE
+        no_payment_methods_available: TODO_TRANSLATE
+        no_shipping_methods_available: TODO_TRANSLATE
     errors_prohibited_this_record_from_being_saved:
+      one: TODO_TRANSLATE
+      other: TODO_TRANSLATE
     event: Sündmus
     events:
       spree:
         cart:
           add: Lisa ostukorvi
         checkout:
-          coupon_code_added:
+          coupon_code_added: TODO_TRANSLATE
         content:
-          visited:
+          visited: TODO_TRANSLATE
         order:
-          contents_changed:
-        page_view:
+          contents_changed: TODO_TRANSLATE
+        page_view: TODO_TRANSLATE
         user:
-          signup:
+          signup: TODO_TRANSLATE
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Aegub
     extension: Laiendus
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Faili nimi
-    fill_in_customer_info:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
     filter_results: Filtreeri tulemusi
     finalize: Lõpeta
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Esimese toote summa
     first_name: Eesnimi
     first_name_begins_with: Eesnimi algab
     flat_percent: Fikseeritud protsent
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Fikseeritud summa tellimuse kohta
     flexible_rate: Paindlik summa
     forgot_password: Unustasid salasõna?
-    free_shipping:
-    free_shipping_amount:
-    front_end:
+    free_shipping: TODO_TRANSLATE
+    free_shipping_amount: TODO_TRANSLATE
+    front_end: TODO_TRANSLATE
     gateway: Lüüs
-    gateway_config_unavailable:
+    gateway_config_unavailable: TODO_TRANSLATE
     gateway_error: Lüüsi viga
     general: "Üldine"
     general_settings: "Üldised sätted"
@@ -649,77 +766,87 @@ et:
     guest_user_account: Vormista ost külalisena
     has_no_shipped_units: Postitatud esemed puuduvad
     height: Kõrgus
-    hide_cents:
+    hide_cents: TODO_TRANSLATE
     home: Avaleht
     i18n:
-      available_locales:
-      fields:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
       language: Keel
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: Eesti keel
       translations: Tõlked
     icon: Icon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Pilt
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Pildid
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
+    included_in_price: TODO_TRANSLATE
+    included_price_validation: TODO_TRANSLATE
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: Täida allolev vorm. Juhised salasõna uuesti seadistamiseks saadetakse Teile e-maili teel.
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
-    intercept_email_address:
-    intercept_email_instructions:
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    insufficient_stock_lines_present: TODO_TRANSLATE
+    intercept_email_address: TODO_TRANSLATE
+    intercept_email_instructions: TODO_TRANSLATE
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: Varustus
     inventory_adjustment: Laoseisu korrigeerimine
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: Pole tarneaadressile saadaval
-    iso_name:
+    iso_name: TODO_TRANSLATE
     item: Toode
     item_description: Toote kirjeldus
     item_total: Tooted kokku
     item_total_rule:
       operators:
-        gt:
-        gte:
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        gt: TODO_TRANSLATE
+        gte: TODO_TRANSLATE
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
-      path:
+      path: TODO_TRANSLATE
     last_name: Perekonnanimi
     last_name_begins_with: Perekonnanimi algab
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Loetelu
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Laen...
     locale_changed: Keel vahetatud
     location: Asukoht
-    lock:
-    log_entries:
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
     logged_in_as: 'Sisse logitud:'
     logged_in_succesfully: Sisselogimine õnnestus!
     logged_out: Oled välja logitud!
@@ -728,38 +855,41 @@ et:
     login_failed: Sisselogimine ebaõnnestus. Palun kontrolli sisestatud andmeid.
     login_name: Kasutajanimi
     logout: Logi välja
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Teised sarnased tooted
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Teosta tagasimakse
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Hind
     match_choices:
-      all:
-      none:
+      all: TODO_TRANSLATE
+      none: TODO_TRANSLATE
     max_items: Maksimaalne toodete arv
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Kirjeldus
     meta_keywords: Märksõnad
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metaandmed
     minimal_amount: Minimal Amount
     month: Kuu
-    more:
-    move_stock_between_locations:
+    more: TODO_TRANSLATE
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: Minu konto
     my_orders: Minu tellimused
     name: Nimi
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Nimetus või SKU
     new: Uus
     new_adjustment: Uus täiendus
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Registreeru
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Uus pilt
     new_option_type: Uus valik
     new_order: Uus tellimus
@@ -768,20 +898,21 @@ et:
     new_payment_method: Uus maksemeetod
     new_product: Uus toode
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Uus omadus
     new_prototype: Uus prototüüp
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Uue toote tagastamine
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Uus tarnekategooria
     new_shipping_method: Uus tarnemeetod
     new_state: Uus maakond
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: Uus maksukategooria
     new_tax_rate: Uus maksumäär
     new_taxon: Uus liik
@@ -791,25 +922,31 @@ et:
     new_variant: Uus variant
     new_zone: Uus tsoon
     next: Järgmine
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: tooteid ei leitud
-    no_resource_found:
-    no_results:
-    no_returns_found:
-    no_rules_added:
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
+    no_results: TODO_TRANSLATE
+    no_returns_found: TODO_TRANSLATE
+    no_rules_added: TODO_TRANSLATE
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: Puuduvad
-    none_selected:
-    normal_amount:
+    none_selected: TODO_TRANSLATE
+    normal_amount: TODO_TRANSLATE
     not: mitte
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Toode on kloonitud
       product_deleted: Toode on kustutatud
@@ -817,47 +954,52 @@ et:
       product_not_deleted: Toote kustutamine ebaõnnestus
       variant_deleted: Variant kustutatud
       variant_not_deleted: Variandi kustutamine ebaõnnestus
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Laoseis
     open: Ava
-    open_all_adjustments:
-    option_type:
-    option_type_placeholder:
+    open_all_adjustments: TODO_TRANSLATE
+    option_type: TODO_TRANSLATE
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Variatsioonid
-    option_value:
+    option_value: TODO_TRANSLATE
     option_values: valiku väärtused
     optional: Valikuline
     options: Variatsioonid
     or: või
-    or_over_price:
+    or_over_price: TODO_TRANSLATE
     order: Tellimus
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_adjustments: TODO_TRANSLATE
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Tellimuse info
     order_email_resent: E-mail tellimuse kohta uuesti saadetud
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Tellimus edastatud
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: Aadress
       awaiting_return: ootab tagastamist
@@ -865,7 +1007,7 @@ et:
       cart: Ostukorv
       complete: Esitatud
       confirm: kinnitamine
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: Saatmine
       payment: Tasumine
       resumed: resumed
@@ -875,28 +1017,30 @@ et:
     order_total: Tellimus kokku
     order_updated: Tellimus uuendatud
     orders: Tellimused
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Laost lõppenud
     overview: "Ülevaade"
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
-      next_page:
-      previous_page:
+      first: TODO_TRANSLATE
+      next_page: TODO_TRANSLATE
+      previous: TODO_TRANSLATE
+      previous_page: TODO_TRANSLATE
       truncate: "…"
     password: Salasõna
     paste: Paste
     path: Teekond
     pay: Maksa
     payment: Makse
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Makse informatsioon
     payment_method: Makseviis
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Makseviisid
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
+    payment_processing_failed: TODO_TRANSLATE
+    payment_processor_choose_banner_text: TODO_TRANSLATE
+    payment_processor_choose_link: TODO_TRANSLATE
     payment_state: Makse staatus
     payment_states:
       balance_due: Ootab tasumist
@@ -910,94 +1054,100 @@ et:
       void: Kehtetu
     payment_updated: Makse uuendatud
     payments: Maksed
-    pending:
+    pending: TODO_TRANSLATE
     percent: Protsent
     percent_per_item: Percent Per Item
     permalink: Püsiviide
     phone: Telefon
     place_order: Esita tellimus
-    please_define_payment_methods:
-    populate_get_error:
+    please_define_payment_methods: TODO_TRANSLATE
+    please_enter_reasonable_quantity: TODO_TRANSLATE
+    populate_get_error: TODO_TRANSLATE
     powered_by: Toetab
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Kuvatav väärtus
     previous: Eelmine
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Hind
-    price_range:
-    price_sack:
+    price_range: TODO_TRANSLATE
+    price_sack: TODO_TRANSLATE
     process: Töötle
     product: Toode
     product_details: Tooteinfo
     product_has_no_description: Tootel puudub kirjeldus
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Toote omadused
     product_rule:
-      choose_products:
-      label:
-      match_all:
-      match_any:
-      match_none:
+      choose_products: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
+      match_none: TODO_TRANSLATE
       product_source:
-        group:
-        manual:
-    products:
-    promotion:
-    promotion_action:
+        group: TODO_TRANSLATE
+        manual: TODO_TRANSLATE
+    products: TODO_TRANSLATE
+    promotion: TODO_TRANSLATE
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: TODO_TRANSLATE
+        any: TODO_TRANSLATE
+    promotion_label: TODO_TRANSLATE
+    promotion_rule: TODO_TRANSLATE
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       item_total:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       landing_page:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Kampaaniad
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Omadused
     property: Omadus
     prototype: Prototüüp
@@ -1008,47 +1158,49 @@ et:
     quantity: Kogus
     quantity_returned: Quantity Returned
     quantity_shipped: Tarnitud kogus
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Hind
     reason: Põhjus
     receive: Võta vastu
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: Vastu võetud
-    reception_status:
-    reference:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
     refund: Tagasimakse
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registreeri kasutajakonto
     registration: Registreeru või vormista ost külalisena
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Mäleta mind
     remove: Eemalda
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: Aruanded
+    resellable: TODO_TRANSLATE
     resend: Saada uuesti
     reset_password: Lähtesta salasõna
     response_code: Vastuse kood
@@ -1056,186 +1208,213 @@ et:
     resumed: Jätkatud
     return: Tagastama
     return_authorization: Tagasta toode
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Toote tagastamine uuendatud
     return_authorizations: Tagasta tooted
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Tagastatav kogus
     returned: Tagastatud
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
+    returns: TODO_TRANSLATE
+    review: TODO_TRANSLATE
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
+    rma_credit: TODO_TRANSLATE
     rma_number: Tagastatud toote number
     rma_value: Tagastatud toote väärtus
+    role_id: TODO_TRANSLATE
     roles: Rollid
-    rules:
-    safe:
+    rules: TODO_TRANSLATE
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Kogumüük
     sales_total_description: Tellimuste tulu kokku
-    sales_totals:
+    sales_totals: TODO_TRANSLATE
     save_and_continue: Salvesta ja jätka
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: TODO_TRANSLATE
+    say_no: TODO_TRANSLATE
+    say_yes: TODO_TRANSLATE
     scope: Käsitlusala
     search: Otsing
     search_results: Otsingu '%{keywords}' tulemused
     searching: Searching
     secure_connection_type: Turvalise ühenduse tüüp
-    security_settings:
+    security_settings: TODO_TRANSLATE
     select: Vali
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Vali prototüüpide hulgast
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Saada koopia kõikidest e-mailidest
     send_mails_as: Saada e-mailid kui
-    server:
+    server: TODO_TRANSLATE
     server_error: Serveris esines viga
     settings: Sätted
     ship: Saada
     ship_address: Kättetoimetamise aadress
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: Tarne
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        shipment_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        track_information: TODO_TRANSLATE
+        track_link: TODO_TRANSLATE
     shipment_state: Tarne staatus
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: partial
       pending: Ootel
       ready: Tarneks valmis
       shipped: Tarnitud
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Tarned
     shipped: Saadetud
     shipping: Transport
     shipping_address: Kättetoimetamise aadress
     shipping_categories: Saatmiskategooriad
     shipping_category: Saatmiskategooria
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: Kättetoimetamise lisainfo
     shipping_method: Tarneviis
     shipping_methods: Tarneviisid
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "%{taxonomy}:"
     shopping_cart: Ostukorv
     show: Näita
     show_active: Näita aktiivseid
     show_deleted: Näita kustutatuid
     show_only_complete_orders: Näita ainult täidetud tellimusi
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
     sku: SKU
-    skus:
-    slug:
-    source:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
     special_instructions: Tarne lisajuhised
-    split:
-    spree_gateway_error_flash_for_checkout:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
+    spree_gateway_error_flash_for_checkout: TODO_TRANSLATE
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Alates
+    start_date: TODO_TRANSLATE
     state: Maakond
     state_based: Maakonnapõhine
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Maakonnad
-    states_required:
+    states_required: TODO_TRANSLATE
     status: Staatus
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
     stop: Kuni
     store: Pood
     street_address: Tänav
     street_address_2: Tänav (jätkub)
     subtotal: Vahesumma
     subtract: Lahuta
-    success:
-    successfully_created:
-    successfully_refunded:
-    successfully_removed:
-    successfully_signed_up_for_analytics:
-    successfully_updated:
-    summary:
+    success: TODO_TRANSLATE
+    successfully_created: TODO_TRANSLATE
+    successfully_refunded: TODO_TRANSLATE
+    successfully_removed: TODO_TRANSLATE
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
+    successfully_updated: TODO_TRANSLATE
+    summary: TODO_TRANSLATE
     tax: Maksud
     tax_categories: Maksukategooriad
     tax_category: Maksukategooria
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Maksumäärad
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taksonoomia
     taxon_edit: Redigeeri taksonoomiaid
-    taxon_placeholder:
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taksonoomia
     taxonomy: Taxonomy
     taxonomy_edit: Redigeeri taksonoomiaid
@@ -1244,66 +1423,72 @@ et:
     taxons: Taksonid
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
-        greeting:
-        message:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
         subject: Testmail
     test_mode: Testrežiim
     thank_you_for_your_order: Täname teid tellimuse eest
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Pisipilt
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Aeg
     to_add_variants_you_must_first_define: variantide lisamiseks pead esmalt defineerima TODO
     total: Kokku
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Jälgimisnumber
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Puu
     type: Tüüp
-    type_to_search:
+    type_to_search: TODO_TRANSLATE
     unable_to_connect_to_gateway: Juurdepääs ebaõnnestus.
-    unable_to_create_reimbursements:
-    under_price:
-    unlock:
+    unable_to_create_reimbursements: TODO_TRANSLATE
+    under_price: TODO_TRANSLATE
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: Tundmatu kaarditüüp
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: Uuenda
     updating: Uuendan
     usage_limit: Kasutuslimiit
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Kasuta arve saaja aadressi
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Kasuta uut kaarti
-    use_s3:
+    use_new_cc_or_payment_method: TODO_TRANSLATE
+    use_s3: TODO_TRANSLATE
     user: Kasutaja
     user_rule:
-      choose_users:
+      choose_users: TODO_TRANSLATE
     users: Kasutajad
     validation:
-      cannot_be_less_than_shipped_units:
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_be_less_than_shipped_units: TODO_TRANSLATE
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: on liiga suur – laos puudub soovitud kogus!
       must_be_int: peab olema täisarv
       must_be_non_negative: peab olema positiivne arv
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Väärtus
-    variant:
-    variant_placeholder:
+    variant: TODO_TRANSLATE
+    variant_placeholder: TODO_TRANSLATE
     variants: Variandid
     version: Versioon
     void: Muuda kehtetuks
@@ -1314,8 +1499,15 @@ et:
     year: Aasta
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Ostukorv on tühi
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: Postiindeks
     zipcode: Postiindeks
     zone: Tsoon
     zones: Tsoonid
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,5 +1,6 @@
+---
 fa:
-  Bazaar: بازار
+  Bazaar: "بازار"
   activerecord:
     attributes:
       spree/address:
@@ -13,11 +14,11 @@ fa:
         state: "استان"
         zipcode: "کد پستی"
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -25,12 +26,12 @@ fa:
         name: "نام"
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: "نوع"
         month: "ماه"
-        name:
+        name: TODO_TRANSLATE
         number: "عدد"
-        verification_value:
+        verification_value: TODO_TRANSLATE
         year: "سال"
       spree/inventory_unit:
         state: "استان"
@@ -41,101 +42,104 @@ fa:
         name: "نام"
         presentation: "نمایش"
       spree/order:
-        checkout_complete:
-        completed_at: پایان یافته در
-        coupon_code: کد کوپن
-        created_at: ساخته شده در
-        email: ایمیل
-        ip_address: آدرس IP
-        item_total: مجموع ایتم ها
-        number: شماره
-        payment_state: وضعیت پرداخت
-        shipment_state: وضعیت مرسوله
-        special_instructions: دستورالعمل ویژه
-        state: وضعیت
-        total: مجموع
-        considered_risky: ریسکی
-
+        checkout_complete: TODO_TRANSLATE
+        completed_at: "پایان یافته در"
+        considered_risky: "ریسکی"
+        coupon_code: "کد کوپن"
+        created_at: "ساخته شده در"
+        email: "ایمیل"
+        ip_address: "آدرس IP"
+        item_total: "مجموع ایتم ها"
+        number: "شماره"
+        payment_state: "وضعیت پرداخت"
+        shipment_state: "وضعیت مرسوله"
+        special_instructions: "دستورالعمل ویژه"
+        state: "وضعیت"
+        total: "مجموع"
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/payment:
-        amount:
+        amount: TODO_TRANSLATE
+        number: TODO_TRANSLATE
       spree/payment_method:
-        name:
+        name: TODO_TRANSLATE
       spree/product:
         available_on: Available On
-        cost_currency:
+        cost_currency: TODO_TRANSLATE
         cost_price: Cost Price
         description: Description
         master_price: Master Price
-        name: نام
+        name: "نام"
         on_hand: On Hand
         shipping_category: Shipping Category
         tax_category: Tax Category
       spree/promotion:
-        advertise:
-        code: کد
-        description:
-        event_name:
-        expires_at:
+        advertise: TODO_TRANSLATE
+        code: "کد"
+        description: TODO_TRANSLATE
+        event_name: TODO_TRANSLATE
+        expires_at: TODO_TRANSLATE
         name: "نام"
         path: "مسیر"
-        starts_at:
-        usage_limit:
+        starts_at: TODO_TRANSLATE
+        usage_limit: TODO_TRANSLATE
       spree/promotion_category:
-        name: نام
+        code: TODO_TRANSLATE
+        name: "نام"
       spree/property:
         name: "نام"
         presentation: "نمایش"
       spree/prototype:
         name: "نام"
       spree/return_authorization:
-        amount: مقدار
+        amount: "مقدار"
       spree/role:
         name: "نام"
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
-        abbr:
+        abbr: TODO_TRANSLATE
         name: "نام"
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type: نوع
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: "نوع"
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: "توضیحات"
         name: "نام"
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: TODO_TRANSLATE
+        included_in_price: TODO_TRANSLATE
+        show_rate_in_label: TODO_TRANSLATE
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: TODO_TRANSLATE
+        permalink: TODO_TRANSLATE
+        position: TODO_TRANSLATE
       spree/taxonomy:
         name: "نام"
       spree/user:
@@ -143,14 +147,14 @@ fa:
         password: "رمز‌عبور"
         password_confirmation: "تایید رمز‌عبور"
       spree/variant:
-        cost_currency:
+        cost_currency: TODO_TRANSLATE
         cost_price: Cost Price
         depth: Depth
         height: Height
-        price: قیمت
-        sku: کد کالا
-        weight: وزن
-        width: عرض
+        price: "قیمت"
+        sku: "کد کالا"
+        weight: "وزن"
+        width: "عرض"
       spree/zone:
         description: "توضیحات"
         name: "نام"
@@ -159,48 +163,54 @@ fa:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired: اعتبار کارت تمام شده است
-              expiry_invalid:
+              card_expired: "اعتبار کارت تمام شده است"
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: "وضعیت بازپرداخت"
+      reimbursement_type: "نوع بازپرداخت"
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: "انواع بازپرداخت"
+      reimbursements: "بازپرداخت‌ها"
       spree/address:
         one: "آدرس"
         other: "آدرس‌ها"
@@ -210,58 +220,68 @@ fa:
       spree/credit_card:
         one: "کارت اعتباری"
         other: "کارت‌های اعتباری"
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/line_item:
-      spree/option_type: نوع گزینه
-      spree/option_value:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/option_type: "نوع گزینه"
+      spree/option_value: TODO_TRANSLATE
       spree/order:
-        one: سفارش
-        other: سفارشات
+        one: "سفارش"
+        other: "سفارشات"
       spree/payment:
         one: Payment
         other: Payments
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: "محصول"
         other: "محصول‌ها"
-      spree/promotion: فروش ویژه
-      spree/promotion_category: دسته بندی فروش ویژه
+      spree/promotion: "فروش ویژه"
+      spree/promotion_category: "دسته بندی فروش ویژه"
       spree/property:
         one: "خصوصیت"
         other: "خصوصیات"
       spree/prototype:
-        one: نمونه آزمایشی
-        other: نمنونه های آزمایشی
-      spree/refund_reason: دلیل استرداد
-      spree/reimbursement: بازپرداخت
-      spree/reimbursement_type: نوع بازپرداخت
-      reimbursement_perform_failed:
-      reimbursement_status: وضعیت بازپرداخت
-      reimbursement_type: نوع بازپرداخت
-      reimbursement_type_override:
-      reimbursement_types: انواع بازپرداخت
-      reimbursements: بازپرداخت‌ها
-      spree/return_authorization: مجوز بازگشت
-      spree/return_authorization_reason: دلیل مجوز بازگشت
-      spree/role: نقش
-      spree/shipment: نحوه ارسال
+        one: "نمونه آزمایشی"
+        other: "نمنونه های آزمایشی"
+      spree/refund_reason: "دلیل استرداد"
+      spree/reimbursement: "بازپرداخت"
+      spree/reimbursement_type: "نوع بازپرداخت"
+      spree/return_authorization: "مجوز بازگشت"
+      spree/return_authorization_reason: "دلیل مجوز بازگشت"
+      spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/shipment: "نحوه ارسال"
       spree/shipping_category:
-        one: دسته‌بندی حمل و نقل
-        other: دسته‌بندی حمل نقل
-      spree/shipping_method:
+        one: "دسته‌بندی حمل و نقل"
+        other: "دسته‌بندی حمل نقل"
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: State
         other: States
-      spree/stock_location:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/tax_rate:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: "کاربر"
         other: "کاربرها"
@@ -271,311 +291,421 @@ fa:
       spree/zone:
         one: Zone
         other: Zones
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
-      inactive:
-      invalid:
-      invalid_token:
-      locked:
-      timeout:
-      unauthenticated:
-      unconfirmed:
+      inactive: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      invalid_token: TODO_TRANSLATE
+      locked: TODO_TRANSLATE
+      timeout: TODO_TRANSLATE
+      unauthenticated: TODO_TRANSLATE
+      unconfirmed: TODO_TRANSLATE
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
-    quick_search: جستوجو سریع . . .
-    filter: فیلتر
     abbreviation: "مخفف"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "حساب"
     account_updated: "حساب شما بروزرسانی شد!"
     action: "حرکت"
     actions:
-      cancel: لغو
-      continue:
-      create: ایجاد
-      destroy: پاک کردن
-      edit: ویرایش
-      list: لیست
-      listing: لیست کردن
-      new: جدید
-      save:
-      update: بروز رسانی
+      cancel: "لغو"
+      continue: TODO_TRANSLATE
+      create: "ایجاد"
+      destroy: "پاک کردن"
+      edit: "ویرایش"
+      list: "لیست"
+      listing: "لیست کردن"
+      new: "جدید"
+      refund: TODO_TRANSLATE
+      save: TODO_TRANSLATE
+      update: "بروز رسانی"
     activate: Activate
-    active: فعال
-    add: افزودن
+    active: "فعال"
+    add: "افزودن"
     add_action_of_type: Add action of type
-    add_country: افزودن کشور
+    add_country: "افزودن کشور"
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
-    add_option_value: افزودن مقدار
-    add_product: افزودن محصول
-    add_product_properties: افزودن ویژگی های محصول
-    add_rule_of_type: افزودن قانون نوع
-    add_state: افزودن ایالت یا استان
-    add_stock:
-    add_stock_management:
-    add_to_cart: افزودن به سبد خرید
-    add_variant:
-    additional_item: قیمت آیتم اضافه شده
-    address1:
-    address2:
-    adjustment: تعدیل
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
-    adjustment_total: تعدیل کل
-    adjustments: تعدیلات
+    add_one: TODO_TRANSLATE
+    add_option_value: "افزودن مقدار"
+    add_product: "افزودن محصول"
+    add_product_properties: "افزودن ویژگی های محصول"
+    add_rule_of_type: "افزودن قانون نوع"
+    add_state: "افزودن ایالت یا استان"
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
+    add_to_cart: "افزودن به سبد خرید"
+    add_variant: TODO_TRANSLATE
+    additional_item: "قیمت آیتم اضافه شده"
+    address: TODO_TRANSLATE
+    address1: TODO_TRANSLATE
+    address2: TODO_TRANSLATE
+    adjustable: TODO_TRANSLATE
+    adjustment: "تعدیل"
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
+    adjustment_total: "تعدیل کل"
+    adjustments: "تعدیلات"
     admin:
       tab:
-        configuration: تنظیمات
-        orders: سفارشات
-        overview: نمای کلی
-        products: محصولات
-        promotions: فروش ویژه
-        properties: ویژگی ها
-        prototypes: نمونه های اولیه
-        reports: گزارشات
-        users: کاربران
-        option_types: انواع اختیارات
-        taxonomies: رده بندی
-        taxons: گونه
-    administration: مدیریت
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
-    all: همه
-    all_adjustments_closed:
-    all_adjustments_opened:
-    all_departments: همه ی دپارتمان ها
+        configuration: "تنظیمات"
+        option_types: "انواع اختیارات"
+        orders: "سفارشات"
+        overview: "نمای کلی"
+        products: "محصولات"
+        promotions: "فروش ویژه"
+        properties: "ویژگی ها"
+        prototypes: "نمونه های اولیه"
+        reports: "گزارشات"
+        taxonomies: "رده بندی"
+        taxons: "گونه"
+        users: "کاربران"
+      user:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
+    administration: "مدیریت"
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
+    all: "همه"
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
+    all_departments: "همه ی دپارتمان ها"
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
-    alt_text: متن جایگزین
-    alternative_phone: تلفن جایگزین
-    amount: مقدار
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
-    analytics_trackers: ردگیرهای تحلیلی
+    already_signed_up_for_analytics: TODO_TRANSLATE
+    alt_text: "متن جایگزین"
+    alternative_phone: "تلفن جایگزین"
+    amount: "مقدار"
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
+    analytics_trackers: "ردگیرهای تحلیلی"
     and: and
-    are_you_sure: آیا مطمئن هستید؟
-    are_you_sure_delete: آیا مطمئن هستید که می خواهید این سطر را پاک کنید؟
-    associated_adjustment_closed:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
+    are_you_sure: "آیا مطمئن هستید؟"
+    are_you_sure_delete: "آیا مطمئن هستید که می خواهید این سطر را پاک کنید؟"
+    associated_adjustment_closed: TODO_TRANSLATE
     attachment_default_style: Attachments Style
     attachment_default_url: Attachments URL
     attachment_path: Attachments Path
     attachment_styles: Paperclip Styles
-    attachment_url:
-    authorization_failure: خرابی در صدور مجوز
-    available_on: موجود است در
-    back: برگشت
+    attachment_url: TODO_TRANSLATE
+    authorization_failure: "خرابی در صدور مجوز"
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
+    available_on: "موجود است در"
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
+    back: "برگشت"
     back_end: Back End
     back_to_adjustments_list: Back To Adjustments List
     back_to_images_list: Back To Images List
-    back_to_option_types_list:
-    back_to_orders_list:
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
     back_to_payment_methods_list: Back To Payment Methods List
     back_to_payments_list: Back To Payments List
     back_to_products_list: Back To Products List
-    back_to_promotions_list: بازگشت به لیست محصولات
+    back_to_promotions_list: "بازگشت به لیست محصولات"
     back_to_properties_list: Back To Products List
     back_to_prototypes_list: Back To Prototypes List
     back_to_reports_list: Back To Reports List
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
     back_to_shipping_categories: Back To Shipping Categories
     back_to_shipping_methods_list: Back To Shipping Methods List
     back_to_states_list: Back To States List
-    back_to_stock_locations_list:
-    back_to_stock_movements_list:
-    back_to_stock_transfers_list:
-    back_to_store: بازگشت به فروشگاه
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
+    back_to_store: "بازگشت به فروشگاه"
     back_to_tax_categories_list: Back To Tax Categories List
     back_to_taxonomies_list: Back To Taxonomies List
     back_to_trackers_list: Back To Trackers List
-    back_to_users_list:
+    back_to_users_list: TODO_TRANSLATE
     back_to_zones_list: Back To Zones List
-    backorderable:
-    backorders_allowed:
-    balance_due: پرداخت نشده
-    bill_address: آدرس
-    billing: پرداخت
-    billing_address: آدرس پرداخت
-    both: هر دو
-    calculator: ماشین حساب
-    calculator_settings_warning: اگر می خواهید نوع ماشین حساب را تغییر دهید، باید پیش از انجام تغییرات، حالت فعلی را ذخیره کنید
-    cancel: لغو
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
+    balance_due: "پرداخت نشده"
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
+    bill_address: "آدرس"
+    billing: "پرداخت"
+    billing_address: "آدرس پرداخت"
+    both: "هر دو"
+    calculated_reimbursements: TODO_TRANSLATE
+    calculator: "ماشین حساب"
+    calculator_settings_warning: "اگر می خواهید نوع ماشین حساب را تغییر دهید، باید پیش از انجام تغییرات، حالت فعلی را ذخیره کنید"
+    cancel: "لغو"
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order no shipped units.
-    cannot_perform_operation: عملیات درخواستی قابل انجام نیست
-    cannot_set_shipping_method_without_address:
+    cannot_perform_operation: "عملیات درخواستی قابل انجام نیست"
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: Capture
-    card_code: کد کارت
-    card_number: شماره کارت
-    card_type_is: نوع کارت
-    cart: سبد خرید
-    categories: دسته بندی ها
-    category: دسته بندی
-    check_for_spree_alerts:
-    checkout: تصفیه حساب
-    choose_a_customer:
-    choose_currency: انتخاب واحد پول
-    choose_dashboard_locale:
-    city: شهر
+    capture_events: TODO_TRANSLATE
+    card_code: "کد کارت"
+    card_number: "شماره کارت"
+    card_type: TODO_TRANSLATE
+    card_type_is: "نوع کارت"
+    cart: "سبد خرید"
+    cart_subtotal: TODO_TRANSLATE
+    categories: "دسته بندی ها"
+    category: "دسته بندی"
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
+    checkout: "تصفیه حساب"
+    choose_a_customer: TODO_TRANSLATE
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: "انتخاب واحد پول"
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
+    city: "شهر"
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clone
-    close:
-    close_all_adjustments:
-    code: کد
-    company: کمپانی
-    complete: تکمیل
-    configuration: پیکربندی
-    configurations: پیکربندی ها
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
+    code: "کد"
+    company: "کمپانی"
+    complete: "تکمیل"
+    configuration: "پیکربندی"
+    configurations: "پیکربندی ها"
     configure_s3: Configure S3
-    confirm: تایید
-    confirm_delete: تایید حذف
-    confirm_password: تکرار رمز عبور
-    continue: ادامه
-    continue_shopping: ادامه خرید
-    cost_currency: واحد پول
-    cost_price: قیمت
-    could_not_connect_to_jirafe:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries: کشورها
-    country: کشور
-    country_based: بر حسب کشور
-    country_name:
-    coupon: کوپن
-    coupon_code: کد کوپن
-    coupon_code_already_applied:
+    confirm: "تایید"
+    confirm_delete: "تایید حذف"
+    confirm_password: "تکرار رمز عبور"
+    continue: "ادامه"
+    continue_shopping: "ادامه خرید"
+    cost_currency: "واحد پول"
+    cost_price: "قیمت"
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
+    countries: "کشورها"
+    country: "کشور"
+    country_based: "بر حسب کشور"
+    country_name: TODO_TRANSLATE
+    country_names:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
+    coupon: "کوپن"
+    coupon_code: "کد کوپن"
+    coupon_code_already_applied: TODO_TRANSLATE
     coupon_code_applied: The coupon code was successfully applied to your order.
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    create: ایجاد
-    create_a_new_account: ایجاد یک حساب جدید
-    created_at:
-    credit: اعتبار
-    credit_card: کارت اعتباری
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
+    create: "ایجاد"
+    create_a_new_account: "ایجاد یک حساب جدید"
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
+    credit: "اعتبار"
+    credit_card: "کارت اعتباری"
     credit_cards: Credit Cards
-    credit_owed: اعتبار مقروض
-    currency: واحد پول
-    currency_decimal_mark:
+    credit_owed: "اعتبار مقروض"
+    credits: TODO_TRANSLATE
+    currency: "واحد پول"
+    currency_decimal_mark: TODO_TRANSLATE
     currency_settings: Currency Settings
     currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator:
-    current: جاری
-    current_promotion_usage:
-    customer: مشتری
-    customer_details: جزئیات مشتری
+    currency_thousands_separator: TODO_TRANSLATE
+    current: "جاری"
+    current_promotion_usage: TODO_TRANSLATE
+    customer: "مشتری"
+    customer_details: "جزئیات مشتری"
     customer_details_updated: The customer's details have been updated.
-    customer_search: جستجوی مشتری
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
+    customer_search: "جستجوی مشتری"
     cut: Cut
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
-    date_range: محدوده ی زمانی
-    default: پیش فرض
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
+    date_range: "محدوده ی زمانی"
+    default: "پیش فرض"
     default_meta_description: Default Meta Description
     default_meta_keywords: Default Meta Keywords
+    default_refund_amount: TODO_TRANSLATE
     default_seo_title: Default Seo Title
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
-    delete: حذف
-    delivery: تحویل
-    depth: عمق
-    description: توضیح
-    destination:
-    destroy: پاک کردن
-    discount_amount: مقدار تخفیف
+    delete: "حذف"
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
+    delivery: "تحویل"
+    depth: "عمق"
+    description: "توضیح"
+    destination: TODO_TRANSLATE
+    destroy: "پاک کردن"
+    details: TODO_TRANSLATE
+    discount_amount: "مقدار تخفیف"
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
-    display: نمایش
+    display: "نمایش"
     display_currency: Display currency
-    edit: ویرایش
-    editing_resource: ویرایش منابع
-    editing_rma_reason: ویرایش دلایل RMA
-    editing_option_type: ویرایش نوع انتخاب
-    editing_payment_method: ویرایش متد پرداخت
-    editing_product: ویرایش محصول
+    doesnt_track_inventory: TODO_TRANSLATE
+    edit: "ویرایش"
+    editing_option_type: "ویرایش نوع انتخاب"
+    editing_payment_method: "ویرایش متد پرداخت"
+    editing_product: "ویرایش محصول"
     editing_promotion: Editing Promotion
-    editing_property: ویرایش اموال
-    editing_prototype: ویرایش نمونه اولیه
-    editing_shipping_category: ویرایش دسته بندی ارسال
-    editing_shipping_method: ویرایش روش ارسال
-    editing_state: ویرایش ایالت یا استان
-    editing_stock_location:
-    editing_stock_movement:
-    editing_tax_category: ویرایش دسته بندی مالیات
-    editing_tax_rate: ویرایش نرخ مالیات
-    editing_tracker: ویرایش ردگیر
-    editing_user: ویرایش کاربر
-    editing_zone: ویرایش ناحیه
-    email: ایمیل
-    empty: خالی
-    empty_cart: سبد خرید خالی شود
-    enable_mail_delivery: فعال سازی تحویل نامه
-    end:
+    editing_property: "ویرایش اموال"
+    editing_prototype: "ویرایش نمونه اولیه"
+    editing_resource: "ویرایش منابع"
+    editing_rma_reason: "ویرایش دلایل RMA"
+    editing_shipping_category: "ویرایش دسته بندی ارسال"
+    editing_shipping_method: "ویرایش روش ارسال"
+    editing_state: "ویرایش ایالت یا استان"
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: "ویرایش دسته بندی مالیات"
+    editing_tax_rate: "ویرایش نرخ مالیات"
+    editing_tracker: "ویرایش ردگیر"
+    editing_user: "ویرایش کاربر"
+    editing_zone: "ویرایش ناحیه"
+    eligibility_errors:
+      messages:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
+    email: "ایمیل"
+    empty: "خالی"
+    empty_cart: "سبد خرید خالی شود"
+    enable_mail_delivery: "فعال سازی تحویل نامه"
+    end: TODO_TRANSLATE
     ending_in: Ending in
-    environment: محیط
-    error: ایراد
+    environment: "محیط"
+    error: "ایراد"
     errors:
       messages:
         could_not_create_taxon: "امکان ایجاد نوع دسته‌بندی وجود ندارد"
-        no_payment_methods_available:
+        no_payment_methods_available: TODO_TRANSLATE
         no_shipping_methods_available: "ارسال برای ناحیه انتخاب شده مقدور نمی‌باشد، لطفا منطقه‌ی دیگری را انتخاب کنید"
     errors_prohibited_this_record_from_being_saved:
       one: "یک ایراد مانع از انجام ذخیره‌سازی است"
@@ -588,424 +718,552 @@ fa:
         checkout:
           coupon_code_added: "کد کوپن اضافه شد"
         content:
-          visited:
+          visited: TODO_TRANSLATE
         order:
           contents_changed: "محتویات سفارش تغییر یافت"
-        page_view:
+        page_view: TODO_TRANSLATE
         user:
           signup: "ثبت‌نام کاربر"
     exceptions:
-      count_on_hand_setter:
-    expiration: انقضاء
-    extension: الحاقی
-    filename: نام فایل
-    fill_in_customer_info:
-    filter_results: فیلتر کردن نتایج
-    finalize: نهایی کردن
-    first_item: هزینه اولین آیتم
-    first_name: نام
-    first_name_begins_with: حرف آغازین نام
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
+    expiration: "انقضاء"
+    extension: "الحاقی"
+    failed_payment_attempts: TODO_TRANSLATE
+    filename: "نام فایل"
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: "فیلتر"
+    filter_results: "فیلتر کردن نتایج"
+    finalize: "نهایی کردن"
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
+    first_item: "هزینه اولین آیتم"
+    first_name: "نام"
+    first_name_begins_with: "حرف آغازین نام"
     flat_percent: Flat Percent
     flat_rate_per_item: Flat Rate (per item)
     flat_rate_per_order: Flat Rate (per order)
     flexible_rate: Flexible Rate
-    forgot_password: آیا رمز عبور را فراموش کرده اید؟
-    free_shipping: ارسال رایگان
+    forgot_password: "آیا رمز عبور را فراموش کرده اید؟"
+    free_shipping: "ارسال رایگان"
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
-    gateway: درگاه
-    gateway_config_unavailable: درگاه برای این محیط در دسترس نیست
-    gateway_error: ایراد درگاه
-    general: عمومی
-    general_settings: تنظیمات عمومی
+    gateway: "درگاه"
+    gateway_config_unavailable: "درگاه برای این محیط در دسترس نیست"
+    gateway_error: "ایراد درگاه"
+    general: "عمومی"
+    general_settings: "تنظیمات عمومی"
     google_analytics: Google Analytics
     google_analytics_id: Analytics ID
-    guest_checkout: تصفیه حساب میهمان
-    guest_user_account: تصفیه حساب به عنوان کاربر میهمان
+    guest_checkout: "تصفیه حساب میهمان"
+    guest_user_account: "تصفیه حساب به عنوان کاربر میهمان"
     has_no_shipped_units: has no shipped units
-    height: ارتفاع
-    hide_cents:
-    home: صفحه اصلی
+    height: "ارتفاع"
+    hide_cents: TODO_TRANSLATE
+    home: "صفحه اصلی"
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
-      this_file_language: فارسی(fa)
-      translations:
-    icon: آیکون
-    image: تصویر
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
+      this_file_language: "فارسی(fa)"
+      translations: TODO_TRANSLATE
+    icon: "آیکون"
+    identifier: TODO_TRANSLATE
+    image: "تصویر"
     image_settings: Image Settings
     image_settings_updated: Image Settings successfully updated.
     image_settings_warning: You will need to regenerate thumbnails if you update the paperclip styles. Use rake paperclip:refresh:thumbnails to do this.
-    images: تصاویر
+    images: "تصاویر"
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    instructions_to_reset_password: فرم زیر را کامل کنید، طریقه ایجاد رمز عبور جدید برای شما ایمیل خواهد شد
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
+    instructions_to_reset_password: "فرم زیر را کامل کنید، طریقه ایجاد رمز عبور جدید برای شما ایمیل خواهد شد"
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
-    internal_name:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
-    inventory: انبار
-    inventory_adjustment: تعدیلات انبار
-    inventory_error_flash_for_insufficient_quantity:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
+    inventory: "انبار"
+    inventory_adjustment: "تعدیلات انبار"
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: is not available to shipment address
-    iso_name:
-    item: آیتم
-    item_description: توضیحات آیتم
-    item_total: کل آیتم ها
+    iso_name: TODO_TRANSLATE
+    item: "آیتم"
+    item_description: "توضیحات آیتم"
+    item_total: "کل آیتم ها"
     item_total_rule:
       operators:
-        gt: بیشتر از
-        gte: بیشتر از یا مساوی با
-    items_cannot_be_shipped:
-    jirafe:
+        gt: "بیشتر از"
+        gte: "بیشتر از یا مساوی با"
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
       path: Path
-    last_name: نام خانوادگی
-    last_name_begins_with: حرف آغازین نام خانوادگی
+    last_name: "نام خانوادگی"
+    last_name_begins_with: "حرف آغازین نام خانوادگی"
     learn_more: Learn More
-    list: لیست
-    listing_countries:
-    listing_orders: لیست کردن سفارش ها
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
+    list: "لیست"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: "لیست کردن سفارش ها"
     listing_products: Listing Products
-    listing_reports: لیست کردن گزارش ها
-    listing_tax_categories: لیست کردن دسته بندی های مالیات
-    listing_users: لیست کردن کاربران
-    loading: در حال بارگذاری
-    locale_changed: (زبان سایت به فارسی تغییر کرد)
-    location:
-    lock:
-    logged_in_as: شما وارد شدید به عنوان
-    logged_in_succesfully: ورود موفقیت آمیز بود
-    logged_out: شما خارج شدید
-    login: ورود
+    listing_reports: "لیست کردن گزارش ها"
+    listing_tax_categories: "لیست کردن دسته بندی های مالیات"
+    listing_users: "لیست کردن کاربران"
+    loading: "در حال بارگذاری"
+    locale_changed: "(زبان سایت به فارسی تغییر کرد)"
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
+    logged_in_as: "شما وارد شدید به عنوان"
+    logged_in_succesfully: "ورود موفقیت آمیز بود"
+    logged_out: "شما خارج شدید"
+    login: "ورود"
     login_as_existing: Log In as Existing Customer
-    login_failed: ورود شما موفقیت آمیز نبود
-    login_name: ورود
-    logout: خروج
-    look_for_similar_items: جستجوی اقلام مشابه
+    login_failed: "ورود شما موفقیت آمیز نبود"
+    login_name: "ورود"
+    logout: "خروج"
+    logs: TODO_TRANSLATE
+    look_for_similar_items: "جستجوی اقلام مشابه"
     maestro_or_solo_cards: Maestro/Solo cards
-    mail_method_settings:
-    mail_methods: متدهای نامه
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: "متدهای نامه"
     make_refund: Make refund
-    master_price: قیمت اصلی
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
+    master_price: "قیمت اصلی"
     match_choices:
-      all: همه
-      none: هیچی
-    max_items: حداکثر اقلام
+      all: "همه"
+      none: "هیچی"
+    max_items: "حداکثر اقلام"
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta Description
     meta_keywords: Meta Keywords
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
-    minimal_amount: حداقل مقدار
-    month: ماه
-    more: بیشتر
-    move_stock_between_locations:
-    my_account: حساب من
-    my_orders: سفارش های من
-    name: نام
-    name_or_sku: نام یا کد کالا
-    new: جدید
-    new_adjustment: تعدیل جدید
-    new_customer: مشتری جدید
-    new_image: تصویر جدید
-    new_option_type: نوع جدید
-    new_order: سفارش جدید
-    new_order_completed: سفارش جدید کامل شد
-    new_payment: پرداخت جدید
-    new_payment_method: متد پرداخت جدید
-    new_product: محصول جدید
-    new_promotion: فروش ویژه جدید
-    new_promotion_category: دسته بندی جدید برای فروش ویژه
-    new_property: ویژگی جدید
-    new_prototype: نمونه اولیه جدید
-    new_return_authorization: جدید
-    new_rma_reason: ایجاد دلیل برای مجوز بازگشت کالا
-    new_shipping_category: دسته بندی ارسال جدید
-    new_shipping_method: متد ارسال جدید
-    new_state: ایالت جدید
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
-    new_tax_category: دسته بندی مالیات جدید
-    new_tax_rate: نرخ مالیات جدید
-    new_taxon: دسته جدید
-    new_taxonomy: دسته‌بندی جدید
-    new_tracker: ردگیر جدید
-    new_user: کاربر جدید
+    minimal_amount: "حداقل مقدار"
+    month: "ماه"
+    more: "بیشتر"
+    move_stock_between_locations: TODO_TRANSLATE
+    my_account: "حساب من"
+    my_orders: "سفارش های من"
+    name: "نام"
+    name_on_card: TODO_TRANSLATE
+    name_or_sku: "نام یا کد کالا"
+    new: "جدید"
+    new_adjustment: "تعدیل جدید"
+    new_country: TODO_TRANSLATE
+    new_customer: "مشتری جدید"
+    new_customer_return: TODO_TRANSLATE
+    new_image: "تصویر جدید"
+    new_option_type: "نوع جدید"
+    new_order: "سفارش جدید"
+    new_order_completed: "سفارش جدید کامل شد"
+    new_payment: "پرداخت جدید"
+    new_payment_method: "متد پرداخت جدید"
+    new_product: "محصول جدید"
+    new_promotion: "فروش ویژه جدید"
+    new_promotion_category: "دسته بندی جدید برای فروش ویژه"
+    new_property: "ویژگی جدید"
+    new_prototype: "نمونه اولیه جدید"
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
+    new_return_authorization: "جدید"
+    new_rma_reason: "ایجاد دلیل برای مجوز بازگشت کالا"
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
+    new_shipping_category: "دسته بندی ارسال جدید"
+    new_shipping_method: "متد ارسال جدید"
+    new_state: "ایالت جدید"
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
+    new_tax_category: "دسته بندی مالیات جدید"
+    new_tax_rate: "نرخ مالیات جدید"
+    new_taxon: "دسته جدید"
+    new_taxonomy: "دسته‌بندی جدید"
+    new_tracker: "ردگیر جدید"
+    new_user: "کاربر جدید"
     new_variant: New Variant
-    new_zone: ناحیه جدید
-    next: بعدی
-    no_actions_added:
-    no_orders_found:
-    no_payment_methods_found:
-    no_pending_payments:
-    no_products_found: هیچ محصولی یافت نشد
-    no_promotions_found:
-    no_resource_found:
-    no_results: بدون نتیجه
-    no_rules_added: هیچ قانونی اضافه نشده
-    no_shipping_methods_found:
-    no_stock_locations_found:
-    no_trackers_found:
-    no_tracking_present:
-    none: هیچکدام
-    normal_amount: مقدار نرمال
+    new_zone: "ناحیه جدید"
+    next: "بعدی"
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
+    no_products_found: "هیچ محصولی یافت نشد"
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
+    no_results: "بدون نتیجه"
+    no_returns_found: TODO_TRANSLATE
+    no_rules_added: "هیچ قانونی اضافه نشده"
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
+    none: "هیچکدام"
+    none_selected: TODO_TRANSLATE
+    normal_amount: "مقدار نرمال"
     not: not
     not_available: N/A
-    not_enough_stock:
-    not_found: ! '%{resource} is not found'
+    not_enough_stock: TODO_TRANSLATE
+    not_found: "%{resource} is not found"
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Product has been cloned
-      product_deleted: محصول حذف شد
+      product_deleted: "محصول حذف شد"
       product_not_cloned: Product could not be cloned
-      product_not_deleted: نمی توان این محصول را حذف کرد
+      product_not_deleted: "نمی توان این محصول را حذف کرد"
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
+    num_orders: TODO_TRANSLATE
     on_hand: On Hand
-    open:
-    open_all_adjustments:
-    option_type: نوع اختیار
-    option_type_placeholder:
-    option_types: انواع اختیارات
-    option_value: مقدار
-    option_values: مقادیر
-    optional: اختیاری
-    options: اختیارات
-    or: یا
-    or_over_price: ! '%{price} or over'
-    order: سفارش
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
+    option_type: "نوع اختیار"
+    option_type_placeholder: TODO_TRANSLATE
+    option_types: "انواع اختیارات"
+    option_value: "مقدار"
+    option_values: "مقادیر"
+    optional: "اختیاری"
+    options: "اختیارات"
+    or: "یا"
+    or_over_price: "%{price} or over"
+    order: "سفارش"
     order_adjustments: Order adjustments
-    order_details: جزئیات سفارش
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
+    order_details: "جزئیات سفارش"
     order_email_resent: Order Email Resent
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer: مشتری محترم,
+        dear_customer: "مشتری محترم,"
         instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
-        subject: لغو سفارش
-        subtotal:
-        total:
+        subject: "لغو سفارش"
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer: مشتری محترم,
+        dear_customer: "مشتری محترم,"
         instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
-        subject: تایید سفارش
-        subtotal:
-        thanks: از خرید شما متشکریم.
-        total:
-    order_not_found:
-    order_number: سفارش
-    order_processed_successfully: سفارش شما به طور موفقیت‌آمیز ثبت شد.
+        subject: "تایید سفارش"
+        subtotal: TODO_TRANSLATE
+        thanks: "از خرید شما متشکریم."
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: "سفارش"
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
+    order_processed_successfully: "سفارش شما به طور موفقیت‌آمیز ثبت شد."
+    order_resumed: TODO_TRANSLATE
     order_state:
-      address: آدرس
+      address: "آدرس"
       awaiting_return: awaiting return
-      canceled: لغو شد
-      cart: سبد خرید
-      complete: تکمیل
-      confirm: تایید
-      delivery: تحویل
-      payment: پرداخت
-      resumed: ادامه
-      returned: برگشت خورد
-    order_summary: خلاصه سفارش
-    order_sure_want_to:
-    order_total: کل سفارش
-    order_updated: سفارش بروز رسانی شد
-    orders: سفارشات
-    out_of_stock: موجودی نداریم
-    overview: مرور کلی
-    package_from:
+      canceled: "لغو شد"
+      cart: "سبد خرید"
+      complete: "تکمیل"
+      confirm: "تایید"
+      considered_risky: TODO_TRANSLATE
+      delivery: "تحویل"
+      payment: "پرداخت"
+      resumed: "ادامه"
+      returned: "برگشت خورد"
+    order_summary: "خلاصه سفارش"
+    order_sure_want_to: TODO_TRANSLATE
+    order_total: "کل سفارش"
+    order_updated: "سفارش بروز رسانی شد"
+    orders: "سفارشات"
+    other_items_in_other: TODO_TRANSLATE
+    out_of_stock: "موجودی نداریم"
+    overview: "مرور کلی"
+    package_from: TODO_TRANSLATE
     pagination:
+      first: TODO_TRANSLATE
       next_page: next page &raquo;
-      previous_page: ! '&laquo; previous page'
-      truncate: ! '&hellip;'
-    password: رمز عبور
+      previous: TODO_TRANSLATE
+      previous_page: "&laquo; previous page"
+      truncate: "&hellip;"
+    password: "رمز عبور"
     paste: Paste
     path: Path
     pay: pay
-    payment: پرداخت
-    payment_information: اطلاعات پرداخت
-    payment_method: روش پرداخت
-    payment_method_not_supported:
-    payment_methods: روش های پرداخت
-    payment_processing_failed: پردازش پرداخت با مشکل مواجه شد. لطفا اطلاعات ورودی خود را کنترل کنید
+    payment: "پرداخت"
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
+    payment_information: "اطلاعات پرداخت"
+    payment_method: "روش پرداخت"
+    payment_method_not_supported: TODO_TRANSLATE
+    payment_methods: "روش های پرداخت"
+    payment_processing_failed: "پردازش پرداخت با مشکل مواجه شد. لطفا اطلاعات ورودی خود را کنترل کنید"
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
     payment_processor_choose_link: our payments page
-    payment_state: وضعیت پرداخت
+    payment_state: "وضعیت پرداخت"
     payment_states:
-      balance_due: پرداخت نشده
-      checkout: تصفیه حساب
-      completed: تکمیل شده
+      balance_due: "پرداخت نشده"
+      checkout: "تصفیه حساب"
+      completed: "تکمیل شده"
       credit_owed: credit owed
       failed: failed
-      paid: پرداخت شده
-      pending: معلق
-      processing: در حال پردازش
+      paid: "پرداخت شده"
+      pending: "معلق"
+      processing: "در حال پردازش"
       void: void
-    payment_updated: پرداخت بروز رسانی شد
-    payments: پرداخت ها
-    percent:
+    payment_updated: "پرداخت بروز رسانی شد"
+    payments: "پرداخت ها"
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
     percent_per_item: Percent Per Item
     permalink: Permalink
-    phone: تلفن
-    place_order: انجام سفارش
+    phone: "تلفن"
+    place_order: "انجام سفارش"
     please_define_payment_methods: Please define some payment methods first.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Something went wrong. Please try adding the item again.
-    powered_by: قدرت گرفته شده توسط
-    presentation: ارائه دهده
-    previous: قبلی
-    price: قیمت
-    price_range: محدوده قیمت
+    powered_by: "قدرت گرفته شده توسط"
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
+    presentation: "ارائه دهده"
+    previous: "قبلی"
+    previous_state_missing: TODO_TRANSLATE
+    price: "قیمت"
+    price_range: "محدوده قیمت"
     price_sack: Price Sack
-    process: پردازش
-    product: محصول
-    product_details: اطلاعات محصول
-    product_has_no_description: این محصول فاقد توضیحات است
-    product_not_available_in_this_currency:
-    product_properties: ویژگی های محصول
+    process: "پردازش"
+    product: "محصول"
+    product_details: "اطلاعات محصول"
+    product_has_no_description: "این محصول فاقد توضیحات است"
+    product_not_available_in_this_currency: TODO_TRANSLATE
+    product_properties: "ویژگی های محصول"
     product_rule:
       choose_products: "محصول‌ها را انتخاب کنید"
-      label:
+      label: TODO_TRANSLATE
       match_all: "همه"
       match_any: "حداقل یکی"
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
-        group: از گروه محصول
-        manual: انتخاب دستی
-    products: محصولات
+        group: "از گروه محصول"
+        manual: "انتخاب دستی"
+    products: "محصولات"
     promotion: "فروش ویژه"
-    promotion_action: فروش ویژه فعال
+    promotion_action: "فروش ویژه فعال"
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: TODO_TRANSLATE
+        any: TODO_TRANSLATE
+    promotion_label: TODO_TRANSLATE
+    promotion_rule: TODO_TRANSLATE
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       item_total:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       landing_page:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotions: فروش ویژه
-    properties: ویژگی ها
-    property: ویژگی
-    prototype: نونه آزمایشی
-    prototypes: نمونه های آزمایشی
-    provider: فراهم آورنده
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
+    promotions: "فروش ویژه"
+    propagate_all_variants: TODO_TRANSLATE
+    properties: "ویژگی ها"
+    property: "ویژگی"
+    prototype: "نونه آزمایشی"
+    prototypes: "نمونه های آزمایشی"
+    provider: "فراهم آورنده"
     provider_settings_warning: If you are changing the provider type, you must save first before you can edit the provider settings
-    qty: تعداد
-    quantity:
+    qty: "تعداد"
+    quantity: TODO_TRANSLATE
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
+    quick_search: "جستوجو سریع . . ."
     rate: Rate
     reason: Reason
     receive: receive
-    receive_stock:
-    received: دریافت شد
-    reference: ارجاع
-    refund_amount_must_be_greater_than_zero: مقدار بازپرداخت باید از صفر بیشتر باشد
-    refund_reasons: دلیل استرداد
-    refunded_amount: مقدار استرداد
-    refund: استرداد
-    register: به عنوان کاربر جدید ثبت نام کنید
-    registration: ثبت نام
-    remember_me: من را به یاد بسپار
-    remove: حدف
-    rename: تغییر نام
-    reports: گزارشات
-    resend: اخیرا
-    reset_password: ریست رمز عبور
+    receive_stock: TODO_TRANSLATE
+    received: "دریافت شد"
+    reception_status: TODO_TRANSLATE
+    reference: "ارجاع"
+    reference_contains: TODO_TRANSLATE
+    refund: "استرداد"
+    refund_amount_must_be_greater_than_zero: "مقدار بازپرداخت باید از صفر بیشتر باشد"
+    refund_reasons: "دلیل استرداد"
+    refunded_amount: "مقدار استرداد"
+    refunds: TODO_TRANSLATE
+    register: "به عنوان کاربر جدید ثبت نام کنید"
+    registration: "ثبت نام"
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
+    reimbursement_mailer:
+      reimbursement_email:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
+    remember_me: "من را به یاد بسپار"
+    remove: "حدف"
+    rename: "تغییر نام"
+    report: TODO_TRANSLATE
+    reports: "گزارشات"
+    resellable: TODO_TRANSLATE
+    resend: "اخیرا"
+    reset_password: "ریست رمز عبور"
     response_code: Response Code
-    resume: ادامه
+    resume: "ادامه"
     resumed: Resumed
-    return: برگشت
-    return_authorization: مجوز بازگشت
-    return_authorization_reasons: دلایل صدور مجوز بازگشت
+    return: "برگشت"
+    return_authorization: "مجوز بازگشت"
+    return_authorization_reasons: "دلایل صدور مجوز بازگشت"
     return_authorization_updated: Return authorization updated
     return_authorizations: Return Authorizations
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Return Quantity
-    returned: برگشت داده شد
-    review: بازنگری
+    returned: "برگشت داده شد"
+    returns: TODO_TRANSLATE
+    review: "بازنگری"
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
+    role_id: TODO_TRANSLATE
     roles: "نقش ها"
-    rules: قوانین
-    safe: مطمئن
+    rules: "قوانین"
     s3_access_key: Access Key
     s3_bucket: Bucket
     s3_headers: S3 Headers
     s3_protocol: S3 Protocol
     s3_secret: Secret Key
-    sales_total: کل فروش
-    sales_total_description: کل فروش برای همه سفارش ها
-    sales_totals: کلیه فروش ها
-    save_and_continue: ذخیره و ادامه
+    safe: "مطمئن"
+    sales_total: "کل فروش"
+    sales_total_description: "کل فروش برای همه سفارش ها"
+    sales_totals: "کلیه فروش ها"
+    save_and_continue: "ذخیره و ادامه"
+    save_my_address: TODO_TRANSLATE
     say_no: 'No'
     say_yes: 'Yes'
     scope: Scope
-    search: جستجو
+    search: "جستجو"
     search_results: Search results for '%{keywords}'
-    searching: در حال جستجو
-    secure_connection_type: نوع اتصال امن
-    security_settings: تنظیمات امنیتی
-    select: انتخاب
-    select_from_prototype: از نمونه اولیه انتخاب کن
-    select_stock:
+    searching: "در حال جستجو"
+    secure_connection_type: "نوع اتصال امن"
+    security_settings: "تنظیمات امنیتی"
+    select: "انتخاب"
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
+    select_from_prototype: "از نمونه اولیه انتخاب کن"
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
-    server: سرور
-    server_error: سرور با ایراد مواجه شد
-    settings: تنظیمات
-    ship: ارسال
+    server: "سرور"
+    server_error: "سرور با ایراد مواجه شد"
+    settings: "تنظیمات"
+    ship: "ارسال"
     ship_address: Ship Address
-    ship_total:
-    shipment:
+    ship_total: TODO_TRANSLATE
+    shipment: TODO_TRANSLATE
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
     shipment_inc_vat: Shipment including VAT
     shipment_mailer:
       shipped_email:
@@ -1014,155 +1272,238 @@ fa:
         shipment_summary: Shipment Summary
         subject: Shipment Notification
         thanks: Thank you for your business.
-        track_information: ! 'Tracking Information: %{tracking}'
-        track_link:
+        track_information: 'Tracking Information: %{tracking}'
+        track_link: TODO_TRANSLATE
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder
+      canceled: TODO_TRANSLATE
       partial: partial
-      pending: معلق
-      ready: آماده
-      shipped: ارسال شد
+      pending: "معلق"
+      ready: "آماده"
+      shipped: "ارسال شد"
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Shipments
-    shipped: ارسال شد
-    shipping: ارسال
-    shipping_address: آدرس ارسال
-    shipping_categories: دسته بندی های ارسال
-    shipping_category: دسته بندی ارسال
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
-    shipping_instructions: دستورالعمل های ارسال
-    shipping_method: روش ارسال
-    shipping_methods: روش های ارسال
-    shipping_price_sack:
-    shop_by_taxonomy: خرید بر حسب %{taxonomy}
-    shopping_cart: سبد خرید
-    show: نمایش
+    shipped: "ارسال شد"
+    shipping: "ارسال"
+    shipping_address: "آدرس ارسال"
+    shipping_categories: "دسته بندی های ارسال"
+    shipping_category: "دسته بندی ارسال"
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
+    shipping_instructions: "دستورالعمل های ارسال"
+    shipping_method: "روش ارسال"
+    shipping_methods: "روش های ارسال"
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
+    shop_by_taxonomy: "خرید بر حسب %{taxonomy}"
+    shopping_cart: "سبد خرید"
+    show: "نمایش"
     show_active: Show Active
     show_deleted: Show Deleted
-    show_only_complete_orders: نمایش سفارشات تکمیل شده
-    show_rate_in_label:
-    sku: کد کالا
+    show_only_complete_orders: "نمایش سفارشات تکمیل شده"
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
+    sku: "کد کالا"
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
     smtp: SMTP
     smtp_authentication_type: SMTP Authentication Type
     smtp_domain: SMTP Domain
     smtp_mail_host: SMTP Mail Host
     smtp_password: SMTP Password
     smtp_port: SMTP Port
-    smtp_send_all_emails_as_from_following_address: تمام نامه ها را از آدرس ذیل ارسال کن
+    smtp_send_all_emails_as_from_following_address: "تمام نامه ها را از آدرس ذیل ارسال کن"
     smtp_send_copy_to_this_addresses: Sends a copy of all outgoing mails to this address. For multiple addresses, separate with commas.
     smtp_username: SMTP Username
-    source:
-    special_instructions: ساختارهای خاص
-    split:
+    source: TODO_TRANSLATE
+    special_instructions: "ساختارهای خاص"
+    split: TODO_TRANSLATE
     spree/order:
-      coupon_code:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
-    start: شروع
+    ssl:
+      change_protocol: TODO_TRANSLATE
+    start: "شروع"
     start_date: Valid from
-    state: ایالت یا استان
+    state: "ایالت یا استان"
     state_based: State Based
-    states: ایالات یا استان ها
-    states_required:
-    status: وضعیت
-    stock_location: مکان انبار
-    stock_location_info: توضیحات انبار
-    stock_locations: مکان انبارها
-    stock_management: مدیریت انبار
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer: ترخیص از انبار
-    stock_transfers: ترخیص ها از انبار
-    stop: توقف
-    store: فروشگاه
-    street_address: آدرس
-    street_address_2: ادامه آدرس
-    subtotal: جمع
+    state_machine_states:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
+    states: "ایالات یا استان ها"
+    states_required: TODO_TRANSLATE
+    status: "وضعیت"
+    stock: TODO_TRANSLATE
+    stock_location: "مکان انبار"
+    stock_location_info: "توضیحات انبار"
+    stock_locations: "مکان انبارها"
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: "مدیریت انبار"
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: "ترخیص از انبار"
+    stock_transfers: "ترخیص ها از انبار"
+    stop: "توقف"
+    store: "فروشگاه"
+    street_address: "آدرس"
+    street_address_2: "ادامه آدرس"
+    subtotal: "جمع"
     subtract: Subtract
-    successfully_created: ! '%{resource} با موفقیت اضافه شد!'
-    successfully_removed: ! '%{resource} با موفقیت حذف شد!'
-    successfully_signed_up_for_analytics:
-    successfully_updated: ! '%{resource} با موفقیت به روز رسانی شد!'
-    tax: مالیات
-    tax_categories: دسته بندی های مالیات
-    tax_category: دسته بندی مالیات
-    tax_rate_amount_explanation:
-    tax_rates: نرخ مالیات
-    tax_settings: تنظیمات مالیات
-    tax_total: کل مالیات
-    taxon: دسته
-    taxon_edit: ویرایش دسته
-    taxon_placeholder:
-    taxonomies: رده‌بندی‌ها
-    taxonomy: رده‌بندی
-    taxonomy_edit: ویرایش طبقه بندی
+    success: TODO_TRANSLATE
+    successfully_created: "%{resource} با موفقیت اضافه شد!"
+    successfully_refunded: TODO_TRANSLATE
+    successfully_removed: "%{resource} با موفقیت حذف شد!"
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
+    successfully_updated: "%{resource} با موفقیت به روز رسانی شد!"
+    summary: TODO_TRANSLATE
+    tax: "مالیات"
+    tax_categories: "دسته بندی های مالیات"
+    tax_category: "دسته بندی مالیات"
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
+    tax_rates: "نرخ مالیات"
+    tax_settings: "تنظیمات مالیات"
+    tax_total: "کل مالیات"
+    taxon: "دسته"
+    taxon_edit: "ویرایش دسته"
+    taxon_placeholder: TODO_TRANSLATE
+    taxon_rule:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
+    taxonomies: "رده‌بندی‌ها"
+    taxonomy: "رده‌بندی"
+    taxonomy_edit: "ویرایش طبقه بندی"
     taxonomy_tree_error: The requested change has not been accepted and the tree has been returned to its previous state, please try again.
-    taxonomy_tree_instruction: ! '* Right click a child in the tree to access the menu for adding, deleting or sorting a child.'
-    taxons: گونه ها
-    test: تست
+    taxonomy_tree_instruction: "* Right click a child in the tree to access the menu for adding, deleting or sorting a child."
+    taxons: "گونه ها"
+    test: "تست"
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Congratulations!
         message: If you have received this email, then your email settings are correct.
         subject: Testmail
-    test_mode: مد تست
-    thank_you_for_your_order: با تشکر، لطفا یک کپی از این صفحه برای نگهداری در نزد خود، پرینت کنید
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields: به مشکلاتی در فیلدهای ذیل برخوردیم
+    test_mode: "مد تست"
+    thank_you_for_your_order: "با تشکر، لطفا یک کپی از این صفحه برای نگهداری در نزد خود، پرینت کنید"
+    there_are_no_items_for_this_order: TODO_TRANSLATE
+    there_were_problems_with_the_following_fields: "به مشکلاتی در فیلدهای ذیل برخوردیم"
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: To add variants, you must first define
-    total: کل
-    tracking: ردگیری
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    total: "کل"
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
+    tracking: "ردگیری"
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Tree
-    type: نوع
+    type: "نوع"
     type_to_search: Type to search
-    unable_to_connect_to_gateway: اتصال به درگاه مقدور نیست
+    unable_to_connect_to_gateway: "اتصال به درگاه مقدور نیست"
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
-    unlock:
-    unrecognized_card_type: نوع کارت ناشناخته
-    unshippable_items:
-    update: بروز رسانی
-    updating: در حال بروز رسانی
-    usage_limit: محدودیت استفاده
-    use_billing_address: همانند آدرس پرداخت
-    use_new_cc: از یک کارت جدید استفاده کن
+    unlock: TODO_TRANSLATE
+    unrecognized_card_type: "نوع کارت ناشناخته"
+    unshippable_items: TODO_TRANSLATE
+    update: "بروز رسانی"
+    updating: "در حال بروز رسانی"
+    usage_limit: "محدودیت استفاده"
+    use_app_default: TODO_TRANSLATE
+    use_billing_address: "همانند آدرس پرداخت"
+    use_existing_cc: TODO_TRANSLATE
+    use_new_cc: "از یک کارت جدید استفاده کن"
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Use Amazon S3 For Images
-    user: کاربر
+    user: "کاربر"
     user_rule:
       choose_users: "انتخاب کاربرها"
     users: "کاربرها"
     validation:
       cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
       cannot_destory_line_item_as_inventory_units_have_shipped: Cannot destory line item as some inventory units have shipped.
-      exceeds_available_stock:
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
-      must_be_int: باید به صورت عدد صحیح وارد شوند
+      must_be_int: "باید به صورت عدد صحیح وارد شوند"
       must_be_non_negative: must be a non-negative value
-    value: مقدار
+      unpaid_amount_not_zero: TODO_TRANSLATE
+    value: "مقدار"
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Variants
-    version: نسخه
+    version: "نسخه"
     void: Void
-    weight: وزن
+    weight: "وزن"
     what_is_a_cvv: What is a (CVV) Credit Card Code?
-    what_is_this: این چیست؟
-    width: پهنا
-    year: سال
-    you_have_no_orders_yet: شما هنوز سفارشی ثبت نکرده اید
-    your_cart_is_empty: سبد خرید شما خالی است
-    your_order_is_empty_add_product:
-    zip: کد پستی
-    zipcode:
-    zone: ناحیه
-    zones: ناحیه ها
+    what_is_this: "این چیست؟"
+    width: "پهنا"
+    year: "سال"
+    you_have_no_orders_yet: "شما هنوز سفارشی ثبت نکرده اید"
+    your_cart_is_empty: "سبد خرید شما خالی است"
+    your_order_is_empty_add_product: TODO_TRANSLATE
+    zip: "کد پستی"
+    zipcode: TODO_TRANSLATE
+    zone: "ناحیه"
+    zones: "ناحیه ها"
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,4 +1,6 @@
+---
 fi:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ fi:
         state: Osavaltio tai maakunta
         zipcode: Postinumero
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ fi:
         name: Nimi
         numcode: ISO-koodi
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tyyppi
         month: Kuukausi
-        name:
+        name: TODO_TRANSLATE
         number: Numero
         verification_value: Tarkistuskoodi
         year: Vuosi
@@ -42,7 +44,7 @@ fi:
       spree/order:
         checkout_complete: Tilaus valmis
         completed_at: Valmistui
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: Kupongin koodi
         created_at: Tilauspäivä
         email: Asiakkaan sähköposti
@@ -72,6 +74,7 @@ fi:
         zipcode: Vastaanottajan postinumero
       spree/payment:
         amount: Summa
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nimi
       spree/product:
@@ -95,7 +98,8 @@ fi:
         starts_at: Alkaa
         usage_limit: Käyttöraja
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Nimi
         presentation: Julkinen nimi
@@ -105,24 +109,26 @@ fi:
         amount: Määrä
       spree/role:
         name: Nimi
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Lyhenne
         name: Nimi
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Kuvaus
         name: Nimi
@@ -157,48 +163,54 @@ fi:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: Kortti on vanhentunut
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Osoite
         other: Osoitteet
@@ -208,15 +220,15 @@ fi:
       spree/credit_card:
         one: Luottokortti
         other: Luottokortit
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Myyntiyksikkö
         other: Myyntiyksikköä
       spree/line_item:
         one: Tuoterivi
         other: Tuoterivit
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Tilaus
         other: Tilaukset
@@ -232,21 +244,23 @@ fi:
       spree/promotion:
         one: Kampanja
         other: Kampanjat
-      spree/promotion_category:
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Ominaisuus
         other: Ominaisuudet
       spree/prototype:
         one: Prototyyppi
         other: Prototyypit
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Asiakaspalautus
         other: Asiakaspalautukset
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Rooli
         other: Roolit
       spree/shipment:
@@ -261,11 +275,11 @@ fi:
       spree/state:
         one: Osavalitio
         other: Osavaltiot
-      spree/state_change:
+      spree/state_change: TODO_TRANSLATE
       spree/stock_location:
         one: Varasto
         other: Varastot
-      spree/stock_movement:
+      spree/stock_movement: TODO_TRANSLATE
       spree/stock_transfer:
         one: Varastosiirto
         other: Varastosiirrot
@@ -293,6 +307,9 @@ fi:
       spree/zone:
         one: Alue
         other: Alueet
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Kiitos tilisi vahvistamisesta! Kirjasimme sinut nyt sisään.
@@ -331,6 +348,7 @@ fi:
     user_sessions:
       signed_in: Olet nyt kirjautunut sisään.
       signed_out: Olet nyt kirjautunut ulos.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: on jo vahvistettu
@@ -339,12 +357,30 @@ fi:
       not_saved:
         one: 'Yksi virhe esti kohteen %{resource} tallennuksen:'
         other: "%{count} virhettä estivät kohteen %{resource} tallennuksen:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Lyhenne
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Tili
     account_updated: Tilin tiedot päivitetty
     action: Toimenpide
@@ -357,7 +393,7 @@ fi:
       list: Lista
       listing: Listataan
       new: Uusi
-      refund:
+      refund: TODO_TRANSLATE
       save: Tallenna
       update: Päivitä
     activate: Ota käyttöön
@@ -365,7 +401,7 @@ fi:
     add: Lisää
     add_action_of_type: Lisää toimintotyyppi
     add_country: Lisää maa
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Lisää uusi otsikko
     add_new_style: Lisää uusi tyyli
     add_one: Lisää yksi
@@ -379,11 +415,16 @@ fi:
     add_to_cart: Lisää koriin
     add_variant: Lisää variantti
     additional_item: Ylimääräiset kulut
+    address: TODO_TRANSLATE
     address1: Osoite
     address2: Osoite (jatkuu)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Hintamuutos
     adjustment_amount: Summa
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Hintamuutos on nyt suljettu!
     adjustment_successfully_opened: Hintamuutos on nyt avattu!
     adjustment_total: Hintamuutokset yhteensä
@@ -391,35 +432,35 @@ fi:
     admin:
       tab:
         configuration: Konfigurointi
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: Tilaukset
         overview: Yleiskatsaus
         products: Tuotteet
         promotions: Kampanjat
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: Raportit
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Käyttäjät
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Hallinnointi
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Hyväksy rekisteriselosteen ehdot
     agree_to_terms_of_service: Hyväksy käyttöehdot
     all: Kaikki
     all_adjustments_closed: Kaikki hintamuutokset on suljettiin!
     all_adjustments_opened: Kaikki hintamuutokset avattiin!
     all_departments: Kaikki tuoteryhmät
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Salli SSL-suojauksen käyttö kehitys- ja testiympäristöissä
     allow_ssl_in_production: Salli SSL-suojauksen käyttö tuotantoympäristössä
     allow_ssl_in_staging: Allow SSL to be used in staging mode
@@ -435,70 +476,104 @@ fi:
     analytics_desc_list_4: Se on täysin ilmainen!
     analytics_trackers: Tilastoinnin seurantakoodit
     and: ja
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Oletko varma?
     are_you_sure_delete: Haluatko varmasti poistaa tämän tiedon?
     associated_adjustment_closed: Tähän liitetty hintamuutos on suljettu, joten sitä ei huomioida laskuissa. Haluatko avata sen?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Valtuutus epäonnistui
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Saatavilla
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Takaisin
     back_end: Backend
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Takaisin kauppaan
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Takaisin käyttäjäluetteloon
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Jälkitoimitus sallittu
-    backorderable_default:
-    backordered:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
     backorders_allowed: Jälkitoimitukset sallittu
     balance_due: Erääntyvät
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Laskun osoite
     billing: Laskutus
     billing_address: Laskutusosoite
     both: Molemmat
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Laskin
     calculator_settings_warning: Mikäli vaihdat laskimen tyyppiä, sinun täytyy ensin tallentaa ennen kuin voit muuttaa laskimen asetuksia
     cancel: peruuta
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: Et voi luoda maksua tilaukselle ilman että mitään maksutapoja on määritelty.
     cannot_create_returns: Palautuksia ei voida luoda, koska tilausta ei ole vielä lähetetty.
     cannot_perform_operation: Pyydettyä toimitoa ei voida suorittaa.
     cannot_set_shipping_method_without_address: Toimitustapaa ei voi valita ennen kuin asiakastiedot on annettu.
     capture: Kuittaa maksetuksi
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kortin koodi
     card_number: Kortin numero
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Kortin tyyppi on
     cart: Ostoskori
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategoriat
     category: Kategoria
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Tarkasta Spreen varoitukset
     checkout: Kassa
     choose_a_customer: Valitse asiakas
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Valitse valuutta
     choose_dashboard_locale: Valitse hallintapaneelin kieli
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Postitoimipaikka
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Klooni
     close: Sulje
     close_all_adjustments: Sulje kaikki hintamuutokset
@@ -507,6 +582,7 @@ fi:
     complete: valmis
     configuration: Asetukset
     configurations: Asetukset
+    configure_s3: TODO_TRANSLATE
     confirm: Vahvista
     confirm_delete: Vahvista poistaminen
     confirm_password: Vahvista salasana
@@ -515,7 +591,7 @@ fi:
     cost_currency: Maksuvaluutta
     cost_price: Kustannushinta
     could_not_connect_to_jirafe: Tietojen päivittäminen Jirafeen epäonnistui. Yritetään automaattisesti myöhemmin uudelleen.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Varaston siirron tallentamisessa tapahtui jokin virhe. Yritä uudelleen.
     count_on_hand: Määrä varastossa
     countries: Maat
@@ -523,10 +599,10 @@ fi:
     country_based: Sijaintimaa
     country_name: Nimi
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Kuponki
     coupon_code: Tarjouskoodi
     coupon_code_already_applied: Kampanjakoodi on jo käytössä tällä tilauksella
@@ -536,17 +612,17 @@ fi:
     coupon_code_max_usage: Kaikki kampanjakoodit on jo käytetty
     coupon_code_not_eligible: Kampanjakoodi ei ole käytettävissä tälle tilaukselle
     coupon_code_not_found: Näppäilemääsi kampanjakoodia ei löytynyt. Yritä uudelleen.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Luo
     create_a_new_account: Tee uusi tili
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Luotu
     credit: Luotto
     credit_card: Luottokortti
     credit_cards: Luottokortit
     credit_owed: Veloittamatta
-    credits:
+    credits: TODO_TRANSLATE
     currency: Valuutta
     currency_decimal_mark: Valuutan desimaalien erotin
     currency_settings: Valuutta-asetukset
@@ -557,11 +633,11 @@ fi:
     customer: Asiakas
     customer_details: Asiakastiedot
     customer_details_updated: Asiakkaan tiedot on päivitetty.
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Asiakashaku
     cut: Leikkaa
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: App ID
@@ -580,41 +656,60 @@ fi:
       js_format: dd.mm.yy
     date_range: Päivämäärä (mistä mihin)
     default: Oletus
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Oletusvero
     default_tax_zone: Default Tax Zone
     delete: Poista
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Toimitus
     depth: Syvyys
     description: Kuvaus
     destination: Kohde
     destroy: Tuhoa
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Alennuksen määrä
     dismiss_banner: Ei kiitos! En ole kiinnostunut, älä näytä tätä viestiä uudelleen.
     display: Näytä
     display_currency: Näytä valuutta
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Muokkaa
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Muokataan käyttäjää
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Sähköposti
     empty: Tyhjä
     empty_cart: Tyhjennä ostoskori
@@ -647,28 +742,30 @@ fi:
           signup: Käyttäjän rekisteröityminen
     exceptions:
       count_on_hand_setter: 'Ei voida asettaa count_on_hand -tietoa manuaalisesti, koska recalculate_count_on_hand -callback asettaa sen automaattisesti. Käytä sen seuraavaa: update_column(:count_on_hand, value)'
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Erääntyminen
     extension: Laajennus
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Tiedostonimi
     fill_in_customer_info: Täytä asiakastiedot
+    filter: TODO_TRANSLATE
     filter_results: Suodata tuloksia
     finalize: Viimeistele
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Ensimmäisen tuotteen kulut
     first_name: Etunimi
     first_name_begins_with: Etunimi alkaa
     flat_percent: Kiinteä prosentti
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Kiinteä hinta (per tilaus)
     flexible_rate: Joustava hinta
     forgot_password: Unohdettu salasana
     free_shipping: Ilmainen toimitus
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Yhdyskäytävä
     gateway_config_unavailable: Yhdyskäytävä ei ole saatavilla ympäristöön
@@ -692,37 +789,41 @@ fi:
       only_incomplete: Vain keskeneräiset
       select_locale: Valitse kieli
       show_only: Näytä vain
+      store_translations: TODO_TRANSLATE
       supported_locales: Tuetut kielet
       this_file_language: Suomi
       translations: Käännökset
     icon: Kuvake
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Kuva
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Kuvat
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Sisällytetty hintaan
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Täytä alla oleva lomake, ja ohjeet salasanan palauttamiseksi lähetetään sähköpostilla:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Sisäinen nimi
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Virheellinen maksutavan tarjoaja.
     invalid_promotion_action: Virheellinen kampanjan toiminto.
     invalid_promotion_rule: Virheellinen kampanjan sääntö.
     inventory: Varasto
     inventory_adjustment: Varaston muutos
     inventory_error_flash_for_insufficient_quantity: Ostoskorissasi oleva tuote ei valitettavasti ole enää saatavilla.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: ei ole saatavilla toimitusosoitteeseen
     iso_name: ISO-nimi
     item: Tuote
@@ -732,26 +833,32 @@ fi:
       operators:
         gt: suurempi kuin
         gte: suurempi tai yhtäsuuri kuin
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: Toimituskulujen laskeminen näille tuotteille ei onnistunut.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Polku
     last_name: Sukunimi
     last_name_begins_with: Sukunimi alkaa
     learn_more: Lue lisää
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Ladataan
     locale_changed: Lokalisointi vaihdettu
     location: Sijainti
     lock: Lukitse
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Kirjauduttu
     logged_in_succesfully: Kirjauduttu onnistuneesti
     logged_out: Olet kirjautunut ulos.
@@ -760,23 +867,26 @@ fi:
     login_failed: Kirjautumisen autentikointi epäonnistui.
     login_name: Nimi
     logout: Kirjaudu ulos
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Etsi samanlaisia tuotteita
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Tee hyvitys
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Toimitushinta
     match_choices:
       all: Kaikki
       none: Ei mitään
     max_items: Tuotteiden enimmäismäärä
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta-kuvaus
     meta_keywords: Meta-avainsanat
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Vähimmäismäärä
     month: Kuukausi
@@ -785,13 +895,13 @@ fi:
     my_account: Oma tili
     my_orders: Tilaukseni
     name: Nimi
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Nimi tai SKU
     new: Uusi
     new_adjustment: Uusi hintamuutos
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Uusi asiakas
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Uusi kuva
     new_option_type: Uusi valintatyyppi
     new_order: Uusi tilaus
@@ -800,14 +910,15 @@ fi:
     new_payment_method: Uusi maksutapa
     new_product: Uusi tuote
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Uusi ominaisuus
     new_prototype: Uusi prototyyppi
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Uusi asiakaspalautus
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Uusi toimituskategoria
     new_shipping_method: Uusi toimitustapa
     new_state: Uusi osavaltio
@@ -824,24 +935,30 @@ fi:
     new_zone: Uusi alue
     next: Seuraava
     no_actions_added: Toimintoja ei lisätty
-    no_payment_found:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: Ei maksuja odottamassa
     no_products_found: Ei löytynyt tuotteita
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: Kohdetta %{resource} ei löytynyt
     no_results: Ei tuloksia
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Sääntöjä ei lisätty
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Seurantatietoja ei ole annettu.
     none: Ei yhtäkään
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normaali määrä
     not: ei
     not_available: N/A
     not_enough_stock: Varastossa josta tuotteet pitäisi lähettää ei ole tarpeeksi montaa tuotetta siirron suorittamiseksi.
     not_found: "%{resource} ei löytynyt"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Tuote kloonattu
       product_deleted: Tuote poistettu
@@ -849,7 +966,7 @@ fi:
       product_not_deleted: Tuotetta ei voitu poistaa
       variant_deleted: Variantti poistettu
       variant_not_deleted: Varianttia ei voitu poistaa
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Saatavilla
     open: Avaa
     open_all_adjustments: Avaa kaikki hintamuutokset
@@ -864,36 +981,37 @@ fi:
     or_over_price: "%{price} or over"
     order: Tilaus
     order_adjustments: Tilauksen hintamuutokset
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Tilauksen tiedot
     order_email_resent: Tilausviesti uudelleenlähetetty
     order_information: Tilauksen tiedot
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Hyvä asiakkaamme,\n
         instructions: Tilauksesi on PERUUTETTU. Ole hyvä ja pidä tämä peruutusvahvistus tallessa.
         order_summary_canceled: Tilauksen yhteenveto [PERUUTETTU]
         subject: Tilauksen peruutus
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Dear Customer,\n
         instructions: Ole hyvä ja pidä tilauksen tiedot tallessa.
         order_summary: Tilauksen yhteenveto
         subject: Tilausvahvistus
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Thank you for your business.
-        total:
+        total: TODO_TRANSLATE
     order_not_found: Tilaustasi ei löytynyt näillä tiedoilla. Yritä ystävällisesti uudelleen.
-    order_number:
+    order_number: TODO_TRANSLATE
     order_populator:
       out_of_stock: "%{item} on loppunut varastosta."
       please_enter_reasonable_quantity: Anna joku kohtuullinen määrä.
-      selected_quantity_not_available:
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Tilauksenne käsitelty onnistuneesti
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: osoite
       awaiting_return: odottaa palautusta
@@ -901,7 +1019,7 @@ fi:
       cart: ostoskori
       complete: valmis
       confirm: vahvista
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: toimitus
       payment: maksu
       resumed: resumed
@@ -911,12 +1029,14 @@ fi:
     order_total: Tilaus yhteensä
     order_updated: Tilaus päivitetty
     orders: Tilaukset
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Ei saatavilla
     overview: Yleiskuva
     package_from: lähetys varastosta
     pagination:
+      first: TODO_TRANSLATE
       next_page: seruaava sivu »
+      previous: TODO_TRANSLATE
       previous_page: "« edellinen sivu"
       truncate: "…"
     password: Salasana
@@ -924,8 +1044,8 @@ fi:
     path: Polku
     pay: maksa
     payment: Maksu
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Maksun tiedot
     payment_method: Maksutapa
     payment_method_not_supported: Tätä maksutapaa ei voida hyväksyä. Valitse joku toinen maksutapa.
@@ -946,22 +1066,23 @@ fi:
       void: mitätön
     payment_updated: Maksu päivitetty
     payments: Maksut
-    pending:
+    pending: TODO_TRANSLATE
     percent: Prosentti
     percent_per_item: Percent Per Item
     permalink: Permalink
     phone: Puhelin
     place_order: Tee tilaus
     please_define_payment_methods: Ole hyvä ja määrittele ensin joitakin maksutapoja.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Jokin meni pieleen. Ole hyvä ja yritä lisätä tuotetta uudelleen.
     powered_by: Palvelun tarjoaa
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Esitys
     previous: Edellinen
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Hinta
     price_range: Price Range
     price_sack: Price Sack
@@ -973,10 +1094,10 @@ fi:
     product_properties: Tuotteen ominaisuudet
     product_rule:
       choose_products: Valitse tuotteet
-      label:
+      label: TODO_TRANSLATE
       match_all: kaikki
       match_any: ainakin yksi
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Tuoteryhmästä
         manual: Valitse
@@ -988,19 +1109,24 @@ fi:
         description: Luo tilaukselle hintamuutoksen kampanjan avulla
         name: Uusi hintamuutos
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Populates the cart with the specified quantity of variant
         name: Create line items
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Actions
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Match any of these rules
         any: Match all of these rules
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
@@ -1013,27 +1139,27 @@ fi:
         description: Asiakkaan on täytynyt vierailla tietyllä sivulla
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Tilaus sisältää määritellyt tuotteet
         name: Tuotteet
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Saatavilla vain määritellyille käyttäjille
         name: Käyttäjä
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Kampanjat
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Ominaisuudet
     property: Ominaisuus
     prototype: Prototyyppi
@@ -1044,47 +1170,49 @@ fi:
     quantity: Määrä
     quantity_returned: Palautettu määrä
     quantity_shipped: Toimitettu määrä
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Taso
     reason: Syy
     receive: vastaanota
     receive_stock: Varastoon
     received: Vastaanotettu
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Viite
+    reference_contains: TODO_TRANSLATE
     refund: Hyvitä
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Rekisteröidy uutena käyttäjänä
     registration: Rekisteröityminen
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Muista minut
     remove: Poista
     rename: Nimeä uudelleen
-    report:
+    report: TODO_TRANSLATE
     reports: Raportit
+    resellable: TODO_TRANSLATE
     resend: Lähetä uudelleen
     reset_password: Palauta salasana
     response_code: Vastauskoodi
@@ -1092,34 +1220,41 @@ fi:
     resumed: Jatkettu
     return: palaa
     return_authorization: Asiakaspalautus
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Asiakaspalautus päivitetty
     return_authorizations: Asiakaspalautukset
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Palautettava määrä
     returned: Palattu
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: Palautusnumero (RMA)
     rma_value: Palautusnumeron arvo
+    role_id: TODO_TRANSLATE
     roles: Roolit
     rules: Säännöt
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Kokonaismyynti
     sales_total_description: Kaikkien tilausten kokonaismyynti
     sales_totals: Myynti yhteensä
     save_and_continue: Tallenna ja jatka
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: Ei
     say_yes: Kyllä
     scope: Laajuus
@@ -1129,10 +1264,11 @@ fi:
     secure_connection_type: Turvallinen yhteystyyppi
     security_settings: Turvallisuusasetukset
     select: Valitse
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Valitse prototyypistä
     select_stock: Valitse varasto
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Lähetä kopio kaikista sähköposteista
     send_mails_as: Lähetä sähköpostiviestit
     server: Palvelin
@@ -1142,8 +1278,9 @@ fi:
     ship_address: Toimitusosoite
     ship_total: Toimitus yhteensä
     shipment: Toimitus
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Hyvä asiakkaamme,\n
@@ -1156,13 +1293,13 @@ fi:
     shipment_state: Toimituksen tila
     shipment_states:
       backorder: jälkitoimitus
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: vajaa
       pending: odottava
       ready: valmis
       shipped: toimitettu
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Toimitukset
     shipped: Toimitettu
     shipping: Toimitus
@@ -1176,67 +1313,83 @@ fi:
     shipping_method: Toimitustapa
     shipping_methods: Toimitustavat
     shipping_price_sack: Hintasäkki
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: Ostoskori
     show: Näytä
     show_active: Näytä aktiiviset
     show_deleted: Näytä poistetut
     show_only_complete_orders: Näytä vain valmiit tilaukset
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Näytä vero hinnoissa
     sku: SKU
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Lähde
     special_instructions: Erityisohjeet
     split: Jaa osiin
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Maksusi tiedoissa oli virhe. Ole hyvä ja tarkista tiedot, ja yritä uudelleen.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Alku
+    start_date: TODO_TRANSLATE
     state: Osavaltio
     state_based: Sijaintilääni/-osavaltio
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Läänit/osavaltiot
     states_required: Maakunta vaaditaan
     status: Tila
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Varaston sijainti
     stock_location_info: Varaston tiedot
     stock_locations: Varastot
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Varastonhallinta
     stock_management_requires_a_stock_location: Luo ensin varasto, että voit hallita varastotilannetta.
     stock_movements: Varastosiirrot
@@ -1250,28 +1403,30 @@ fi:
     street_address_2: Katuosoite (jatkoa)
     subtotal: Summa
     subtract: Vähennä
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} luonti onnistui!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} poisto onnistui!"
     successfully_signed_up_for_analytics: Rekisteröidytty Spree Analyticsiin
     successfully_updated: "%{resource} päivitys onnistui!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Vero
     tax_categories: Verokategoriat
     tax_category: Verokategoria
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Veroprosentit ilmoitetaan desimaalin sadasosina helpottamaan laskemista, (esim. 5% ilmoitetaan 0.05)
     tax_rates: Veroprosentit
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taksoni
     taxon_edit: Muokkaa taksonia
     taxon_placeholder: Lisää taksoni
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taksonomiat
     taxonomy: Taxonomy
     taxonomy_edit: Muokkaa taksonomiaa
@@ -1280,6 +1435,9 @@ fi:
     taxons: Taksonit
     test: Testaa
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Onnittelut!
         message: Mikäli sait tämän sähköpostin, sähköpostiasetuksesi ovat oikein.
@@ -1288,24 +1446,24 @@ fi:
     thank_you_for_your_order: Kiitos tilauksestasi! Tulosta tarvittaessa kopio tästä vahvistuksesta.
     there_are_no_items_for_this_order: Tilaus ei sisällä yhtään tuotetta. Lisää tuote jatkaaksesi tästä eteenpäin.
     there_were_problems_with_the_following_fields: Seuraavissa kentissä oli virhe
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Näytekuva
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Aika
     to_add_variants_you_must_first_define: Ennen variantin lisäämistä sinun tulee määritellä
     total: Yhteensä
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Seuranta
     tracking_number: Seurantatunnus
     tracking_url: Seurantaosoite
     tracking_url_placeholder: esim. https://ohjelmat.posti.fi/Saapumisilmoitus/fi/:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Siirto varastosta
     transfer_stock: Tee varastosiirto
     transfer_to_location: Siirrä varastoon
@@ -1313,7 +1471,7 @@ fi:
     type: Tyyppi
     type_to_search: Type to search
     unable_to_connect_to_gateway: Ei saatu yhteyttä yhdyskäytävään
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
     unlock: Avaa lukitus
     unrecognized_card_type: Tunnistamaton korttityyppi
@@ -1321,9 +1479,11 @@ fi:
     update: Päivitä
     updating: Päivitetään
     usage_limit: Käyttöraja
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Käytä laskutusosoitetta
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Käytä uutta korttia
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Käytä Amazon S3:a kuvia varten
     user: Käyttäjä
     user_rule:
@@ -1331,12 +1491,13 @@ fi:
     users: Käyttäjät
     validation:
       cannot_be_less_than_shipped_units: ei voi olla pienempi kuin toimitettu määrä.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: ylittää nykyisen varastotilanteen. Varmista tuoterivien oikea kappalemäärä.
       is_too_large: on liian iso -- varastossa ei riittävästi tuotteita
       must_be_int: täytyy olla kokonaisluku
       must_be_non_negative: täytyy olla ei-negatiivinen
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Arvo
     variant: Variantti
     variant_placeholder: Valitse variantti
@@ -1355,3 +1516,10 @@ fi:
     zipcode: Postinumero
     zone: Alue
     zones: Alueet
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,6 @@
+---
 fr:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -24,7 +26,7 @@ fr:
         name: Nom
         numcode: Code ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Type
         month: Mois
         name: Nom
@@ -72,6 +74,7 @@ fr:
         zipcode: Code postal de l'adresse de livraison
       spree/payment:
         amount: Montant
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nom
       spree/product:
@@ -95,6 +98,7 @@ fr:
         starts_at: Débute le
         usage_limit: Limite d'utilisation
       spree/promotion_category:
+        code: TODO_TRANSLATE
         name: Nom
       spree/property:
         name: Nom
@@ -105,13 +109,15 @@ fr:
         amount: Montant
       spree/role:
         name: Nom
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abréviation
         name: Nom
       spree/state_change:
         state_changes: Changement d'état
         state_from: de
-        state_to: à
+        state_to: "à"
         timestamp: Horodatage
         type: Type
         updated: Mis à jour le
@@ -157,20 +163,20 @@ fr:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: "Les clés Tier devraient toutes être des nombres plus grand que 0"
+              keys_should_be_positive_number: Les clés Tier devraient toutes être des nombres plus grand que 0
             preferred_tiers:
-              should_be_hash: "devrait être une table de hachage"
+              should_be_hash: devrait être une table de hachage
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: "Les clés Tier devraient toutes être des nombres plus grand que 0"
-              values_should_be_percent: "Les valeurs Tier devraient toutes être des percentages compris entre 0% et 100%"
+              keys_should_be_positive_number: Les clés Tier devraient toutes être des nombres plus grand que 0
+              values_should_be_percent: Les valeurs Tier devraient toutes être des percentages compris entre 0% et 100%
             preferred_tiers:
-              should_be_hash: "devrait être une table de hachage"
+              should_be_hash: devrait être une table de hachage
         spree/classification:
           attributes:
             taxon_id:
-              already_linked: "est déjà relié à ce produit"
+              already_linked: est déjà relié à ce produit
         spree/credit_card:
           attributes:
             base:
@@ -190,15 +196,21 @@ fr:
               return_items_order_id_does_not_match: Un ou plusieurs des articles de retour spécifiées n'appartiennent pas à la même commande que du remboursement.
         spree/return_item:
           attributes:
-            reimbursement:
-              cannot_be_associated_unless_accepted: ne peut pas être associé à un article retourné qui n'est pas accepté.
             inventory_unit:
               other_completed_return_item_exists: "%{inventory_unit_id} est déjà pris par un article retourné %{return_item_id}"
+            reimbursement:
+              cannot_be_associated_unless_accepted: ne peut pas être associé à un article retourné qui n'est pas accepté.
         spree/store:
           attributes:
             base:
               cannot_destroy_default_store: Impossible de détruire la boutique par défaut.
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adresse
         other: Adresses
@@ -263,6 +275,8 @@ fr:
         one: Raison du retour d'autorisation
         other: Raisons du retour d'autorisation
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Rôle
         other: Rôles
       spree/shipment:
@@ -313,6 +327,9 @@ fr:
       spree/zone:
         one: Zone
         other: Zones
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Votre compte a été confirmé avec succès. Vous êtes maintenant enregistré.
@@ -351,6 +368,7 @@ fr:
     user_sessions:
       signed_in: Vous êtes désormais connecté.
       signed_out: Vous êtes désormais déconnecté.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: est déjà confirmé
@@ -359,6 +377,24 @@ fr:
       not_saved:
         one: "%{resource} n'a pu etre sauvegardé à cause d' 1 erreur:"
         other: "%{resource} n'a pu etre sauvegardé à cause de %{count} erreurs:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abréviation
     accept: Accepter
@@ -399,11 +435,16 @@ fr:
     add_to_cart: Ajouter au panier
     add_variant: Ajouter une variante
     additional_item: Coût d'un article supplémentaire
+    address: TODO_TRANSLATE
     address1: Adresse
     address2: Adresse (complément)
     adjustable: Ajustable
     adjustment: Ajustement
     adjustment_amount: Montant
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Ajustement fermé avec succès!
     adjustment_successfully_opened: Ajustement ouvert avec succès!
     adjustment_total: Ajustement Total
@@ -428,7 +469,7 @@ fr:
         items: Articles
         items_purchased: Articles achetés
         order_history: Historique des commandes
-        order_num: "Commande #"
+        order_num: 'Commande #'
         orders: Commandes
         user_information: Informations de l'utilisateur
     administration: Administration
@@ -455,12 +496,24 @@ fr:
     analytics_desc_list_4: C'est totalement gratuit!
     analytics_trackers: Traqueurs analytiques
     and: et
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: Approuver
     approved_at: approuver le
     approver: Approbateur
     are_you_sure: En êtes-vous sûr ?
     are_you_sure_delete: "Êtes-vous sûr de vouloir supprimer cet enregistrement ?"
     associated_adjustment_closed: L'ajustement associé est fermé, et ne sera pas recalculé. Voulez-vous l'ouvrir?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Vous n'avez pas les droits nécessaires pour afficher cette section
     authorized: Autorisé
     auto_capture: Acceptation automatique
@@ -469,11 +522,33 @@ fr:
     avs_response: Réponse AVS
     back: Retour
     back_end: Gestion
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
     back_to_payment: Retour au paiement
-    back_to_resource_list: 'Retour à la liste %{resource}'
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: Retour à la liste %{resource}
     back_to_rma_reason_list: Retour à la liste des RMA
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Boutique
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Retour à la liste des utilisateurs
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Peut être acheté même si le stock est vide
     backorderable_default: Peut être acheté même si le stock est vide (défault)
     backordered: En rupture de stock
@@ -497,22 +572,22 @@ fr:
     cannot_perform_operation: Ne peut pas accomplir l'action demandée
     cannot_set_shipping_method_without_address: La méthode d'expédition ne peut être définie tant que les données du client ne sont pas spécifiées
     capture: accepté
-    capture_events: Événements d'acceptation
+    capture_events: "Événements d'acceptation"
     card_code: Code de la carte
     card_number: Numéro de carte
     card_type: Type de cate
     card_type_is: Le type de la carte est
     cart: Panier
     cart_subtotal:
-      one: 'Sous-total (1 article)'
-      other: 'Sous-total (%{count} articles)'
+      one: Sous-total (1 article)
+      other: Sous-total (%{count} articles)
     categories: Catégories
     category: Categorie
     charged: Chargé
     check_for_spree_alerts: Recevoir les alertes de Spree
     checkout: Passer la commande
     choose_a_customer: Choisissez un client
-    choose_a_taxon_to_sort_products_for: "Choisir une taxon pour organiser les produits pour"
+    choose_a_taxon_to_sort_products_for: Choisir une taxon pour organiser les produits pour
     choose_currency: Choisir la devise
     choose_dashboard_locale: Choisir la langue du tableau de bord
     choose_location: Choisir la localisation
@@ -520,7 +595,7 @@ fr:
     clear_cache: Supprimer la cache
     clear_cache_ok: La cache a bien été supprimée
     clear_cache_warning: Supprimer la cache va temporairement réduire les performances de votre boutique.
-    click_and_drag_on_the_products_to_sort_them:  Cliquer et faire glisser les produits pour les organiser.
+    click_and_drag_on_the_products_to_sort_them: Cliquer et faire glisser les produits pour les organiser.
     clone: Cloner
     close: Fermer
     close_all_adjustments: Fermer tous les ajustements
@@ -529,6 +604,7 @@ fr:
     complete: compléter
     configuration: Configuration
     configurations: Configurations
+    configure_s3: TODO_TRANSLATE
     confirm: Confirmation
     confirm_delete: Confirmation de la suppression
     confirm_password: Confirmation du mot de passe
@@ -548,7 +624,7 @@ fr:
       CA: Canada
       FRA: France
       ITA: Italie
-      US: États-Unis d'Amérique
+      US: "États-Unis d'Amérique"
     coupon: Coupon
     coupon_code: Code Promo
     coupon_code_already_applied: Le code promo a déjà été utilisé pour cette commande
@@ -602,10 +678,14 @@ fr:
       js_format: dd/mm/yy
     date_range: Sélection de dates
     default: Défaut
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
     default_refund_amount: Montant de remboursement par défaut
+    default_seo_title: TODO_TRANSLATE
     default_tax: Taxe par défaut
     default_tax_zone: Zone de taxe par défaut
     delete: Supprimer
+    delete_from_taxon: TODO_TRANSLATE
     deleted_variants_present: Certains articles de cette commande ne sont plus disponibles.
     delivery: Livraison
     depth: Profondeur
@@ -617,23 +697,41 @@ fr:
     dismiss_banner: Non Merci ! Ça ne m'intéresse pas, ne pas afficher ce message les prochaines fois
     display: Afficher
     display_currency: Devise d'affichage
-    edit: Éditer
-    editing_option_type: Édition du type d'option
-    editing_payment_method: Édition de la méthode de paiement
-    editing_product: Édition du produit
-    editing_promotion: Édition de la Promotion
-    editing_property: Édition de la propriété
-    editing_prototype: Édition du prototype
-    editing_shipping_category: Édition de la catégorie de livraison
-    editing_shipping_method: Édition de la méthode de livraison
-    editing_state: Édition de la région
-    editing_stock_location: Édition du lieu de Stock
-    editing_stock_movement: Édition du mouvement de Stock
-    editing_tax_category: Édition de la catégorie fiscale
+    doesnt_track_inventory: TODO_TRANSLATE
+    edit: "Éditer"
+    editing_option_type: "Édition du type d'option"
+    editing_payment_method: "Édition de la méthode de paiement"
+    editing_product: "Édition du produit"
+    editing_promotion: "Édition de la Promotion"
+    editing_property: "Édition de la propriété"
+    editing_prototype: "Édition du prototype"
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: "Édition de la catégorie de livraison"
+    editing_shipping_method: "Édition de la méthode de livraison"
+    editing_state: "Édition de la région"
+    editing_stock_location: "Édition du lieu de Stock"
+    editing_stock_movement: "Édition du mouvement de Stock"
+    editing_tax_category: "Édition de la catégorie fiscale"
     editing_tax_rate: Modification du taux d'imposition
-    editing_tracker: Édition du tracker
-    editing_user: Édition d'un utilisateur
-    editing_zone: Édition d'une zone
+    editing_tracker: "Édition du tracker"
+    editing_user: "Édition d'un utilisateur"
+    editing_zone: "Édition d'une zone"
+    eligibility_errors:
+      messages:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Courriel
     empty: Vide
     empty_cart: Vider le panier
@@ -666,15 +764,16 @@ fr:
           signup: Inscription utilisateur
     exceptions:
       count_on_hand_setter: Impossible de définir count_on_hand manuellement, tel qu'il est défini automatiquement par le rappel de recalculate_count_on_hand. S'il vous plaît utilisez `update_column (:count_on_hand, value)` à la place.
-    exchange_for: Échange pour
+    exchange_for: "Échange pour"
     excl: exclu.
-    existing_shipments:
-    expedited_exchanges_warning:
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Expiration
     extension: Prolongation
     failed_payment_attempts: Tentatives de paiement échouées
     filename: Nom du fichier
     fill_in_customer_info: Merci de remplir les informations client.
+    filter: TODO_TRANSLATE
     filter_results: Filtrer les resultats
     finalize: Finaliser
     finalized: Finaliser
@@ -683,6 +782,7 @@ fr:
     first_name: Prénom
     first_name_begins_with: Prénom commmençant par
     flat_percent: Pourcentage net
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Taux net par commande
     flexible_rate: Taux flexible
     forgot_password: Mot de passe oublié
@@ -711,15 +811,19 @@ fr:
       only_incomplete: Commandes incomplètes seulement
       select_locale: Sélectionnez vos paramètres régionaux
       show_only: Afficher seulement
+      store_translations: TODO_TRANSLATE
       supported_locales: Paramètres régionaux supportés
       this_file_language: Français (FR)
       translations: Traductions
     icon: Icône
     identifier: Identification
     image: Image
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Images
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
     inactive: Inactif
     incl: inclus
     included_in_price: Inclus dans le prix
@@ -727,8 +831,8 @@ fr:
     incomplete: Incomplet
     info_number_of_skus_not_shown:
       one: un
-      other: "et %{count} autres"
-    info_product_has_multiple_skus: "Ce produit possède %{count} variantes:"
+      other: et %{count} autres
+    info_product_has_multiple_skus: 'Ce produit possède %{count} variantes:'
     instructions_to_reset_password: 'Remplissez le formulaire ci-dessous et les instructions pour réinitialiser votre mot de passe vous seront envoyées par courriel:'
     insufficient_stock: Stock disponible insuffisant, il n'en reste seulement que %{on_hand}
     insufficient_stock_lines_present: Nous n'avons pas tous les articles de votre commande dans notre inventaire.
@@ -736,14 +840,14 @@ fr:
     intercept_email_instructions: Remplacer l'adresse courriel de destination par cette adresse
     internal_name: Nom interne
     invalid_credit_card: Carte de crédit invalide
-    invalid_exchange_variant:
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Fournisseur de paiement invalide.
     invalid_promotion_action: Action de promotion invalide.
     invalid_promotion_rule: Règle de promotion invalide
     inventory: Inventaire
     inventory_adjustment: Ajustement de l'inventaire
     inventory_error_flash_for_insufficient_quantity: Un article de votre panier n'est plus disponible.
-    inventory_state: État de l'inventaire
+    inventory_state: "État de l'inventaire"
     is_not_available_to_shipment_address: n'est pas disponible pour l'adresse de livraison
     iso_name: Nom ISO
     item: Article
@@ -752,13 +856,13 @@ fr:
     item_total_rule:
       operators:
         gt: plus grand que
-        gte: égal ou plus grand que
+        gte: "égal ou plus grand que"
         lt: plus petit que
-        lte: égal ou plus petit que
+        lte: "égal ou plus petit que"
     items_cannot_be_shipped: Il nous est impossible de livrer l'article sélectionné à votre adresse de livraison. Veuillez choisir une autre adresse de livraison.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Chemin
@@ -766,8 +870,14 @@ fr:
     last_name_begins_with: Le nom commmence par
     learn_more: Pour en savoir plus
     lifetime_stats: Statistiques à vie
-    line_item_adjustments:
+    line_item_adjustments: TODO_TRANSLATE
     list: Liste
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Chargement
     locale_changed: Paramètres régionaux changés
     location: Emplacement
@@ -783,6 +893,9 @@ fr:
     logout: Se déconnecter
     logs: Journal
     look_for_similar_items: Rechercher des articles similaires
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Effectuer un remboursement
     make_sure_the_above_reimbursement_amount_is_correct: Veuillez vérifier que le montant du remboursement est correct
     manage_promotion_categories: Gérer les catégories de promotions
@@ -812,7 +925,7 @@ fr:
     new_adjustment: Nouvel ajustement
     new_country: Nouveau pays
     new_customer: Nouveau client
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nouvelle image
     new_option_type: Nouveau type d'option
     new_order: Nouvelle commande
@@ -827,7 +940,8 @@ fr:
     new_refund: Nouveau remboursement
     new_refund_reason: Nouvelle raison pour un remboursement
     new_return_authorization: Nouveau retour d'autorisation
-    new_rma_reason:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
     new_shipment_at_location: Nouvel envoi de livrasion
     new_shipping_category: Nouvelle catégorie de livraison
     new_shipping_method: Nouvelle méthode de livraison
@@ -845,15 +959,21 @@ fr:
     new_zone: Nouvelle zone
     next: Suivant
     no_actions_added: Aucune action ajoutée
+    no_orders_found: TODO_TRANSLATE
     no_payment_found: Aucun paiment trouvé
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: Aucun paiement en attente
     no_products_found: Aucun article trouvé
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: Aucun ressource trouvée
     no_results: Aucun résultat
     no_returns_found: Aucun retour trouvé
     no_rules_added: Aucune règle ajoutée
     no_shipping_method_selected: Aucune méthode de livraison sélectionnée
+    no_shipping_methods_found: TODO_TRANSLATE
     no_state_changes: Aucun changement de province, de région ou d'état
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Les détails pour le traqueur ne sont pas présents
     none: Aucun
     none_selected: Aucune sélection
@@ -870,7 +990,7 @@ fr:
       product_not_deleted: Le produit n'a pas pu être supprimé
       variant_deleted: La variante a été supprimée
       variant_not_deleted: La variante n'a pas pu être supprimée
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Disponible
     open: Ouvrir
     open_all_adjustments: Ouvrir tous les ajustements
@@ -891,14 +1011,15 @@ fr:
     order_details: Détails de la commande
     order_email_resent: Renvoi de la commande par courriel
     order_information: Information sur la commande
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Cher client,\n
         instructions: Votre commande a été ANNULÉE. Veuillez conserver les informations suivantes à propos de votre commande annulée.
         order_summary_canceled: Sommaire de la commande [ANNULÉE]
         subject: Annulation de la commande
-        subtotal: ! 'Sous-total: %{subtotal}'
-        total: ! 'Total de la commande: %{total}'
+        subtotal: 'Sous-total: %{subtotal}'
+        total: 'Total de la commande: %{total}'
       confirm_email:
         dear_customer: Cher client,
         instructions: Veuillez vérifier et sauvegarder les informations suivantes à propos de votre commande.
@@ -906,9 +1027,13 @@ fr:
         subject: Confirmation de commande
         subtotal: Sous-total de la commande
         thanks: Merci d'avoir fait affaire avec nous.
-        total: ! 'Total de la commande: %{total}'
+        total: 'Total de la commande: %{total}'
     order_not_found: Impossible de trouver votre commande. Merci d'essayer à nouveau.
     order_number: Numéro de facture
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Votre commande a été traitée avec succès
     order_resumed: Résumé de votre commande
     order_state:
@@ -928,12 +1053,14 @@ fr:
     order_total: Total de la commande
     order_updated: Commande mise à jour
     orders: Commandes
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: En rupture de stock
     overview: Vue d'ensemble
     package_from: Paquet de
     pagination:
-      next_page: "page suivante »"
+      first: TODO_TRANSLATE
+      next_page: page suivante »
+      previous: TODO_TRANSLATE
       previous_page: "« page précédente"
       truncate: "…"
     password: Mot de passe
@@ -941,8 +1068,8 @@ fr:
     path: Chemin
     pay: payer
     payment: Paiement
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Information sur le paiement
     payment_method: Méthode de paiement
     payment_method_not_supported: Ce méthode de paiement n'est pas supportée
@@ -963,22 +1090,23 @@ fr:
       void: vide
     payment_updated: Paiement mis à jour
     payments: Paiements
-    pending:
+    pending: TODO_TRANSLATE
     percent: Pourcent
     percent_per_item: Pourcent par article
     permalink: Permalien
     phone: Téléphone
     place_order: Passer la commande
     please_define_payment_methods: S'il vous plaît définissez d'abord certains modes de paiement.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Quelque chose s'est passé mal. Essayez S'il vous plaît d'ajouter l'article de nouveau.
     powered_by: Réalisé avec
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Présentation
     previous: Précédent
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Prix
     price_range: Prix
     price_sack: Prix du sac
@@ -990,10 +1118,10 @@ fr:
     product_properties: Propriété du produit
     product_rule:
       choose_products: Choississez des produits
-      label:
+      label: TODO_TRANSLATE
       match_all: tout
       match_any: au moins un
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Dans les groupes de produits
         manual: Choisir manuellement
@@ -1010,17 +1138,19 @@ fr:
       create_line_items:
         description: Remplit le panier avec la quantité spécifiée de variante
         name: Créez des lignes d'article
-      give_store_credit:
-        description: Accorde à l'utilisateur un avoir de la quantité indiquée
-        name: Accorder un avoir
       free_shipping:
         description: Livraison gratuite pour la commande.
         name: Livraison gratuite
+      give_store_credit:
+        description: Accorde à l'utilisateur un avoir de la quantité indiquée
+        name: Accorder un avoir
     promotion_actions: Actions
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Répond à toutes ces règles
         any: Répond à une des règles
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Règle de Promotion
     promotion_rule_types:
       first_order:
@@ -1033,27 +1163,27 @@ fr:
         description: Le client doit avoir visité la page spécifiée
         name: Page de destination
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: La commande comprend le ou les produit(s) spécifié(s)
         name: Produit(s)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Disponible uniquement pour l'utilisateur spécifié
         name: Utilisateur
       user_logged_in:
         description: Disponible seulement aux utilisateurs enregistrés
         name: Utilisateur connecté
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promotions
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Propriétés
     property: Propriété
     prototype: Prototype
@@ -1070,41 +1200,43 @@ fr:
     receive: recevoir
     receive_stock: Recevoir le stock
     received: Reçu
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Référence
+    reference_contains: TODO_TRANSLATE
     refund: Remboursement
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: S'inscrire comme nouvel utilisateur
     registration: Enregistrement
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Se souvenir de moi
     remove: Supprimer
     rename: Renommer
-    report:
+    report: TODO_TRANSLATE
     reports: Statistiques
+    resellable: TODO_TRANSLATE
     resend: Renvoyer
     reset_password: Réinitialiser mon mot de passe
     response_code: Code de réponse
@@ -1112,34 +1244,41 @@ fr:
     resumed: repris
     return: retourner
     return_authorization: Retour d'autorisation
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Retour d'autorisation mis à jour
     return_authorizations: Retour d'autorisations
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Quantité de retour
     returned: Retourner
-    returns:
+    returns: TODO_TRANSLATE
     review: Examen
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: Credit RMA
     rma_number: Numéro RMA
     rma_value: Valeur RMA
+    role_id: TODO_TRANSLATE
     roles: Rôles
     rules: Règles
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Total de ventes
     sales_total_description: Vente total pour toutes les commandes
     sales_totals: Ventes totales
     save_and_continue: Continuer
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: Non
     say_yes: Oui
     scope: Scope
@@ -1149,10 +1288,11 @@ fr:
     secure_connection_type: Type de connexion sécurisée
     security_settings: Paramètres de sécurité
     select: Sélectionner
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Sélectionner d'après le prototype
     select_stock: Sélectionner le stock
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Envoyer une copie de tous les courriels à
     send_mails_as: Envoyer les courriels en tant que
     server: Serveur
@@ -1162,8 +1302,9 @@ fr:
     ship_address: Adresse de livraison
     ship_total: Envois Totales
     shipment: Livraison
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Cher client,\n
@@ -1176,13 +1317,13 @@ fr:
     shipment_state: "État de livraison"
     shipment_states:
       backorder: rupture de stock
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: partiel
       pending: en attente
       ready: prêt
       shipped: expédié
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Livraisons
     shipped: Livré
     shipping: Frais de livraison
@@ -1196,7 +1337,11 @@ fr:
     shipping_method: Méthode de livraison
     shipping_methods: Méthodes de livraison
     shipping_price_sack: Prix groupé
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Acheter par %{taxonomy}
     shopping_cart: Panier
     show: Afficher
@@ -1206,57 +1351,69 @@ fr:
     show_only_considered_risky: Afficher seulement les commandes considérées à risque
     show_rate_in_label: Montrer les taux dans les legendes
     sku: Code barre
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Origine
     special_instructions: Instructions spéciales
     split: Diviser
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Il y a eu un problème avec vos informations de paiement. Merci de bien vouloir les vérifier et de réessayer.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Départ
+    start_date: TODO_TRANSLATE
     state: Province / Région / État
     state_based: Basé sur une région
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Régions
     states_required: Etat / province obligatoire
     status: Statut
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Emplacement de stock
     stock_location_info: Informations sur l'emplacement de stock
     stock_locations: Emplacements de stock
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Gestion de stock
     stock_management_requires_a_stock_location: Veuillez créer un lieu de stockage afin de pouvoir gérer vos stocks
     stock_movements: Mouvements de Stock
@@ -1270,28 +1427,30 @@ fr:
     street_address_2: Adresse (suite)
     subtotal: Sous-total
     subtract: Soustraire
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} a été crée avec succès!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} a été supprimé avec succès!"
     successfully_signed_up_for_analytics: Vous avez été enregistré avec succès à Spree Analytics.
     successfully_updated: "%{resource} a été modifié avec succès!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: TVA
     tax_categories: Catégories de taxes
     tax_category: Catégorie de taxe
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Les taux de taxe représentent un nombre décimal pour simplifier les calculs. (i.e. si le taux est  5%, entrer 0.05)
     tax_rates: Taux des taxes
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Arborescence
     taxon_edit: Modifier l'aborescence
     taxon_placeholder: Ajouter un taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Arborescences
     taxonomy: Taxonomy
     taxonomy_edit: Modifier l'aborescence
@@ -1300,6 +1459,9 @@ fr:
     taxons: Arborescences
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Félicitations !
         message: Si vous avez reçu cet e-mail, vos paramètres de messagerie sont correctes.
@@ -1308,24 +1470,24 @@ fr:
     thank_you_for_your_order: Merci de nous avoir fait confiance. Imprimez cette page de confirmation pour vos archives.
     there_are_no_items_for_this_order: Il n'y a aucun article dans cette commande. Veuillez en ajouter un à la commande pour continuer.
     there_were_problems_with_the_following_fields: Il y a eu des problèmes aves les champs suivants
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Vignette
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Temps
     to_add_variants_you_must_first_define: Pour ajouter des variantes, vous devez premièrement définir
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Localiser
     tracking_number: Numéro de suivi
     tracking_url: URL du traqueur
     tracking_url_placeholder: i.e. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Transférer de
     transfer_stock: Transférer le Stock
     transfer_to_location: Transférer vers
@@ -1333,7 +1495,7 @@ fr:
     type: Type
     type_to_search: Type à rechercher
     unable_to_connect_to_gateway: N'arrive pas à se connecter à la méthode de paiement.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Moins de %{price}
     unlock: Déverrouiller
     unrecognized_card_type: Le type de la carte n'est pas reconnu
@@ -1341,9 +1503,11 @@ fr:
     update: Mise à jour
     updating: Mise à jour
     usage_limit: Limite d'utilisation
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Utiliser l'adresse de facturation
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Utiliser une nouvelle carte
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Utiliser Amazon S3 pour les Images
     user: Utilisateur
     user_rule:
@@ -1351,12 +1515,13 @@ fr:
     users: Utilisateurs
     validation:
       cannot_be_less_than_shipped_units: ne peut pas être inférieur à la quantité livrée.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: Surpasse le stock disponible. Merci de vous assurer que les quantités sont valides
       is_too_large: est trop importante -- le stock disponible ne peut pas couvrir la quantité demandée !
       must_be_int: doit être un entier
       must_be_non_negative: doit être une valeur positive ou nulle
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Valeur
     variant: Variante
     variant_placeholder: Choisissez une variante
@@ -1375,3 +1540,10 @@ fr:
     zipcode: Code postal
     zone: Zone
     zones: Zones
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,4 +1,6 @@
+---
 id:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ id:
         state: Provinsi
         zipcode: Kode Pos
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ id:
         name: Nama
         numcode: Kode ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tipe
         month: Bulan
-        name:
+        name: TODO_TRANSLATE
         number: Nomor
         verification_value: Kode Verifikasi
         year: Tahun
@@ -72,6 +74,7 @@ id:
         zipcode: Alamat pengiriman kode pos
       spree/payment:
         amount: Jumlah
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nama
       spree/product:
@@ -95,6 +98,7 @@ id:
         starts_at: Mulai Pada
         usage_limit: Batas Penggunaan
       spree/promotion_category:
+        code: TODO_TRANSLATE
         name: Nama
       spree/property:
         name: Nama
@@ -105,24 +109,26 @@ id:
         amount: Jumlah
       spree/role:
         name: Nama
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Singkatan
         name: Nama
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
         type: Tipe
-        updated:
-        user:
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
         name: Nama
         seo_title: Judul SEO
-        url:
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Deskripsi
         name: Nama
@@ -157,48 +163,54 @@ id:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Alamat
         other: Alamat lainnya
@@ -208,41 +220,43 @@ id:
       spree/credit_card:
         one: Kartu Kredit
         other: Kartu kredit lainnya
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Satuan Unit
         other: Satuan Unit lainnya
       spree/line_item:
         one: Barang
         other: Barang lainnya
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Pesanan
         other: Pesanan lainnya
       spree/payment:
         one: Pembayaran
         other: Pembayaran lainnya
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Produk
         other: Produk lainnya
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Properti
         other: Properti lainnya
       spree/prototype:
         one: Prototipe
         other: Prototipe lainnya
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Otorisasi Pengembalian
         other: Otorisasi Pengembalian lainnya
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Peran
         other: Peran lainnya
       spree/shipment:
@@ -251,14 +265,14 @@ id:
       spree/shipping_category:
         one: Kategori Pengiriman
         other: Kategori Pengiriman lainnya
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Provinsi
         other: Provinsi lainnya
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Kategori Pajak
         other: Kategori Pajak lainnya
@@ -271,7 +285,7 @@ id:
       spree/taxonomy:
         one: Taksonomi
         other: Taksonomi lainnya
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Pengguna
         other: Pengguna lainnya
@@ -281,6 +295,9 @@ id:
       spree/zone:
         one: Wilayah
         other: Wilayah-wilayah
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Akun Anda telah berhasil di konfirmasi. Anda sekarang telah masuk sistem.
@@ -319,18 +336,37 @@ id:
     user_sessions:
       signed_in: Berhasil masuk ke dalam sistem.
       signed_out: Berhasil keluar dari sistem.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: telah dikonfirmasi.
       not_found: tidak ditemukan
       not_locked: tidak terkunci
       not_saved: "%{count} kesalahan menyebabkan %{resource} tidak bisa disimpan"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Singkatan
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Akun
     account_updated: Akun sudah diperbarui!
     action: Aksi
@@ -343,7 +379,7 @@ id:
       list: Daftar
       listing: Daftar
       new: Baru
-      refund:
+      refund: TODO_TRANSLATE
       save: Simpan
       update: Pembaharuan
     activate: Aktivasi
@@ -351,7 +387,7 @@ id:
     add: Tambahkan
     add_action_of_type: Tambahkan Aksi Dari Tipe
     add_country: Tambahkan Negara
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Tambahkan Header
     add_new_style: Tambahkan Style Baru
     add_one: Tambahkan satu
@@ -365,47 +401,52 @@ id:
     add_to_cart: Tambahkan ke Keranjang Belanja
     add_variant: Tambah Variasi
     additional_item: Tambahan Harga Barang
+    address: TODO_TRANSLATE
     address1: Alamat
     address2: Alamat (lanjutan)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Penyesuaian
     adjustment_amount: Jumlah
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Penyesuaian telah berhasil ditutup!
     adjustment_successfully_opened: Penyesuaian telah berhasil dibuka!
     adjustment_total: Total Penyesuaian
     adjustments: Penambahan
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administrasi
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Setuju kepada Kebijakan Privasi
     agree_to_terms_of_service: Setuju kepada Ketentuan Servis
     all: Semua
     all_adjustments_closed: Semua penyesuaian berhasil ditutup!
     all_adjustments_opened: Semua penyesuaian berhasil dibuka!
     all_departments: Semua departemen
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Memperbolehkan SSL untuk development dan test
     allow_ssl_in_production: Memperbolehkan SSL untuk production
     allow_ssl_in_staging: Memperbolehkan SSL untuk staging mode
@@ -421,70 +462,104 @@ id:
     analytics_desc_list_4: Ini semua gratis!
     analytics_trackers: Penelusuran Analisis
     and: dan
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Anda yakin?
     are_you_sure_delete: Anda yakin mau menghilangkan record berikut?
     associated_adjustment_closed: Penyesuaian yang dimaksud telah ditutup. Apakah Anda mau membukanya?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Gagal Otorisasi
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Tersedia Pada
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Kembali
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Kembali ke Toko
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Kembali ke Daftar User
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Sisa Pelunasan
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Alamat Tagihan
     billing: Penagihan
     billing_address: Alamat Penagihan
     both: Kedua-nya
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Kalkulator
     calculator_settings_warning: Jika anda sedang mengganti tipe kalkulator, anda harus menyimpan terlebih dahulu sebelum anda dapat mengubah pengaturan kalkulator
     cancel: Batal
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: Anda tidak dapat melakukan pembayaran untuk pesanan, tanpa mendefinisikan metode pembayaran terlebih dahulu
     cannot_create_returns: Tidak dapat melakukan pengembalian untuk pesanan ini karena tidak ada barang yang dikirim
     cannot_perform_operation: Tidak dapat melakukan pekerjaan yang diminta
     cannot_set_shipping_method_without_address: Tidak bisa memilih metode pengiriman sampai detil info pelanggan diberikan.
     capture: Ambil
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kode Kartu
     card_number: Nomor Kartu
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Tipe kartu adalah
     cart: Keranjang belanja
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategori
     category: Kategori
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Cek peringatan Spree
     checkout: Checkout
     choose_a_customer: Pilih pelanggan
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Pilih Mata Uang
     choose_dashboard_locale: Pilih Bahasa Dashboard
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Kota
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Gandakan
     close: Tutup
     close_all_adjustments: Tutup Semua Penyesuaian
@@ -493,6 +568,7 @@ id:
     complete: Selesai
     configuration: Konfigurasi
     configurations: Konfigurasi
+    configure_s3: TODO_TRANSLATE
     confirm: Yakin
     confirm_delete: Konfirmasi Penghapusan
     confirm_password: Konfirmasi Kata Sandi
@@ -501,18 +577,18 @@ id:
     cost_currency: Biaya Mata Uang
     cost_price: Harga Pokok
     could_not_connect_to_jirafe: Tidak dapat terhubung ke Jirafe untuk sinkronisasi data. Akan dicoba kembali secara otomatis.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Ada masalah saat menyimpan pergerakan stok. Silahkan dicoba kembali.
-    count_on_hand:
+    count_on_hand: TODO_TRANSLATE
     countries: Negara
     country: Negara
     country_based: Berdasarkan negara
     country_name: Nama
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Kupon
     coupon_code: Kode kupon
     coupon_code_already_applied: Kode kupon suda diaplikasikan ke pesanan ini sebelumnya.
@@ -522,17 +598,17 @@ id:
     coupon_code_max_usage: Pemakaian kode kupon telah melewati batas
     coupon_code_not_eligible: Kode kupon tidak bisa digunakan untuk pesanan ini.
     coupon_code_not_found: Kode kupon yang Anda masukkan tidak tersedia. Silahkan dicoba kembali.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Buat
     create_a_new_account: Buat akun baru
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Dibuat Saat
     credit: Kredit
     credit_card: Kartu Kredit
     credit_cards: Kartu Kredit
     credit_owed: Pemberian Kredit
-    credits:
+    credits: TODO_TRANSLATE
     currency: Mata Uang
     currency_decimal_mark: Kurs tanda desimal
     currency_settings: Pengaturan Mata Uang
@@ -543,17 +619,17 @@ id:
     customer: Pelanggan
     customer_details: Detail Pelanggan
     customer_details_updated: Detail pelanggan telah diubah
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Pencarian pelanggan
     cut: Potong
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: ID Aplikasi
         app_token: Token Aplikasi
-        currently_unavailable:
-        explanation:
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
         header: Pengaturan Analisis Jirafe
         site_id: ID Situs
         token: Token
@@ -561,46 +637,65 @@ id:
     date: Tanggal
     date_completed: Tanggal Selesai
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
     date_range: Rentang Tanggal
     default: Nilai Awal
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Nilai Awal Pajak
     default_tax_zone: Wilayah Pajak Awal
     delete: Hapus
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Pengiriman
     depth: Kedalaman
     description: Deskripsi
     destination: Tujuan
     destroy: Hapus
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Jumlah Diskon
     dismiss_banner: Tidak. Terima Kasih! Saya tidak tertarik, jangan tampilkan pesan ini lagi
     display: Tampilan
     display_currency: Tampilan mata uang
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Ubah
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Pengubahan Pengguna
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Kosong
     empty_cart: Kosongkan Keranjang Belanja
@@ -632,29 +727,31 @@ id:
         user:
           signup: Pendaftaran pengguna
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Waktu kedaluwarsa
     extension: Ektensi
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Nama file
     fill_in_customer_info: Silahkan isi informasi pelanggan
+    filter: TODO_TRANSLATE
     filter_results: Hasil Filter
     finalize: Penyelesaian
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Harga Barang Pertama
     first_name: Nama Depan
     first_name_begins_with: Nama Depan Dimulai Dengan
     flat_percent: Persentase Tetap
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Tarif Tetap (per pesanan)
     flexible_rate: Tarif Fleksibel
     forgot_password: Lupa Kata Sandi?
     free_shipping: Gratis Pengiriman
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Tampilan Depan
     gateway: Gateway
     gateway_config_unavailable: Gateway tidak tersedia untuk lingkungan
@@ -670,45 +767,49 @@ id:
     hide_cents: Sembunyikan nilai sen
     home: Beranda
     i18n:
-      available_locales:
-      fields:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
       language: Bahasa
       localization_settings: Pengaturan Lokalisasi
-      only_complete:
-      only_incomplete:
-      select_locale:
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
       show_only: Tampilkan hanya
-      supported_locales:
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: Indonesian (ID)
       translations: Terjemahan
     icon: Ikon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Gambar
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Gambar
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Termasuk dalam Harga
     included_price_validation: tidak dapat dipilih jika anda tidak mengatur Area Awal Pajak
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: Isi formulir di bawah ini dan instruksi perubahan kata sandi akan dikirimkan ke email anda
     insufficient_stock: Stok tidak cukup, hanya tersedia %{on_hand} buah
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Ganti email penerima dengan email ini
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Penyedia pembayaran tidak valid
     invalid_promotion_action: Aksi promosi tidak valid
     invalid_promotion_rule: Aturan promosi tidak valid
     inventory: Inventori
     inventory_adjustment: Penyesuaian Inventori
     inventory_error_flash_for_insufficient_quantity: Sebuah barang dalam keranjang Anda menjadi tidak tersedia.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: tidak tersedia untuk alamat tujuan
     iso_name: Nama ISO
     item: Barang
@@ -718,26 +819,32 @@ id:
       operators:
         gt: lebih besar dari
         gte: lebih besar dari atau sama dengan
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: Nama Belakang
     last_name_begins_with: Nama Belakang Dimulai Dengan
     learn_more: Mengenal Lebih
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Daftar
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Loading
     locale_changed: Bahasa telah terganti
     location: Lokasi
     lock: Kunci
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Login sebagai
     logged_in_succesfully: Login berhasil
     logged_out: Anda telah keluar.
@@ -746,13 +853,16 @@ id:
     login_failed: Otentikasi login gagal.
     login_name: Login
     logout: Keluar
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Cari barang yang mirip
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Melakukan pengembalian
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Harga Master
     match_choices:
       all: Semua
@@ -786,20 +896,21 @@ id:
     new_payment_method: Metode baru pembayaran
     new_product: Produk baru
     new_promotion: Promosi baru
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Properti baru
     new_prototype: Prototipe baru
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Pengembalian baru
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Kategori pengiriman baru
     new_shipping_method: Metode pengiriman baru
     new_state: Provinsi baru
     new_stock_location: Lokasi Stok Baru
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: Kategori pajak baru
     new_tax_rate: Tarif pajak baru
     new_taxon: Takson baru
@@ -810,24 +921,30 @@ id:
     new_zone: Daerah baru
     next: Lanjut
     no_actions_added: Tidak ada aksi yang ditambahkan
-    no_payment_found:
-    no_pending_payments:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Produk tidak ditemukan
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Tidak ada hasil
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Tidak ada aturan tambahan
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: Tidak ada
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Jumlah normal
     not: Bukan
     not_available: Tidak tersedia
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource} tidak ditemukan"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Produk telah digandakan
       product_deleted: Produk telah dihapus
@@ -835,12 +952,12 @@ id:
       product_not_deleted: Produk tidak dapat dihapus
       variant_deleted: Varian dapat dihapus
       variant_not_deleted: Varian tidak dapat dihapus
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Stok yang tersedia
     open: Buka
     open_all_adjustments: Buka Semua Penyesuaian
     option_type: Pilihan tipe
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Pilihan tipe
     option_value: Pilihan nilai
     option_values: Pilihan nilai
@@ -850,32 +967,37 @@ id:
     or_over_price: "%{price} atau lebih"
     order: Pesanan
     order_adjustments: Penyesuaian pesanan
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Rincian pesanan
     order_email_resent: Pengiriman ulang email pesanan
     order_information: Informasi Pesanan
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Untuk pelanggan,\n
         instructions: Pesanan anda telah DIBATALKAN.  Silahkan simpan informasi pendaftaran ini untuk catatan anda.
         order_summary_canceled: Rekap pesanan [DIBATALKAN]
         subject: Pembatalan order
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Untuk pelanggan,\n
         instructions: Silahkan melihat dan menyimpan urutan informasi sebagai berikut untuk catatan anda.
         order_summary: Rekap pesanan
         subject: Konfirmasi pesanan
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Terima kasih.
-        total:
+        total: TODO_TRANSLATE
     order_not_found: Kami tidak dapat menemukan pesanan Anda. Silahkan coba lagi.
     order_number: Nomor Pesanan
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Pesanan anda telah berhasil diproses
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: Alamat
       awaiting_return: Menunggu pengembalian
@@ -893,14 +1015,14 @@ id:
     order_total: Total pesanan
     order_updated: Memperbarui pesanan
     orders: Pesanan
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Stok habis
     overview: Keseluruhan
     package_from: paket dari
     pagination:
       first: halaman awal
-      previous: « halaman sebelumnya
       next_page: halaman selanjutnya »
+      previous: "« halaman sebelumnya"
       previous_page: "« halaman sebelumnya"
       truncate: "…"
     password: Kata sandi
@@ -908,11 +1030,11 @@ id:
     path: Path
     pay: Membayar
     payment: Pembayaran
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Informasi Pembayaran
     payment_method: Metode Pembayaran
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Metode Pembayaran
     payment_processing_failed: Pembayaran tidak dapat diproses, silahkan periksa rincian yang anda masukan
     payment_processor_choose_banner_text: Jika anda membutuhkan pilihan bantuan untuk proses pembayaran, silahkan kunjungi
@@ -930,22 +1052,23 @@ id:
       void: membatalkan
     payment_updated: Pembayaran diperbaharui
     payments: Pembayaran
-    pending:
+    pending: TODO_TRANSLATE
     percent: Persen
     percent_per_item: Persentase per barang
     permalink: Permalink
     phone: Telepon
     place_order: Tempat Pesanan
     please_define_payment_methods: Silahkan mendefinisikan beberapa metode pembayaran pertama.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Sesuatu ada yang salah. Silahkan mencoba ulang untuk menambahkan barang.
     powered_by: Didukung oleh
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentasi
     previous: Sebelumnya
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Harga
     price_range: Batasan Harga
     price_sack: price sack
@@ -953,14 +1076,14 @@ id:
     product: Produk
     product_details: Rincian Produk
     product_has_no_description: Produk ini tidak memiliki deskripsi
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Properti Produk
     product_rule:
       choose_products: Pilih produk
-      label:
+      label: TODO_TRANSLATE
       match_all: semua
       match_any: Minimal satu
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Dari kelompok produk
         manual: Pilih manual
@@ -972,19 +1095,24 @@ id:
         description: Membuat penyesuaian kredit promosi pada pembelian
         name: Membuat penyesuaian
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Penuhi keranjang belanja dengan kuantitas varian yang telah ditentukan
         name: Tambah barang baru
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Aksi
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Sesuai dengan semua peraturan
         any: Sesuai dengan beberapa peraturan
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Aturan Promosi
     promotion_rule_types:
       first_order:
@@ -997,27 +1125,27 @@ id:
         description: Pelanggan harus telah mengunjungi halaman spesifik
         name: Halaman Arahan
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Pesanan berisi produk spesifik
         name: Produk
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Hanya tersedia untuk pengguna tertentu
         name: Pengguna
       user_logged_in:
         description: Hanya tersedia untuk pengguna yang telah masuk
         name: Pengguna yang telah masuk
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promosi
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Properti
     property: Properti
     prototype: Prototipe
@@ -1032,43 +1160,45 @@ id:
     rate: Harga
     reason: Sebab
     receive: Terima
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: Telah diterima
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Referensi
+    reference_contains: TODO_TRANSLATE
     refund: Pengembalian Uang
     refund_amount_must_be_greater_than_zero: Pengembalian Uang harus lebih besar dari 0
     refund_reasons: Alasan Pengembalian Uang
-    refunded_amount:
-    refunds:
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Mendaftar sebagai Pengguna Baru
     registration: Pendaftaran
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
     reject: Ditolak
     rejected: Penolakan
     remember_me: Ingat otomatis
     remove: Menghapus
     rename: Menamakan Ulang
-    report:
+    report: TODO_TRANSLATE
     reports: Laporan
+    resellable: TODO_TRANSLATE
     resend: Kirim Ulang
     reset_password: atur ulang kata sandi
     response_code: Kode Respon
@@ -1076,19 +1206,20 @@ id:
     resumed: Telah Dilanjutkan
     return: Kembali
     return_authorization: Otorisasi Pengembalian
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Otorisasi Pengembalian telah dirubah
     return_authorizations: Otorisasi Pengembalian
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
     return_items: Pengembalian Barang
-    return_items_cannot_be_associated_with_multiple_orders:
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
     return_number: Nomor Pengembalian Barang
     return_quantity: Jumlah Pengembalian
     returned: Telah Dikembalikan
-    returns:
+    returns: TODO_TRANSLATE
     review: Periksa
     risk: Risiko
     risk_analysis: Analisis risiko
@@ -1096,8 +1227,14 @@ id:
     rma_credit: Kredit RMA
     rma_number: Nomor RMA
     rma_value: Nilai RMA
+    role_id: TODO_TRANSLATE
     roles: Peran
     rules: Aturan
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
     safe: Aaman
     sales_total: Total Penjualan
     sales_total_description: Total Penjualan untuk semua Pesanan
@@ -1113,10 +1250,11 @@ id:
     secure_connection_type: Jenis Koneksi Aman
     security_settings: Pengaturan Kemanan
     select: Pilih
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Pilih dari Prototipe
     select_stock: Pilih stok
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Kirim Salinan ke semua
     send_mails_as: Kirim pesan sebagai
     server: Server
@@ -1126,8 +1264,9 @@ id:
     ship_address: Alamat Kirim
     ship_total: Total Pengiriman
     shipment: Pengiriman
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Kepada Pelanggan,\n
@@ -1136,17 +1275,17 @@ id:
         subject: Pemberitahuan Pengiriman
         thanks: Terima kasih untuk bisnis anda
         track_information: 'Informasi Pelacakan: %{tracking}'
-        track_link:
+        track_link: TODO_TRANSLATE
     shipment_state: Status Pengiriman
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: Sebagian
       pending: tunda
       ready: siap
       shipped: dikirim
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Pengiriman
     shipped: Dikirim
     shipping: Mengirimkan
@@ -1159,8 +1298,12 @@ id:
     shipping_instructions: Instruksi Pengiriman
     shipping_method: Metode Pengiriman
     shipping_methods: Metode Pengiriman
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Belanja berdasar %{taxonomy}
     shopping_cart: Keranjang Belanja
     show: Perlihatkan
@@ -1170,62 +1313,74 @@ id:
     show_only_considered_risky: Tampilkan yang dianggap berisiko
     show_rate_in_label: Tampilkan nilai di label
     sku: SKU
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Sumber
     special_instructions: Instruksi Spesial
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Terdapat suatu masalah dengan informasi pembayaran anda. Cek informasi anda lagi dan coba lagi.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Mulai
+    start_date: TODO_TRANSLATE
     state: Provinsi
     state_based: Berdasar Provinsi
     state_machine_states:
       accepted: Diterima
       address: Alamat
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Provinsi
     states_required: Memerlukan Provinsi
     status: Status
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Lokasi Stok
     stock_location_info: Informasi lokasi stok
     stock_locations: Lokasi Stok
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Manajemen Stok
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
     stock_movements: Pergerakan Stok
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
     stock_transfer: Pemindahan Stok
     stock_transfers: Pemindahan Stok
     stop: Berakhir
@@ -1234,36 +1389,41 @@ id:
     street_address_2: Alamat Jalan (lanjutan)
     subtotal: Subtotal
     subtract: Kurangi
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} telah Berhasil Dibuat!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} telah Berhasil Dihapus!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource} telah Berhasil Diubah!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Pajak
     tax_categories: Kategori Pajak
     tax_category: Kategori Pajak
     tax_code: Kode Pajak
     tax_included: Termasuk Pajak
-    tax_rate_amount_explanation:
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Tingkat Pajak
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Takson
     taxon_edit: Ubah Takson
     taxon_placeholder: Placeholder Takson
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taksonomi
-    taxonomy:
+    taxonomy: TODO_TRANSLATE
     taxonomy_edit: Edit taksonomy
     taxonomy_tree_error: Permintaan perubahan belum diterima dan susunan kembali kepada pengaturan awal, tolong coba lagi.
     taxonomy_tree_instruction: "* Klik kanan untuk mengakses child di dalam tree untuk menambah, menghapus atau mengurutkan"
     taxons: Takson
     test: Tes
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Selamat!
         message: Jika anda telah menerima email ini, maka pengaturan email anda benar.
@@ -1272,42 +1432,44 @@ id:
     thank_you_for_your_order: Terima kasih atas pemesanan anda. Silahkan cetak salinan dari halaman konfirmasi ini untuk arsip anda.
     there_are_no_items_for_this_order: Tidak ada barang dalam pesanan ini
     there_were_problems_with_the_following_fields: Terdapat beberapa masalah dengan
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Waktu
     to_add_variants_you_must_first_define: Untuk menambah varian, pertama kali anda harus mendefinisikan
     total: Total
     total_per_item: Total per barang
-    total_pre_tax_refund:
+    total_pre_tax_refund: TODO_TRANSLATE
     total_price: Total Harga
-    total_sales:
-    track_inventory:
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Pelacakan
     tracking_number: Nomor Pelacakan
-    tracking_url:
+    tracking_url: TODO_TRANSLATE
     tracking_url_placeholder: 'contoh: e.g. http://quickship.com/package?num=:tracking'
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Susunan
     type: Tipe
     type_to_search: Ketik untuk Mencari
     unable_to_connect_to_gateway: Tidak dapat berkoneksi dengan gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Dibawah %{price}
-    unlock:
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: Tipe Kartu tidak dikenal
     unshippable_items: Barang-barang yang Tidak Bisa Dikirim
     update: Perbarui
     updating: Memberbarui
     usage_limit: Batas Penggunaan
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Alamat Penagihan
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Gunakan kartu baru
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Pakai Amazon S3 untuk gambar
     user: Pengguna
     user_rule:
@@ -1315,12 +1477,13 @@ id:
     users: Pengguna
     validation:
       cannot_be_less_than_shipped_units: tidak bisa kurang dari jumlah barang yang dikirimkan.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: melebihi stok yang tersedia. Silahkan pastikan barang-barang Anda mempunyai jumlah yang benar.
       is_too_large: terlalu besar -- stok tidak dapat memenuhi kuantitas yang telah dipesan!
       must_be_int: Harus berupa integer
       must_be_non_negative: Harus merupakan nilai positif
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Nilai
     variant: Varian
     variant_placeholder: Varian placeholder
@@ -1339,3 +1502,10 @@ id:
     zipcode: Kode Pos
     zone: Wilayah
     zones: Wilayah
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,4 +1,6 @@
+---
 it:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -72,6 +74,7 @@ it:
         zipcode: CAP indirizzo di spedizione
       spree/payment:
         amount: Quantità
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nome
       spree/product:
@@ -95,6 +98,7 @@ it:
         starts_at: Inizia il
         usage_limit: Limite di Utilizzo
       spree/promotion_category:
+        code: TODO_TRANSLATE
         name: Nome
       spree/property:
         name: Nome
@@ -105,6 +109,8 @@ it:
         amount: Quantità
       spree/role:
         name: Nome
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abbreviazione
         name: Nome
@@ -157,14 +163,14 @@ it:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: 'Le chiavi dei livelli devono tutti essere numeri maggiori di 0'
+              keys_should_be_positive_number: Le chiavi dei livelli devono tutti essere numeri maggiori di 0
             preferred_tiers:
               should_be_hash: deve essere un Hash
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: 'Le chiavi dei livelli devono tutti essere numeri maggiori di 0'
-              values_should_be_percent: "I valori dei livelli devono tutti essere percentuali tra 0% e 100%"
+              keys_should_be_positive_number: Le chiavi dei livelli devono tutti essere numeri maggiori di 0
+              values_should_be_percent: I valori dei livelli devono tutti essere percentuali tra 0% e 100%
             preferred_tiers:
               should_be_hash: deve essere un Hash
         spree/classification:
@@ -183,7 +189,7 @@ it:
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed: è maggiore dell'importo consentito.
+              greater_than_allowed: "è maggiore dell'importo consentito."
         spree/reimbursement:
           attributes:
             base:
@@ -199,6 +205,12 @@ it:
             base:
               cannot_destroy_default_store: Non è possibile eliminare lo Store di default.
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Indirizzo
         other: Indirizzi
@@ -263,6 +275,8 @@ it:
         one: Motivazione Autorizzazione Restituzione
         other: Motivazioni Autorizzazione Restituzione
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Ruolo
         other: Ruoli
       spree/shipment:
@@ -313,6 +327,9 @@ it:
       spree/zone:
         one: Zona
         other: Zone
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Il tuo account è stato confermato. Hai effettuato il login.
@@ -333,8 +350,8 @@ it:
       unlock_instructions:
         subject: Istruzioni per Sbloccare
     oauth_callbacks:
-      failure: "Non è stato possibile autorizzarti da %{kind} perché %{reason}."
-      success: "Autorizzato correttamente dall'account %{kind}"
+      failure: Non è stato possibile autorizzarti da %{kind} perché %{reason}.
+      success: Autorizzato correttamente dall'account %{kind}
     unlocks:
       send_instructions: Riceverai un'email con le istruzioni per sbloccare il tuo account entro pochi minuti.
       unlocked: Il tuo account è stato sbloccato con successo. Hai effettuato il login.
@@ -345,12 +362,13 @@ it:
         updated: Hai modificato la tua password con successo. Hai effettuato il login.
     user_registrations:
       destroyed: Ciao! Il tuo account è stato eliminato con successo. Speriamo di rivederti presto.
-      inactive_signed_up: "Ti sei registrato con successo. Purtroppo non abbiamo potuto effettuare il login perché il tuo account è %{reason}"
+      inactive_signed_up: Ti sei registrato con successo. Purtroppo non abbiamo potuto effettuare il login perché il tuo account è %{reason}
       signed_up: Benvenuto! Hai effettuato il login con successo.
       updated: Hai aggiornato il tuo account con successo.
     user_sessions:
       signed_in: Hai effettuato il login con successo.
       signed_out: Hai effettuato il logout con successo.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: "è già stato confermato"
@@ -359,6 +377,24 @@ it:
       not_saved:
         one: 'questo %{resource} non può essere salvato a causa di 1 errore:'
         other: 'questo %{resource} non può essere salvato a causa di %{count} errori:'
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abbreviazione
     accept: Accetta
@@ -399,11 +435,16 @@ it:
     add_to_cart: Aggiungi al Carrello
     add_variant: Aggiungi Variante
     additional_item: Costo Aggiuntivo Articolo
+    address: TODO_TRANSLATE
     address1: Indirizzo
     address2: Indirizzo (cont.)
     adjustable: Variabile
     adjustment: Variazione
     adjustment_amount: Importo
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: La variazione è stata chiusa correttamente
     adjustment_successfully_opened: La variazione è stata aperta correttamente
     adjustment_total: Totale Variazione
@@ -428,7 +469,7 @@ it:
         items: Articoli
         items_purchased: Articoli Acquistati
         order_history: Storia Ordini
-        order_num: "Ordine #"
+        order_num: 'Ordine #'
         orders: Ordini
         user_information: Informazioni Utente
     administration: Amministrazione
@@ -457,10 +498,10 @@ it:
     and: e
     api:
       access: Accesso
-      key: Chiave
-      no_key: Nessuna Chiave
       clear_key: Elimina Chiave
       generate_key: Genera Chiave
+      key: Chiave
+      no_key: Nessuna Chiave
       regenerate_key: Genera nuova Chiave
     approve: approva
     approved_at: Approvato il
@@ -468,6 +509,11 @@ it:
     are_you_sure: Sei sicuro?
     are_you_sure_delete: Sei sicuro di voler eliminare questo record?
     associated_adjustment_closed: La variazione associata è chiusa e non verrà ricalcolata. Vuoi riaprirla?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Autorizzazione Fallita
     authorized: Autorizzato
     auto_capture: Riscossione Automatica
@@ -476,11 +522,33 @@ it:
     avs_response: Risposta AVS
     back: Indietro
     back_end: Backend
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
     back_to_payment: Torna al Pagamento
-    back_to_resource_list: "Torna alla Lista %{resource}"
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: Torna alla Lista %{resource}
     back_to_rma_reason_list: Torna alla Lista Motivazioni RMA
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Torna al Negozio
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Torna alla Lista degli Utenti
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Ordinabile anche se terminato
     backorderable_default: Ordinabile di default
     backordered: Arretrato
@@ -494,7 +562,7 @@ it:
     both: Entrambi
     calculated_reimbursements: Rimborsi Calcolati
     calculator: Calcolatore
-    calculator_settings_warning: "Se stai cambiando la tipologia di calcolatore, devi prima salvare per modificare le impostazioni del calcolatore"
+    calculator_settings_warning: Se stai cambiando la tipologia di calcolatore, devi prima salvare per modificare le impostazioni del calcolatore
     cancel: annulla
     canceled_at: Annullato il
     canceler: Annullatore
@@ -512,7 +580,7 @@ it:
     cart: Carrello
     cart_subtotal:
       one: Subtotale (1 articolo)
-      other: "Subtotale (%{count} articoli)"
+      other: Subtotale (%{count} articoli)
     categories: Categorie
     category: Categoria
     charged: Addebitato
@@ -536,6 +604,7 @@ it:
     complete: completo
     configuration: Impostazione
     configurations: Impostazioni
+    configure_s3: TODO_TRANSLATE
     confirm: Conferma
     confirm_delete: Conferma Eliminazione
     confirm_password: Conferma Password
@@ -609,12 +678,15 @@ it:
       js_format: dd/mm/yy
     date_range: Intervallo di date
     default: Default
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
     default_refund_amount: Importo Rimborso di default
+    default_seo_title: TODO_TRANSLATE
     default_tax: Tassazione di default
     default_tax_zone: Zona di Tassazione di Default
     delete: Elimina
     delete_from_taxon: Rimuovi dalla Taxon
-    deleted_variants_present:  Alcune linee di questo ordine hanno prodotti che non sono più disponibili.
+    deleted_variants_present: Alcune linee di questo ordine hanno prodotti che non sono più disponibili.
     delivery: Consegna
     depth: Profondità
     description: Descrizione
@@ -622,21 +694,36 @@ it:
     destroy: Elimina
     details: Dettagli
     discount_amount: Importo dello sconto
-    dismiss_banner: "No, grazie! Non sono interessato, non mostrare più questo messaggio"
+    dismiss_banner: No, grazie! Non sono interessato, non mostrare più questo messaggio
     display: Mostra
     display_currency: Mostra valuta
     doesnt_track_inventory: Non tiene traccia dell'inventario
     edit: Modifica
-    editing_resource: 'Modifica %{resource}'
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: Modifica %{resource}
     editing_rma_reason: Modifica Motivazione RMA
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Modifica Utente
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
         has_excluded_product: Il carrello contiene un prodotto che non permette l'applicazione di questo codice coupon.
-        item_total_less_than: "Questo codice coupon non può essere applicato a ordini di importo inferiore a %{amount}."
-        item_total_less_than_or_equal: "Questo codice coupon non può essere applicato a ordini di importo inferiore o uguale a %{amount}."
-        item_total_more_than: "Questo codice coupon non può essere applicato a ordini di importo maggiore di %{amount}."
-        item_total_more_than_or_equal: "Questo codice coupon non può essere applicato a ordini di importo maggiore o uguale di %{amount}."
+        item_total_less_than: Questo codice coupon non può essere applicato a ordini di importo inferiore a %{amount}.
+        item_total_less_than_or_equal: Questo codice coupon non può essere applicato a ordini di importo inferiore o uguale a %{amount}.
+        item_total_more_than: Questo codice coupon non può essere applicato a ordini di importo maggiore di %{amount}.
+        item_total_more_than_or_equal: Questo codice coupon non può essere applicato a ordini di importo maggiore o uguale di %{amount}.
         limit_once_per_user: Questo codice coupon può essere usato solamente una volta per utente.
         missing_product: Questo codice coupon non può essere applicato poiché non hai nel carrello tutti i prodotti necessari.
         missing_taxon: Devi aggiungere un prodotto da tutte le categorie appropriate prima di applicare questo codice coupon.
@@ -657,7 +744,7 @@ it:
       messages:
         could_not_create_taxon: Non è possibile creare il taxon
         no_payment_methods_available: Non ci sono metodi di pagamenti configurati per questo ambiente
-        no_shipping_methods_available: "Non ci sono metodi di spedizione disponibili per l'indirizzo scelto, prova ancora."
+        no_shipping_methods_available: Non ci sono metodi di spedizione disponibili per l'indirizzo scelto, prova ancora.
     errors_prohibited_this_record_from_being_saved:
       one: un errore non ha permesso di salvare questo record
       other: "%{count} errori non hanno permesso di salvare questo record"
@@ -676,11 +763,11 @@ it:
         user:
           signup: Registrazione dell'utente
     exceptions:
-      count_on_hand_setter: 'Non è possibile impostare la disponibilità manualmente dato che è calcolata automaticamente dalla callback "recalculate_count_on_hand". Per favore usa il metodo "update_column(:count_on_hand, value)".'
+      count_on_hand_setter: Non è possibile impostare la disponibilità manualmente dato che è calcolata automaticamente dalla callback "recalculate_count_on_hand". Per favore usa il metodo "update_column(:count_on_hand, value)".
     exchange_for: Cambio per
     excl: escl.
     existing_shipments: Spedizioni esistenti
-    expedited_exchanges_warning: "Ogni cambio specificato sarà spedito al cliente immediatamente dopo il salvataggio. Al cliente sarà addebitato l'importo completo dell'articolo se l'articolo originale non verrà restituito entro %{days_window} giorni."
+    expedited_exchanges_warning: Ogni cambio specificato sarà spedito al cliente immediatamente dopo il salvataggio. Al cliente sarà addebitato l'importo completo dell'articolo se l'articolo originale non verrà restituito entro %{days_window} giorni.
     expiration: Scadenza
     extension: Estensione
     failed_payment_attempts: Tentativi di Pagamento falliti
@@ -695,6 +782,7 @@ it:
     first_name: Nome
     first_name_begins_with: Nome Comincia Con
     flat_percent: Percentuale Uniforme
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Tariffa Flat
     flexible_rate: Rata Flessibile
     forgot_password: Password Dimenticata?
@@ -723,25 +811,30 @@ it:
       only_incomplete: Solo incomplete
       select_locale: Seleziona lingua
       show_only: Mostra solo
+      store_translations: TODO_TRANSLATE
       supported_locales: Lingue Supportate
       this_file_language: Italiano (IT)
       translations: Traduzioni
     icon: Icona
+    identifier: TODO_TRANSLATE
     image: Immagine
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Immagini
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
     inactive: Inattivo
     incl: incl.
     included_in_price: Incluso nel prezzo
     included_price_validation: non può essere selezionato senza aver impostato una Zona di Tassazione di Default
     incomplete: incompleto
     info_number_of_skus_not_shown:
-      one: "e un'altra"
-      other: "e altre %{count}"
-    info_product_has_multiple_skus: "Questo prodotto ha %{count} varianti:"
+      one: e un'altra
+      other: e altre %{count}
+    info_product_has_multiple_skus: 'Questo prodotto ha %{count} varianti:'
     instructions_to_reset_password: Per favore inserisci la tua email nel form sottostante
-    insufficient_stock: "Scorte insufficienti, ne rimangono solo %{on_hand}"
+    insufficient_stock: Scorte insufficienti, ne rimangono solo %{on_hand}
     insufficient_stock_lines_present: Alcune linee di questo ordine hanno quantità insufficiente.
     intercept_email_address: Intercetta indirizzo Email
     intercept_email_instructions: Sovrascrivi il destinatario dell'email con questo indirizzo.
@@ -779,6 +872,12 @@ it:
     lifetime_stats: Statistiche Totali
     line_item_adjustments: Variazioni della riga d'ordine
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Caricamento
     locale_changed: Lingua cambiata
     location: Luogo
@@ -794,11 +893,14 @@ it:
     logout: Esci
     logs: Log
     look_for_similar_items: Cerca articoli simili
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Esegui rimborso
     make_sure_the_above_reimbursement_amount_is_correct: Assicurati che l'importo di rimborso qui sopra sia corretto
     manage_promotion_categories: Gestisci Categorie di Promozione
     manage_variants: Gestisci le Varianti
-    manual_intervention_required: È richiesto un'intervento manuale
+    manual_intervention_required: "È richiesto un'intervento manuale"
     master_price: Prezzo principale
     match_choices:
       all: Tutti
@@ -832,13 +934,14 @@ it:
     new_payment_method: Nuovo Metodo di Pagamento
     new_product: Nuovo Prodotto
     new_promotion: Nuova Promozione
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nuova Proprietà
     new_prototype: Nuovo Prototipo
     new_refund: Nuovo
     new_refund_reason: Nuova Motivazione Rimborso
     new_return_authorization: Nuova Autorizzazione Restituzione
     new_rma_reason: Nuova Motivazione RMA
+    new_role: TODO_TRANSLATE
     new_shipment_at_location: Nuova spedizione alla location
     new_shipping_category: Nuova Categoria di Spedizione
     new_shipping_method: Nuovo Metodo di Spedizione
@@ -856,15 +959,21 @@ it:
     new_zone: Nuova Zona
     next: Prossimo
     no_actions_added: Nessuna azione aggiunta
+    no_orders_found: TODO_TRANSLATE
     no_payment_found: Nessun pagamento trovato
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: Nessun pagamento pendente
     no_products_found: Nessun prodotto trovato
-    no_resource_found: "Nessun %{resource} trovato"
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: Nessun %{resource} trovato
     no_results: Nessun risultato
     no_returns_found: Nessuna restituazione trovata
     no_rules_added: Nessuna regola aggiunta
     no_shipping_method_selected: Nessun metodo di spedizione selezionato.
+    no_shipping_methods_found: TODO_TRANSLATE
     no_state_changes: Nessun cambio di stato
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Non sono stati forniti dettagli sul tracciamento
     none: Niente
     none_selected: Nessuno selezionato
@@ -896,30 +1005,37 @@ it:
     or_over_price: "%{price} o maggiore"
     order: Ordine
     order_adjustments: Variazioni dell'ordine
-    order_already_updated:
+    order_already_updated: TODO_TRANSLATE
     order_approved: Ordine Approvato
     order_canceled: Ordine Annullato
     order_details: Dettagli Ordine
     order_email_resent: Email dell'ordine inviata nuovamente
     order_information: Informazioni sull'Ordine
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer: "Gentile Cliente,\n"
+        dear_customer: |
+          Gentile Cliente,
         instructions: Il tuo ordine è stato ANNULLATO. Per favore conserva queste informazioni per attestare l'annullamento.
-        order_summary_canceled: "Riassunto Ordine [ANNULLATO]"
+        order_summary_canceled: Riassunto Ordine [ANNULLATO]
         subject: Annullamento Ordine
-        subtotal: ! 'Subtotale:'
-        total: ! 'Totale Ordine:'
+        subtotal: 'Subtotale:'
+        total: 'Totale Ordine:'
       confirm_email:
-        dear_customer: "Caro Cliente,\n"
+        dear_customer: |
+          Caro Cliente,
         instructions: Per favore rivedi queste informazioni e conservale come riferimento.
         order_summary: Riassunto Ordine
         subject: Conferma Ordine
-        subtotal: ! 'Subtotale:'
+        subtotal: 'Subtotale:'
         thanks: Grazie per il tuo ordine.
-        total: ! 'Totale Ordine:'
+        total: 'Totale Ordine:'
     order_not_found: Non abbiamo trovato il tuo ordine. Per favore riprova ancora.
-    order_number: "Ordine %{number}"
+    order_number: Ordine %{number}
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Il tuo ordine è stato processato con successo
     order_resumed: Ordine Riattivato
     order_state:
@@ -935,16 +1051,18 @@ it:
       resumed: riattivato
       returned: restituito
     order_summary: Riassunto Ordine
-    order_sure_want_to: "Sei sicuro di voler %{event} questo ordine?"
+    order_sure_want_to: Sei sicuro di voler %{event} questo ordine?
     order_total: Totale Ordine
     order_updated: Ordine Aggiornato
     orders: Ordini
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Non disponibile
     overview: Panoramica
     package_from: pacco da
     pagination:
-      next_page: "pagina successiva &raquo;"
+      first: TODO_TRANSLATE
+      next_page: pagina successiva &raquo;
+      previous: TODO_TRANSLATE
       previous_page: "&laquo; pagina precedente"
       truncate: "&hellip;"
     password: Password
@@ -958,8 +1076,8 @@ it:
     payment_method: Metodo di Pagamento
     payment_method_not_supported: Quel metodo di pagamento non è supportato. Per favore scegline un'altro.
     payment_methods: Metodi di Pagamento
-    payment_processing_failed: "Il pagamento non è stato processato correttamente, per favore controlla i dati inseriti"
-    payment_processor_choose_banner_text: "Se hai bisogno di assistenza nella scelta di un processore di pagamento, per favore visita"
+    payment_processing_failed: Il pagamento non è stato processato correttamente, per favore controlla i dati inseriti
+    payment_processor_choose_banner_text: Se hai bisogno di assistenza nella scelta di un processore di pagamento, per favore visita
     payment_processor_choose_link: la nostra pagina dei pagamenti
     payment_state: Stato Pagamento
     payment_states:
@@ -981,6 +1099,7 @@ it:
     phone: Telefono
     place_order: Completa Ordine
     please_define_payment_methods: Per favore definisci prima dei metodi di pagamento.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Qualcosa è andato storto. Per favore prova ad aggiungere di nuovo l'articolo.
     powered_by: Powered by
     pre_tax_amount: Importo al lordo delle tasse
@@ -989,7 +1108,7 @@ it:
     preferred_reimbursement_type: Tipologia di rimborso preferita
     presentation: Presentazione
     previous: Precedente
-    previous_state_missing: "n.a."
+    previous_state_missing: n.a.
     price: Prezzo
     price_range: Gamma di Prezzo
     price_sack: Costo imballaggio
@@ -1024,11 +1143,16 @@ it:
       free_shipping:
         description: Rendi gratuite tutte le spedizioni dell'ordine
         name: Spedizione Gratuita
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Azioni
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Rispetta tutte queste regole
         any: Rispetta una di queste regole
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Regola Promozione
     promotion_rule_types:
       first_order:
@@ -1067,7 +1191,7 @@ it:
     prototype: Prototipo
     prototypes: Prototipi
     provider: Fornitore
-    provider_settings_warning: "Se stai cambiando la tipologia di fornitore, devi prima aver salvato le impostazioni del fornitore"
+    provider_settings_warning: Se stai cambiando la tipologia di fornitore, devi prima aver salvato le impostazioni del fornitore
     qty: Qtà
     quantity: Quantità
     quantity_returned: Quantità Restituita
@@ -1078,8 +1202,9 @@ it:
     receive: ricevi
     receive_stock: Ricevi Scorte
     received: Ricevuto
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Riferimento
+    reference_contains: TODO_TRANSLATE
     refund: Rimborso
     refund_amount_must_be_greater_than_zero: L'importo del rimborso deve essere maggiore di zero
     refund_reasons: Motivazioni Rimborso
@@ -1092,15 +1217,15 @@ it:
     reimbursement: Rimborso
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send: "Hai %{days} giorni per rispedire indietro gli articoli in attesa di cambio."
-        dear_customer: "Gentile Cliente,"
+        days_to_send: Hai %{days} giorni per rispedire indietro gli articoli in attesa di cambio.
+        dear_customer: Gentile Cliente,
         exchange_summary: Riassunto cambi
         for: per
         instructions: Il tuo rimborso è stato processato.
         refund_summary: Riassunto rimborso
         subject: Notifica di Rimborso
-        total_refunded: "Totale Rimborsato: %{total}"
-    reimbursement_perform_failed: "Il rimborso non può essere effettuato. Errore: %{error}"
+        total_refunded: 'Totale Rimborsato: %{total}'
+    reimbursement_perform_failed: 'Il rimborso non può essere effettuato. Errore: %{error}'
     reimbursement_status: Stato Rimborso
     reimbursement_type: Tipologia Rimborso
     reimbursement_type_override: Override Tipologia Rimborso
@@ -1113,6 +1238,7 @@ it:
     rename: Rinomina
     report: Report
     reports: Report
+    resellable: TODO_TRANSLATE
     resend: Rinvio
     reset_password: Resetta la mia password
     response_code: Codice di Risposta
@@ -1125,6 +1251,7 @@ it:
     return_authorizations: Autorizzazioni Restituzione
     return_item_inventory_unit_ineligible: L'unita di inventario dell'articolo reso deve essere spedita
     return_item_inventory_unit_reimbursed: L'unita di inventario dell'articolo è già stata rimborsata
+    return_item_order_not_completed: TODO_TRANSLATE
     return_item_rma_ineligible: L'articolo reso richiede un RMA
     return_item_time_period_ineligible: L'articolo reso è fuori dal periodo idoneo
     return_items: Articoli Reso
@@ -1140,8 +1267,14 @@ it:
     rma_credit: Credito RMA
     rma_number: Numero RMA
     rma_value: Valore RMA
+    role_id: TODO_TRANSLATE
     roles: Ruoli
     rules: Regole
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
     safe: Sicuro
     sales_total: Totale Vendite
     sales_total_description: Totale Vendite per Tutti gli Ordini
@@ -1152,7 +1285,7 @@ it:
     say_yes: Sì
     scope: Campo
     search: Cerca
-    search_results: "Risultati ricerca per '%{keywords}'"
+    search_results: Risultati ricerca per '%{keywords}'
     searching: Ricerca
     secure_connection_type: Tipologia Connessione Sicura
     security_settings: Impostazioni Sicurezza
@@ -1161,6 +1294,7 @@ it:
     select_a_stock_location: Seleziona un Magazzino
     select_from_prototype: Seleziona da Prototipo
     select_stock: Seleziona Scorte
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Invia una Copia di Tutte le Mail a
     send_mails_as: Invia Mail come
     server: Server
@@ -1171,10 +1305,12 @@ it:
     ship_total: Totale Spedizione
     shipment: Spedizione
     shipment_adjustments: Variazioni spedizioni
-    shipment_details: "Da %{stock_location} via %{shipping_method}"
+    shipment_details: Da %{stock_location} via %{shipping_method}
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer: "Gentile Cliente,\n"
+        dear_customer: |
+          Gentile Cliente,
         instructions: Il tuo ordine è stato spedito
         shipment_summary: Riassunto Spedizione
         subject: Notifica di spedizione
@@ -1204,8 +1340,12 @@ it:
     shipping_method: Metodo di Spedizione
     shipping_methods: Metodi di Spedizione
     shipping_price_sack: Costo imballaggio
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     shipping_total: Totale Spedizione
-    shop_by_taxonomy: "Acquista per %{taxonomy}"
+    shop_by_taxonomy: Acquista per %{taxonomy}
     shopping_cart: Carrello
     show: Visualizza
     show_active: Mostra Attivi
@@ -1216,13 +1356,25 @@ it:
     sku: SKU
     skus: SKU
     slug: Slug
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Origine
     special_instructions: Istruzioni Speciali
     split: Diviso
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Si è verificato un problema con le tue informazioni di pagamento. Per favore controlla le tue informazioni e prova ancora.
     ssl:
       change_protocol: Per favore passa all'utilizzo di HTTP (invece che HTTPS) e riprova questa richiesta.
     start: Inizio
+    start_date: TODO_TRANSLATE
     state: Stato
     state_based: Basato sullo Stato
     state_machine_states:
@@ -1232,22 +1384,22 @@ it:
       awaiting: In Attesa
       awaiting_return: In attesa di reso
       backordered: Arretrato
-      cart: Carrello
       canceled: Annullato
+      cart: Carrello
       checkout: Checkout
-      confirm: Conferma
+      closed: Chiuso
       complete: Completo
       completed: Completato
-      closed: Chiuso
+      confirm: Conferma
       delivery: Spedizione
       errored: In Errore
       failed: Fallito
       given_to_customer: Dato al Cliente
       invalid: Non Valido
       manual_intervention_required: Richiesto intervento manuale
+      on_hand: Disponibile
       open: Aperto
       order: Ordine
-      on_hand: Disponibile
       payment: Pagamento
       pending: In Sospeso
       processing: In Lavorazione
@@ -1268,7 +1420,7 @@ it:
     stock_management: Gestione Scorte
     stock_management_requires_a_stock_location: Per favore crea un Magazzino per poter gestire le scorte.
     stock_movements: Movimenti di Magazzino
-    stock_movements_for_stock_location: "Movimenti di Magazzino per %{stock_location_name}"
+    stock_movements_for_stock_location: Movimenti di Magazzino per %{stock_location_name}
     stock_successfully_transferred: Le scorte sono state trasferito con successo.
     stock_transfer: Trasferimento di Magazzino
     stock_transfers: Trasferimenti di Magazzino
@@ -1280,7 +1432,7 @@ it:
     subtract: Sottrai
     success: Successo
     successfully_created: "%{resource} è stata creata con successo!"
-    successfully_refunded: '%{resource} è stato rimborsato con successo!'
+    successfully_refunded: "%{resource} è stato rimborsato con successo!"
     successfully_removed: "%{resource} è stato rimosso con successo!"
     successfully_signed_up_for_analytics: Registrazione a Spree Analytics avvenuta con successo
     successfully_updated: "%{resource} è stata aggiornata con successo!"
@@ -1290,8 +1442,10 @@ it:
     tax_category: Categoria di Tassazione
     tax_code: Codice Tassa
     tax_included: Tassa (incl.)
-    tax_rate_amount_explanation: "Le aliquote sono specificate con valore decimale per facilitare le operazioni, (es. se l'aliquota è al 5% inserisci 0.05)"
+    tax_rate_amount_explanation: Le aliquote sono specificate con valore decimale per facilitare le operazioni, (es. se l'aliquota è al 5% inserisci 0.05)
     tax_rates: Aliquote
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxon
     taxon_edit: Modifica Taxon
     taxon_placeholder: Aggiungi Taxon
@@ -1303,14 +1457,17 @@ it:
     taxonomies: Tassonomie
     taxonomy: Tassonomia
     taxonomy_edit: Modifica tassonomia
-    taxonomy_tree_error: "La modifica richiesta non è stata accettata e l'albero è stato riportato allo stato precedente, per favore riprova."
+    taxonomy_tree_error: La modifica richiesta non è stata accettata e l'albero è stato riportato allo stato precedente, per favore riprova.
     taxonomy_tree_instruction: "* Click destro su un nodo nell'albero per accedere al menu e aggiungere, rimuovere o ordinare."
     taxons: Taxon
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Congratulazioni!
-        message: "Se hai ricevuto questa email, allora le tue impostazioni email sono corrette."
+        message: Se hai ricevuto questa email, allora le tue impostazioni email sono corrette.
         subject: E-Mail di Test
     test_mode: Modalità Test
     thank_you_for_your_order: Grazie per il tuo ordine. Per favore stampa una copia di questa conferma come riferimento.
@@ -1322,7 +1479,7 @@ it:
     tiered_percent: Tariffa Fissa a Percentuale
     tiers: Livelli
     time: Ora
-    to_add_variants_you_must_first_define: "Per aggiungere varianti, devi prima definire"
+    to_add_variants_you_must_first_define: Per aggiungere varianti, devi prima definire
     total: Totale
     total_per_item: Totale per articolo
     total_pre_tax_refund: Totale Rimborso al lordo delle tasse
@@ -1342,7 +1499,7 @@ it:
     type_to_search: Digita per cercare
     unable_to_connect_to_gateway: Impossibile connettersi al gateway.
     unable_to_create_reimbursements: Impossibile creare rimborsi perché ci sono articoli in attesa di intervento manuale.
-    under_price: "Inferiore di %{price}"
+    under_price: Inferiore di %{price}
     unlock: Sblocca
     unrecognized_card_type: Carda di credito non riconosciuta
     unshippable_items: Impossibile spedire gli articoli
@@ -1351,6 +1508,7 @@ it:
     usage_limit: Limite di Utilizzo
     use_app_default: Usa il Default dell'App
     use_billing_address: Usa Indirizzo di Fatturazione
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Usa una nuova carta
     use_new_cc_or_payment_method: Usa una nuova carta / Metodo di Pagamento
     use_s3: Usa Amazon S3 per le Immagini
@@ -1360,12 +1518,13 @@ it:
     users: Utenti
     validation:
       cannot_be_less_than_shipped_units: non può essere inferiore al numero di unità spedite.
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       cannot_destroy_line_item_as_inventory_units_have_shipped: Impossibile eliminare le righe d'ordine poiché alcune unità di inventario sono state spedite.
       exceeds_available_stock: supera la disponibilità di magazzino. Per favore assicurati che la quantità degli articoli sia valida.
       is_too_large: "è troppo grande -- il magazzino non può coprire la quantità richiesta!"
       must_be_int: deve essere un intero
       must_be_non_negative: deve essere un valore non negativo
-      unpaid_amount_not_zero: "L'importo non è stato completamente rimborsato. Rimangono: %{amount}"
+      unpaid_amount_not_zero: 'L''importo non è stato completamente rimborsato. Rimangono: %{amount}'
     value: Valore
     variant: Variante
     variant_placeholder: Scegli una variante
@@ -1379,8 +1538,15 @@ it:
     year: Anno
     you_have_no_orders_yet: Non hai alcun ordine
     your_cart_is_empty: Il tuo carrello è vuoto
-    your_order_is_empty_add_product: "Il tuo ordine è vuoto, per favore cerca e aggiungi un prodotto"
+    your_order_is_empty_add_product: Il tuo ordine è vuoto, per favore cerca e aggiungi un prodotto
     zip: Cap
     zipcode: Codice Cap
     zone: Zona
     zones: Zone
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,6 @@
+---
 ja:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ ja:
         state: "都道府県（州）"
         zipcode: "郵便番号"
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ ja:
         name: "名"
         numcode: ISOコード
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: "カード類"
         month: "月"
-        name:
+        name: TODO_TRANSLATE
         number: "カード番号"
         verification_value: "照合コード"
         year: "年"
@@ -42,7 +44,7 @@ ja:
       spree/order:
         checkout_complete: "注文の受け付けを完了しました"
         completed_at: "完了日時"
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: "クーポンコード"
         created_at: "注文日"
         email: "メールアドレス"
@@ -72,6 +74,7 @@ ja:
         zipcode: "配送先の郵便番号"
       spree/payment:
         amount: "金額"
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: "名称"
       spree/product:
@@ -95,7 +98,8 @@ ja:
         starts_at: "開始日時"
         usage_limit: "使用可能回数"
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: "名称"
         presentation: "表示"
@@ -105,24 +109,26 @@ ja:
         amount: "合計"
       spree/role:
         name: "名称"
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: "略語"
         name: "名称"
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: "説明"
         name: "名称"
@@ -157,48 +163,54 @@ ja:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: "住所"
         other: "住所"
@@ -208,41 +220,43 @@ ja:
       spree/credit_card:
         one: "クレジットカード"
         other: "クレジットカード"
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: "在庫品単位"
         other: "在庫品単位"
       spree/line_item:
         one: "品目"
         other: "品目"
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: "注文"
         other: "注文"
       spree/payment:
         one: "支払い"
         other: "支払い"
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: "商品"
         other: "商品"
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: "属性"
         other: "属性"
       spree/prototype:
         one: "プロトタイプ"
         other: "プロトタイプ"
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: "返品許可"
         other: "返品許可"
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: "役割"
         other: "役割"
       spree/shipment:
@@ -251,14 +265,14 @@ ja:
       spree/shipping_category:
         one: "配送カテゴリ"
         other: "配送カテゴリ"
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: "都道府県（州）"
         other: "都道府県（州）"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: "税区分"
         other: "税区分"
@@ -271,7 +285,7 @@ ja:
       spree/taxonomy:
         one: "分類ツリー"
         other: "分類ツリー"
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: "ユーザー"
         other: "ユーザー"
@@ -281,69 +295,93 @@ ja:
       spree/zone:
         one: "ゾーン"
         other: "ゾーン"
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: "アカウントが正常に確認されました。ログインしました。"
-      send_instructions:
+      send_instructions: TODO_TRANSLATE
     failure:
       inactive: "アカウントはまだ確認されませんでした。"
       invalid: Eメールアドレスもしくはパスワードが異なります。
       invalid_token: "無効な認証トークン。"
       locked: "アカウントはロックされています"
-      timeout:
+      timeout: TODO_TRANSLATE
       unauthenticated: "続ける前にサインインかサインアップが必要です。"
       unconfirmed: "続ける前にアカウントの確認が必要です。"
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
         subject: "パスワードのリセット方法"
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
         cannot_be_blank: "パスワードを入力してください。"
-        send_instructions:
+        send_instructions: TODO_TRANSLATE
         updated: "パスワードの変更に成功しました。サインインし直してください。"
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
       signed_in: "サインインに成功しました。"
       signed_out: "サインアウトに成功しました。"
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: "省略"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "アカウント"
     account_updated: "アカウントが更新されました。"
     action: "アクション"
     actions:
       cancel: "キャンセル"
-      continue:
+      continue: TODO_TRANSLATE
       create: "作成"
       destroy: "削除"
       edit: "編集"
       list: "リスト"
       listing: "一覧"
       new: "新規"
-      refund:
+      refund: TODO_TRANSLATE
       save: "保存"
       update: "更新"
     activate: "アクティベートする"
@@ -351,7 +389,7 @@ ja:
     add: "追加"
     add_action_of_type: "次のタイプのアクションを追加する"
     add_country: "国の追加"
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: "新規ヘッダの追加"
     add_new_style: "新規スタイルの追加"
     add_one: "新規追加"
@@ -361,138 +399,178 @@ ja:
     add_rule_of_type: "次のタイプのルールを追加する"
     add_state: "都道府県（州）の追加"
     add_stock: "ストック追加"
-    add_stock_management:
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: "カートに追加"
-    add_variant:
+    add_variant: TODO_TRANSLATE
     additional_item: 2品目からの値段増加
+    address: TODO_TRANSLATE
     address1: "住所１"
     address2: "住所２"
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: "調整（値引き・追加料金）"
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: "調整（値引き・追加料金）総額"
     adjustments: "調整（値引き・追加料金）"
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: "管理"
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
     all: "全て"
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
     all_departments: "全てのカテゴリ"
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: "開発モードとテストモードでSSLを使用"
     allow_ssl_in_production: "プロダクションモードでSSLを使用"
     allow_ssl_in_staging: "ステージングモードでSSLを使用"
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: "代替のテキスト"
     alternative_phone: "代替の電話番号"
     amount: "金額"
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
     analytics_trackers: "アナリティクストラッカー"
     and: "と"
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: "これで宜しいですか?"
     are_you_sure_delete: "削除しますか?"
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: "認証に失敗しました"
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: "発売開始日・入荷日"
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: "戻る"
     back_end: "バックエンド"
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: "ショップに戻る"
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: "ユーザー一覧に戻る"
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: "未払額"
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: "請求先住所"
     billing: "決済"
     billing_address: "請求先住所"
     both: "両方とも"
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: "計算方法"
     calculator_settings_warning: "計算方法のタイプを変更する場合は、計算方法の設定を編集する前に保存してください。"
     cancel: "キャンセル"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: "支払い方法が選択されていないので、支払いを行うことができません"
     cannot_create_returns: "未発送の注文品に対して返品が出来ません。注文をキャンセルし注文を作り直すか問い合わせて下さい。"
     cannot_perform_operation: "処理出来ませんでした"
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: "入金申請（キャプチャリング）"
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: "カード照合値[セキュリティーコード]"
     card_number: "カード番号"
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: "カード類"
     cart: "カート"
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: "カテゴリー"
     category: "カテゴリー"
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Spreeアラートの確認
     checkout: "レジに進む"
     choose_a_customer: Choose a customer
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: "通貨の選択"
     choose_dashboard_locale: "言語の選択"
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: "市区町村"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: "複製"
-    close:
-    close_all_adjustments:
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
     code: "コード"
-    company:
+    company: TODO_TRANSLATE
     complete: "完了"
     configuration: "設定"
     configurations: "設定"
+    configure_s3: TODO_TRANSLATE
     confirm: "確認する"
     confirm_delete: "削除を確認"
     confirm_password: "パスワードの確認"
@@ -500,107 +578,126 @@ ja:
     continue_shopping: "ショッピングを続ける"
     cost_currency: "通貨"
     cost_price: "原価"
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
     countries: "国"
     country: "国"
     country_based: "国による区別"
-    country_name:
+    country_name: TODO_TRANSLATE
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: "クーポン"
     coupon_code: "クーポンコード"
-    coupon_code_already_applied:
+    coupon_code_already_applied: TODO_TRANSLATE
     coupon_code_applied: "クーポンコードが適応されました。"
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: "作成"
     create_a_new_account: "新規アカウント作成"
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
     credit: "債権"
     credit_card: "クレジットカード"
     credit_cards: "クレジットカード"
     credit_owed: "過払い額"
-    credits:
+    credits: TODO_TRANSLATE
     currency: "通貨"
-    currency_decimal_mark:
+    currency_decimal_mark: TODO_TRANSLATE
     currency_settings: "通貨の設定"
     currency_symbol_position: "通貨のマークを前もしくは後ろにつけますか？"
-    currency_thousands_separator:
+    currency_thousands_separator: TODO_TRANSLATE
     current: "現在"
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: "お客様"
     customer_details: "お客様詳細情報"
     customer_details_updated: "お客様詳細情報が更新されました。"
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: "お客様の検索"
     cut: "カット"
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
     date_completed: "完了日"
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: "日範囲"
     default: "初期設定"
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: "デフォルトの税"
     default_tax_zone: "デフォルトのタックスゾーン"
     delete: "削除"
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: "配送/お届け"
     depth: "奥行き"
     description: "説明"
-    destination:
+    destination: TODO_TRANSLATE
     destroy: "破壊する"
-    details:
+    details: TODO_TRANSLATE
     discount_amount: "割引額"
     dismiss_banner: "いいえ。結構です！興味ありません。再びこのメッセージを表示しないでください。"
     display: "表示"
     display_currency: "通貨の表示"
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: "編集"
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: "ユーザーの編集"
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Eメール
     empty: "空です"
     empty_cart: "カートを空にする"
@@ -632,29 +729,31 @@ ja:
         user:
           signup: "ユーザー登録"
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: "有効期限"
     extension: "拡張"
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: "ファイル名"
-    fill_in_customer_info:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
     filter_results: "検索結果"
     finalize: "確定"
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: "一品目の値段"
     first_name: "名前（名）"
     first_name_begins_with: "名前（名）が以下の文字列で始まる"
     flat_percent: "定率"
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: "定格(一注文につき)"
     flexible_rate: "変動料金"
     forgot_password: "パスワードを忘れた方"
     free_shipping: "配送料無料"
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: "フロントエンド"
     gateway: "ゲートウェー"
     gateway_config_unavailable: "この環境ではゲートウェーを利用できません。"
@@ -670,45 +769,49 @@ ja:
     hide_cents: "セントの非表示"
     home: "ホーム"
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: "日本語 (ja-JP)"
       translations: "翻訳"
     icon: "アイコン"
-    identifier:
+    identifier: TODO_TRANSLATE
     image: "画像"
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: "画像"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: "価格に含まれる"
     included_price_validation: "はデフォルトのタックスゾーンを設定しない限り選択できません。"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: "下のフォームを入力してからパスワードの再設定方法の説明がメールで送信されます。"
     insufficient_stock: "在庫が十分ではありません。残り%{on_hand}個です。"
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: "置き換え用のメールアドレス"
     intercept_email_instructions: "メールの宛先をこのアドレスで置き換えます。"
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: "在庫"
     inventory_adjustment: "在庫調整"
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: "はこの配達先では発送出来ません。"
     iso_name: ISO名
     item: "アイテム"
@@ -716,28 +819,34 @@ ja:
     item_total: "合計"
     item_total_rule:
       operators:
-        gt:
-        gte:
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        gt: TODO_TRANSLATE
+        gte: TODO_TRANSLATE
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
       path: "パス"
     last_name: "名前（姓）"
     last_name_begins_with: "名前（姓）が以下の文字列で始まる"
     learn_more: "もっと詳しく"
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: "リスト"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "読み込み中"
     locale_changed: "ロケールを変更しました"
-    location:
-    lock:
-    log_entries:
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
     logged_in_as: "ログイン"
     logged_in_succesfully: "ログインに成功しました"
     logged_out: "ログアウトしました。"
@@ -746,38 +855,41 @@ ja:
     login_failed: "ログイン認証失敗"
     login_name: "ログイン名"
     logout: "ログアウト"
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: "似た商品を探す"
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: "返金する"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: "定価"
     match_choices:
       all: "すべて"
       none: "なし"
     max_items: "商品の数の最大限"
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: "メタ情報説明"
     meta_keywords: "メタキーワード"
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: "メタデータ"
     minimal_amount: "最低額"
     month: "月"
     more: "さらに"
-    move_stock_between_locations:
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: "アカウント情報"
     my_orders: "注文情報"
     name: "名称"
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: "品名もしくは品番"
     new: "新規"
     new_adjustment: "新規の値引き・追加請求"
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: "新規顧客"
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: "新規画像"
     new_option_type: "新規オプションタイプ"
     new_order: "新規注文"
@@ -786,20 +898,21 @@ ja:
     new_payment_method: "支払い方法を追加"
     new_product: "新規商品"
     new_promotion: "新規プロモーション"
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: "新規属性"
     new_prototype: "新規プロトタイプ"
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: "新規返品依頼"
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: "新規配送カテゴリー"
     new_shipping_method: "新規配送方法"
     new_state: "新規都道府県（州）"
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: "新規税金カテゴリー"
     new_tax_rate: "新規税率"
     new_taxon: "新規分類"
@@ -809,25 +922,31 @@ ja:
     new_variant: "新規種類"
     new_zone: "新規ゾーン"
     next: "次へ"
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: "商品が見付かりませんでした。"
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: "検索結果がありませんでした。"
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: "ルールが追加されていません"
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: "空です"
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: "通常価格"
     not: "非"
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource}が見つかりません"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: "商品を複製しました"
       product_deleted: "商品を削除しました"
@@ -835,47 +954,52 @@ ja:
       product_not_deleted: "商品を削除することが出来ませんでした"
       variant_deleted: "種類を削除しました"
       variant_not_deleted: "種類を削除することが出来ませんでした"
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: "入荷数"
-    open:
-    open_all_adjustments:
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
     option_type: "オプションタイプ"
     option_type_placeholder: "プレイスホルダ"
     option_types: "オプションタイプ"
     option_value: "オプション価格"
     option_values: "オプション価格"
-    optional:
+    optional: TODO_TRANSLATE
     options: "オプション"
     or: "もしくは"
     or_over_price: "%{price}以上"
     order: "注文"
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_adjustments: TODO_TRANSLATE
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: "注文詳細"
     order_email_resent: "注文詳細メールを再送信しました"
     order_information: "注文情報"
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
         subject: "注文のキャンセル"
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
         subject: "注文確認"
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: "注文が完了しました。"
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: "住所"
       awaiting_return: "返品待ち"
@@ -883,7 +1007,7 @@ ja:
       cart: "カート"
       complete: "完了"
       confirm: "確認"
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: "配送"
       payment: "支払い"
       resumed: "再開"
@@ -893,12 +1017,14 @@ ja:
     order_total: "合計"
     order_updated: "注文内容が更新されました。"
     orders: "注文"
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: "在庫が品切れです"
     overview: "概要"
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
+      first: TODO_TRANSLATE
       next_page: "次のページ »"
+      previous: TODO_TRANSLATE
       previous_page: "« 前のページ"
       truncate: "…"
     password: "パスワード"
@@ -906,11 +1032,11 @@ ja:
     path: "パス"
     pay: "支払い"
     payment: "支払い方法"
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: "支払い情報"
     payment_method: "支払い方法"
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: "支払い方法"
     payment_processing_failed: "決済が失敗しました。入力した情報を確認してから再び決済を行ってみて下さい。"
     payment_processor_choose_banner_text: "もし決済処理会社の選択でお困りでしたら、どうぞ"
@@ -928,22 +1054,23 @@ ja:
       void: "無効"
     payment_updated: "支払いが更新されました。"
     payments: "支払い方法"
-    pending:
-    percent:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
     percent_per_item: Percent Per Item
     permalink: "パーマリンク"
     phone: "電話番号"
     place_order: "注文を送信する"
     please_define_payment_methods: "まず支払い方法を定義してください。"
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Something went wrong. Please try adding the item again.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: "表示名"
     previous: "前へ"
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: "価格"
     price_range: "価格帯"
     price_sack: "プライスサック"
@@ -951,14 +1078,14 @@ ja:
     product: "商品"
     product_details: "商品詳細"
     product_has_no_description: "この商品に詳細がありません。"
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: "商品情報"
     product_rule:
       choose_products: "商品を選択してください"
-      label:
+      label: TODO_TRANSLATE
       match_all: "少なくとも一つ"
       match_any: "すべて"
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: "商品グループから"
         manual: "手動で選択"
@@ -970,19 +1097,24 @@ ja:
         description: "注文に対して値引きする"
         name: "値引き"
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: "特定の種類の商品をカートに加える"
         name: "商品追加"
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: "アクション"
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: "以下のルールすべてに該当する"
         any: "以下のルールのいずれかに該当する"
+    promotion_label: TODO_TRANSLATE
     promotion_rule: "プロモーションルール"
     promotion_rule_types:
       first_order:
@@ -995,27 +1127,27 @@ ja:
         description: "お客様が特定のページを訪問済みである"
         name: "ランディングページ"
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: "注文に特定の商品を含む"
         name: "商品"
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: "特定のユーザー限定"
         name: "ユーザー"
       user_logged_in:
         description: "ログイン中のユーザー限定"
         name: "ログイン中のユーザー"
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: "プロモーション"
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: "属性"
     property: "属性"
     prototype: "プロトタイプ"
@@ -1023,50 +1155,52 @@ ja:
     provider: "プロバイダー"
     provider_settings_warning: "プロバイダータイプを変更する時は、プロバイダー設定を編集する前に保存しなければなりません。"
     qty: "個数"
-    quantity:
+    quantity: TODO_TRANSLATE
     quantity_returned: "返送された数"
     quantity_shipped: "発送された数"
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: "比率"
     reason: "理由"
     receive: "受信"
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: "受信した"
-    reception_status:
-    reference:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
     refund: "払い戻し"
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: "新規ユーザーとして登録"
     registration: "登録"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: "記録する"
     remove: "削除"
     rename: "リネーム"
-    report:
+    report: TODO_TRANSLATE
     reports: "リポート"
+    resellable: TODO_TRANSLATE
     resend: "再送信"
     reset_password: "パスワードを再設定する"
     response_code: "レスポンスコード"
@@ -1074,34 +1208,41 @@ ja:
     resumed: "リジュームされた"
     return: "返品"
     return_authorization: "返品承認"
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: "返品承認が更新されました"
     return_authorizations: "返品承認"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: "返品数"
     returned: "返品済み"
-    returns:
+    returns: TODO_TRANSLATE
     review: "内容を確認する"
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMAクレジット
     rma_number: RMA番号
     rma_value: RMA値
+    role_id: TODO_TRANSLATE
     roles: "役割"
     rules: "ルール"
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: "売上げ合計"
     sales_total_description: "全注文の売上合計"
-    sales_totals:
+    sales_totals: TODO_TRANSLATE
     save_and_continue: "保存して続行"
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: "いいえ"
     say_yes: "はい"
     scope: "範囲"
@@ -1111,10 +1252,11 @@ ja:
     secure_connection_type: "接続保護のタイプ"
     security_settings: "セキュリティの設定"
     select: "選択"
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: "プロトタイプから選択"
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: "全てのメールのコピーをこの宛先に送る"
     send_mails_as: "メール送信者名"
     server: "サーバ"
@@ -1122,138 +1264,157 @@ ja:
     settings: "設定"
     ship: "配送"
     ship_address: "配送先住所"
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: "発送"
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        shipment_summary: TODO_TRANSLATE
         subject: "発送の通知"
-        thanks:
-        track_information:
-        track_link:
+        thanks: TODO_TRANSLATE
+        track_information: TODO_TRANSLATE
+        track_link: TODO_TRANSLATE
     shipment_state: "配送状況"
     shipment_states:
       backorder: "入荷待ち"
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: "一部配送"
       pending: "配送準備中"
       ready: "配送可能"
       shipped: "配送済み"
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: "配送"
     shipped: "発送済"
     shipping: "送料"
     shipping_address: "配送先"
     shipping_categories: "配送カテゴリー"
     shipping_category: "配送カテゴリー"
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: "配送に関して"
     shipping_method: "配送方法"
     shipping_methods: "配送方法"
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: "ショッピングカート"
     show: "表示"
     show_active: "有効のを表示する"
     show_deleted: "削除済みのを表示"
     show_only_complete_orders: "処理済みの注文のみを表示"
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: "税率を見る"
     sku: "品番[SKU]"
-    skus:
-    slug:
-    source:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
     special_instructions: "特別な指示"
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: "支払い情報に問題があります。情報をお確かめになり再試行願います。"
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: "始め"
+    start_date: TODO_TRANSLATE
     state: "都道府県（州）"
     state_based: "都道府県(州)による区別"
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: "都道府県（州）"
     states_required: "必須"
     status: "状況"
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
     stop: "終わり"
     store: "ストア"
     street_address: "住所"
     street_address_2: "住所の続き"
     subtotal: "合計"
     subtract: "引く"
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource}が作成されました!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource}が削除されました!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource}が更新されました!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: "税金"
     tax_categories: "税金カテゴリー"
     tax_category: "税金カテゴリー"
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: "税率"
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: "分類"
     taxon_edit: "分類を編集"
     taxon_placeholder: "分類プレイスホルダ"
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: "分類ツリー"
     taxonomy: "分類ツリー"
     taxonomy_edit: "分類ツリーを編集する"
@@ -1262,50 +1423,55 @@ ja:
     taxons: "分類"
     test: "テスト"
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: "おめでとうございます！"
         message: "もしこのメールを受け取ったのなら、あなたのメール設定は正しいです。"
         subject: "テストメール"
     test_mode: "テストモード"
     thank_you_for_your_order: "ご注文ありがとうございます。この確認画面を控えとして印刷してください。"
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: "以下の入力欄で問題がありました"
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: "サムネール"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: "種類を追加するには、まずそれを定義する必要があります。"
     total: "合計"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: "トラッキング"
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: "ツリー"
     type: "支払い方法"
     type_to_search: "何か入力すると検索します"
     unable_to_connect_to_gateway: "ゲートウェイに接続できません。"
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: "%{price}より安い"
-    unlock:
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: "認識できないカードタイプ"
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: "更新"
     updating: "更新中"
     usage_limit: "使用制限"
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: "請求先住所を使用する"
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: "新しいカードを使用する"
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: "商品画像の保存にAmazon S3を使用する"
     user: "ユーザー"
     user_rule:
@@ -1313,12 +1479,13 @@ ja:
     users: "ユーザー"
     validation:
       cannot_be_less_than_shipped_units: "配送ユニットの個数より小さくはできません"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: "要求された量は在庫を超えています。"
       must_be_int: "整数であることが必要です"
       must_be_non_negative: 0以上の数字が必要です
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: "値"
     variant: "種類"
     variant_placeholder: "種類プレイスホルダ"
@@ -1332,8 +1499,15 @@ ja:
     year: "年"
     you_have_no_orders_yet: "まだ注文がありません。"
     your_cart_is_empty: "カートは空です"
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: "郵便番号"
-    zipcode:
+    zipcode: TODO_TRANSLATE
     zone: "ゾーン"
     zones: "ゾーン"
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,575 +1,716 @@
+---
 ko:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
-        address1:
-        address2:
-        city:
-        country:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        address2: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        country: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
-        iso:
-        iso3:
-        iso_name:
-        name:
-        numcode:
+        iso: TODO_TRANSLATE
+        iso3: TODO_TRANSLATE
+        iso_name: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        numcode: TODO_TRANSLATE
       spree/credit_card:
-        base:
-        cc_type:
-        month:
-        name:
-        number:
-        verification_value:
-        year:
+        base: TODO_TRANSLATE
+        cc_type: TODO_TRANSLATE
+        month: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        number: TODO_TRANSLATE
+        verification_value: TODO_TRANSLATE
+        year: TODO_TRANSLATE
       spree/inventory_unit:
-        state:
+        state: TODO_TRANSLATE
       spree/line_item:
-        price:
-        quantity:
+        price: TODO_TRANSLATE
+        quantity: TODO_TRANSLATE
       spree/option_type:
-        name:
-        presentation:
+        name: TODO_TRANSLATE
+        presentation: TODO_TRANSLATE
       spree/order:
-        checkout_complete:
-        completed_at:
-        considered_risky:
-        coupon_code:
-        created_at:
-        email:
-        ip_address:
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        checkout_complete: TODO_TRANSLATE
+        completed_at: TODO_TRANSLATE
+        considered_risky: TODO_TRANSLATE
+        coupon_code: TODO_TRANSLATE
+        created_at: TODO_TRANSLATE
+        email: TODO_TRANSLATE
+        ip_address: TODO_TRANSLATE
+        item_total: TODO_TRANSLATE
+        number: TODO_TRANSLATE
+        payment_state: TODO_TRANSLATE
+        shipment_state: TODO_TRANSLATE
+        special_instructions: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/payment:
-        amount:
+        amount: TODO_TRANSLATE
+        number: TODO_TRANSLATE
       spree/payment_method:
-        name:
+        name: TODO_TRANSLATE
       spree/product:
-        available_on:
-        cost_currency:
-        cost_price:
-        description:
-        master_price:
-        name:
-        on_hand:
-        shipping_category:
-        tax_category:
+        available_on: TODO_TRANSLATE
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        description: TODO_TRANSLATE
+        master_price: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        on_hand: TODO_TRANSLATE
+        shipping_category: TODO_TRANSLATE
+        tax_category: TODO_TRANSLATE
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: TODO_TRANSLATE
+        code: TODO_TRANSLATE
+        description: TODO_TRANSLATE
+        event_name: TODO_TRANSLATE
+        expires_at: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        path: TODO_TRANSLATE
+        starts_at: TODO_TRANSLATE
+        usage_limit: TODO_TRANSLATE
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
-        name:
-        presentation:
+        name: TODO_TRANSLATE
+        presentation: TODO_TRANSLATE
       spree/prototype:
-        name:
+        name: TODO_TRANSLATE
       spree/return_authorization:
-        amount:
+        amount: TODO_TRANSLATE
       spree/role:
-        name:
+        name: TODO_TRANSLATE
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
-        abbr:
-        name:
+        abbr: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: TODO_TRANSLATE
+        included_in_price: TODO_TRANSLATE
+        show_rate_in_label: TODO_TRANSLATE
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: TODO_TRANSLATE
+        permalink: TODO_TRANSLATE
+        position: TODO_TRANSLATE
       spree/taxonomy:
-        name:
+        name: TODO_TRANSLATE
       spree/user:
-        email:
-        password:
-        password_confirmation:
+        email: TODO_TRANSLATE
+        password: TODO_TRANSLATE
+        password_confirmation: TODO_TRANSLATE
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        depth: TODO_TRANSLATE
+        height: TODO_TRANSLATE
+        price: TODO_TRANSLATE
+        sku: TODO_TRANSLATE
+        weight: TODO_TRANSLATE
+        width: TODO_TRANSLATE
       spree/zone:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/country:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/credit_card:
-      spree/customer_return:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/line_item:
-      spree/option_type:
-      spree/option_value:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/payment:
-      spree/payment_method:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
-      spree/promotion:
-      spree/promotion_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
-      spree/return_authorization_reason:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipment:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipping_category:
-      spree/shipping_method:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/tax_rate:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
-      spree/tracker:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/tracker: TODO_TRANSLATE
       spree/user:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/variant:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/zone:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
-      inactive:
-      invalid:
-      invalid_token:
-      locked:
-      timeout:
-      unauthenticated:
-      unconfirmed:
+      inactive: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      invalid_token: TODO_TRANSLATE
+      locked: TODO_TRANSLATE
+      timeout: TODO_TRANSLATE
+      unauthenticated: TODO_TRANSLATE
+      unconfirmed: TODO_TRANSLATE
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: "생략"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "계정"
     account_updated: "계정 정보가 수정되었습니다!"
     action: "행동"
     actions:
       cancel: "취소"
-      continue:
+      continue: TODO_TRANSLATE
       create: "생성"
       destroy: "삭제"
-      edit:
+      edit: TODO_TRANSLATE
       list: "목록"
       listing: "목록"
-      new:
-      refund:
-      save:
+      new: TODO_TRANSLATE
+      refund: TODO_TRANSLATE
+      save: TODO_TRANSLATE
       update: "수정"
-    activate:
+    activate: TODO_TRANSLATE
     active: "활성"
     add: "추가"
-    add_action_of_type:
+    add_action_of_type: TODO_TRANSLATE
     add_country: "국가 추가"
-    add_coupon_code:
-    add_new_header:
-    add_new_style:
-    add_one:
+    add_coupon_code: TODO_TRANSLATE
+    add_new_header: TODO_TRANSLATE
+    add_new_style: TODO_TRANSLATE
+    add_one: TODO_TRANSLATE
     add_option_value: "옵션 값 추가"
     add_product: "상품 추가"
     add_product_properties: "상품 속성 추가"
-    add_rule_of_type:
-    add_state:
-    add_stock:
-    add_stock_management:
+    add_rule_of_type: TODO_TRANSLATE
+    add_state: TODO_TRANSLATE
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: "장바구니에 추가"
-    add_variant:
+    add_variant: TODO_TRANSLATE
     additional_item: "추가 된 아이템 비용"
-    address1:
-    address2:
-    adjustable:
+    address: TODO_TRANSLATE
+    address1: TODO_TRANSLATE
+    address2: TODO_TRANSLATE
+    adjustable: TODO_TRANSLATE
     adjustment: "정산"
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: "정산 합계"
     adjustments: "정산"
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: "관리"
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
     all: "전체"
-    all_adjustments_closed:
-    all_adjustments_opened:
-    all_departments:
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
+    all_departments: TODO_TRANSLATE
+    all_items_have_been_returned: TODO_TRANSLATE
+    allow_ssl_in_development_and_test: TODO_TRANSLATE
+    allow_ssl_in_production: TODO_TRANSLATE
+    allow_ssl_in_staging: TODO_TRANSLATE
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: "대체 텍스트"
     alternative_phone: "휴대폰 번호"
     amount: "액수"
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
     analytics_trackers: "애날리틱스 트래커"
-    and:
-    approve:
-    approved_at:
-    approver:
+    and: TODO_TRANSLATE
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: "확실합니까?"
     are_you_sure_delete: "기록을 삭제하시겠습니까?"
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: "인증 실패"
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: "시작일"
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: "뒤로"
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_end: TODO_TRANSLATE
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: "스토어로 돌아가기"
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: "부족"
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: "청구서 주소"
     billing: "청구서"
     billing_address: "청구서 주소"
     both: "양 쪽 모두"
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: "계산기"
-    calculator_settings_warning:
+    calculator_settings_warning: TODO_TRANSLATE
     cancel: "취소"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
-    cannot_create_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
+    cannot_create_payment_without_payment_methods: TODO_TRANSLATE
+    cannot_create_returns: TODO_TRANSLATE
     cannot_perform_operation: "요청한 명령을 실핼 할 수 없습니다"
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: "캡쳐"
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: "카드 코드"
     card_number: "카드 번호"
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: "카드 종료는 입니다"
     cart: "장바구니"
-    cart_subtotal:
-    categories:
-    category:
-    charged:
-    check_for_spree_alerts:
-    checkout:
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
-    city:
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    cart_subtotal: TODO_TRANSLATE
+    categories: TODO_TRANSLATE
+    category: TODO_TRANSLATE
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
+    checkout: TODO_TRANSLATE
+    choose_a_customer: TODO_TRANSLATE
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: TODO_TRANSLATE
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
+    city: TODO_TRANSLATE
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: "복사"
-    close:
-    close_all_adjustments:
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
     code: "코드"
-    company:
+    company: TODO_TRANSLATE
     complete: "완료"
     configuration: "설정"
     configurations: "설정"
+    configure_s3: TODO_TRANSLATE
     confirm: "확인"
-    confirm_delete:
+    confirm_delete: TODO_TRANSLATE
     confirm_password: "비밀번호 확인"
     continue: "계속"
     continue_shopping: "계속 쇼핑"
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: "비용"
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
+    countries: TODO_TRANSLATE
     country: "국가"
     country_based: "국가 기반"
-    country_name:
+    country_name: TODO_TRANSLATE
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: "쿠폰"
     coupon_code: "쿠폰 코드"
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_already_applied: TODO_TRANSLATE
+    coupon_code_applied: TODO_TRANSLATE
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: "생성"
     create_a_new_account: "새 계정 생성"
-    create_new_order:
-    create_reimbursement:
-    created_at:
-    credit:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
+    credit: TODO_TRANSLATE
     credit_card: "신용카드"
-    credit_cards:
-    credit_owed:
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credit_cards: TODO_TRANSLATE
+    credit_owed: TODO_TRANSLATE
+    credits: TODO_TRANSLATE
+    currency: TODO_TRANSLATE
+    currency_decimal_mark: TODO_TRANSLATE
+    currency_settings: TODO_TRANSLATE
+    currency_symbol_position: TODO_TRANSLATE
+    currency_thousands_separator: TODO_TRANSLATE
     current: "현재"
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: "고객"
     customer_details: "고객 정보"
-    customer_details_updated:
-    customer_return:
-    customer_returns:
+    customer_details_updated: TODO_TRANSLATE
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: "고객 검색"
-    cut:
-    cvv_response:
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
+    date_completed: TODO_TRANSLATE
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: "날짜 범위"
     default: "기본"
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
     delete: "삭제"
-    deleted_variants_present:
-    delivery:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
+    delivery: TODO_TRANSLATE
     depth: "높이"
     description: "설명"
-    destination:
+    destination: TODO_TRANSLATE
     destroy: "삭제"
-    details:
+    details: TODO_TRANSLATE
     discount_amount: "할인액"
-    dismiss_banner:
+    dismiss_banner: TODO_TRANSLATE
     display: "표시"
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: TODO_TRANSLATE
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: "편집"
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: "사용자 편집"
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: "이메일"
-    empty:
+    empty: TODO_TRANSLATE
     empty_cart: "장바구니 비우기"
-    enable_mail_delivery:
-    end:
-    ending_in:
+    enable_mail_delivery: TODO_TRANSLATE
+    end: TODO_TRANSLATE
+    ending_in: TODO_TRANSLATE
     environment: "환경"
     error: "에러"
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
+        could_not_create_taxon: TODO_TRANSLATE
+        no_payment_methods_available: TODO_TRANSLATE
+        no_shipping_methods_available: TODO_TRANSLATE
     errors_prohibited_this_record_from_being_saved:
       one: "저장하는 중에 문제가 발생했습니다."
       other: "저장하는 중에 문제가 %{count}개 발생했습니다."
@@ -577,96 +718,102 @@ ko:
     events:
       spree:
         cart:
-          add:
+          add: TODO_TRANSLATE
         checkout:
-          coupon_code_added:
+          coupon_code_added: TODO_TRANSLATE
         content:
-          visited:
+          visited: TODO_TRANSLATE
         order:
-          contents_changed:
-        page_view:
+          contents_changed: TODO_TRANSLATE
+        page_view: TODO_TRANSLATE
         user:
-          signup:
+          signup: TODO_TRANSLATE
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: "유효 기간"
     extension: "확장"
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: "파일이름"
-    fill_in_customer_info:
-    filter_results:
-    finalize:
-    finalized:
-    find_a_taxon:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
+    filter_results: TODO_TRANSLATE
+    finalize: TODO_TRANSLATE
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: "첫 아이템 비용"
     first_name: "이름"
     first_name_begins_with: "이름으로 시작"
-    flat_percent:
-    flat_rate_per_order:
-    flexible_rate:
-    forgot_password:
+    flat_percent: TODO_TRANSLATE
+    flat_rate_per_item: TODO_TRANSLATE
+    flat_rate_per_order: TODO_TRANSLATE
+    flexible_rate: TODO_TRANSLATE
+    forgot_password: TODO_TRANSLATE
     free_shipping: "무료 배송"
-    free_shipping_amount:
-    front_end:
+    free_shipping_amount: TODO_TRANSLATE
+    front_end: TODO_TRANSLATE
     gateway: "게이트웨이"
-    gateway_config_unavailable:
+    gateway_config_unavailable: TODO_TRANSLATE
     gateway_error: "게이트웨이 에러"
-    general:
+    general: TODO_TRANSLATE
     general_settings: "일반 설정"
     google_analytics: "구글 애날리스틱"
     google_analytics_id: "애날리스틱 ID"
     guest_checkout: "비회원 주문"
     guest_user_account: "비회원으로 결제"
-    has_no_shipped_units:
+    has_no_shipped_units: TODO_TRANSLATE
     height: "세로"
-    hide_cents:
+    hide_cents: TODO_TRANSLATE
     home: Home
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: "한국어 (KO)"
-      translations:
+      translations: TODO_TRANSLATE
     icon: "아이콘"
-    identifier:
+    identifier: TODO_TRANSLATE
     image: "이미지"
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: "이미지"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password:
-    insufficient_stock:
-    insufficient_stock_lines_present:
-    intercept_email_address:
-    intercept_email_instructions:
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
+    included_in_price: TODO_TRANSLATE
+    included_price_validation: TODO_TRANSLATE
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
+    instructions_to_reset_password: TODO_TRANSLATE
+    insufficient_stock: TODO_TRANSLATE
+    insufficient_stock_lines_present: TODO_TRANSLATE
+    intercept_email_address: TODO_TRANSLATE
+    intercept_email_instructions: TODO_TRANSLATE
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: "인벤토리"
     inventory_adjustment: "인벤토리 정산"
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
-    is_not_available_to_shipment_address:
-    iso_name:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
+    is_not_available_to_shipment_address: TODO_TRANSLATE
+    iso_name: TODO_TRANSLATE
     item: "아이템"
     item_description: "아이템 설명"
     item_total: "아이템 합계"
@@ -674,88 +821,98 @@ ko:
       operators:
         gt: "보다 큰"
         gte: "보다 크거나 같은"
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
       path: Path
     last_name: "성"
     last_name_begins_with: "성으로 시작"
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: "목록"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "로딩"
     locale_changed: "지역이 변경됨"
-    location:
-    lock:
-    log_entries:
-    logged_in_as:
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
+    logged_in_as: TODO_TRANSLATE
     logged_in_succesfully: "로그인 성공"
     logged_out: "로그아웃 되었습니다."
     login: "로그인"
-    login_as_existing:
-    login_failed:
+    login_as_existing: TODO_TRANSLATE
+    login_failed: TODO_TRANSLATE
     login_name: "로그인"
     logout: "로그아웃"
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: "비슷한 상품들"
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
+    make_refund: TODO_TRANSLATE
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: "기본 가격"
     match_choices:
-      all:
-      none:
+      all: TODO_TRANSLATE
+      none: TODO_TRANSLATE
     max_items: "최대 아이템"
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: "메타 설명"
     meta_keywords: "메타 키워드"
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: "메타데이터"
     minimal_amount: "최소량"
-    month:
-    more:
-    move_stock_between_locations:
+    month: TODO_TRANSLATE
+    more: TODO_TRANSLATE
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: "내 계정"
     my_orders: "내 주문"
     name: "이름"
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: "이름 또는 SKU"
-    new:
+    new: TODO_TRANSLATE
     new_adjustment: "새 정산"
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: "새 고객"
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: "새 이미지"
     new_option_type: "새 옵션 타입"
     new_order: "새 주문"
-    new_order_completed:
+    new_order_completed: TODO_TRANSLATE
     new_payment: "새 결제"
     new_payment_method: "새 결제 방법"
     new_product: "새 상품"
     new_promotion: "새 프로모션"
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: "새 속성"
     new_prototype: "새 견본"
-    new_refund:
-    new_refund_reason:
-    new_return_authorization:
-    new_rma_reason:
-    new_shipment_at_location:
-    new_shipping_category:
-    new_shipping_method:
-    new_state:
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
+    new_return_authorization: TODO_TRANSLATE
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
+    new_shipping_category: TODO_TRANSLATE
+    new_shipping_method: TODO_TRANSLATE
+    new_state: TODO_TRANSLATE
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: "새 세금 분류"
     new_tax_rate: "새로운 세율"
     new_taxon: "새 분류군"
@@ -765,535 +922,592 @@ ko:
     new_variant: "새 품종"
     new_zone: "새 지역"
     next: "다음"
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: "찾는 상품이 없음"
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: "결과가 없음"
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: "추가 된 규칙이 없음"
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: "없음"
-    none_selected:
-    normal_amount:
-    not:
-    not_available:
-    not_enough_stock:
-    not_found:
-    note:
+    none_selected: TODO_TRANSLATE
+    normal_amount: TODO_TRANSLATE
+    not: TODO_TRANSLATE
+    not_available: TODO_TRANSLATE
+    not_enough_stock: TODO_TRANSLATE
+    not_found: TODO_TRANSLATE
+    note: TODO_TRANSLATE
     notice_messages:
-      product_cloned:
-      product_deleted:
-      product_not_cloned:
-      product_not_deleted:
+      product_cloned: TODO_TRANSLATE
+      product_deleted: TODO_TRANSLATE
+      product_not_cloned: TODO_TRANSLATE
+      product_not_deleted: TODO_TRANSLATE
       variant_deleted: "품종이 삭제됐습니다"
       variant_not_deleted: "품종을 삭제할 수 없습니다"
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: "재고"
-    open:
-    open_all_adjustments:
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
     option_type: "옵션 타입"
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: "옵션 타입"
     option_value: "옵션 값"
     option_values: "옵션 값"
-    optional:
+    optional: TODO_TRANSLATE
     options: "옵션"
     or: "또는"
-    or_over_price:
+    or_over_price: TODO_TRANSLATE
     order: "주문"
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_adjustments: TODO_TRANSLATE
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: "주문 상세"
     order_email_resent: "주문 확인 메일 재발송"
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
         subject: "주문 취소"
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
         subject: "주문 확인"
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
     order_populator:
-      out_of_stock:
-      please_enter_reasonable_quantity:
-      selected_quantity_not_available:
-    order_processed_successfully:
-    order_resumed:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
+    order_processed_successfully: TODO_TRANSLATE
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: "주소"
-      awaiting_return:
+      awaiting_return: TODO_TRANSLATE
       canceled: "취소됨"
       cart: "장바구니"
       complete: "완료"
       confirm: "확인"
-      considered_risky:
-      delivery:
+      considered_risky: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
       payment: "지불"
-      resumed:
-      returned:
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
     order_summary: "주문 요약"
-    order_sure_want_to:
+    order_sure_want_to: TODO_TRANSLATE
     order_total: "주문 합계"
     order_updated: "주문이 수정됨"
     orders: "주문"
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: "품절"
     overview: Overiew
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
-      next_page:
-      previous_page:
+      first: TODO_TRANSLATE
+      next_page: TODO_TRANSLATE
+      previous: TODO_TRANSLATE
+      previous_page: TODO_TRANSLATE
       truncate: "…"
     password: "비밀번호"
-    paste:
+    paste: TODO_TRANSLATE
     path: "경로"
-    pay:
+    pay: TODO_TRANSLATE
     payment: "지불"
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: "지불 정보"
     payment_method: "결제 방법"
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: "결제 방법"
     payment_processing_failed: "결제 중에 문제가 발생했습니다. 잠시 후에 다시 해보시기 바랍니다."
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
+    payment_processor_choose_banner_text: TODO_TRANSLATE
+    payment_processor_choose_link: TODO_TRANSLATE
     payment_state: "지불 상태"
     payment_states:
       balance_due: "부족"
-      checkout:
+      checkout: TODO_TRANSLATE
       completed: "완료"
-      credit_owed:
-      failed:
+      credit_owed: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
       paid: "지불"
       pending: "보류"
-      processing:
-      void:
-    payment_updated:
+      processing: TODO_TRANSLATE
+      void: TODO_TRANSLATE
+    payment_updated: TODO_TRANSLATE
     payments: "지불"
-    pending:
-    percent:
-    percent_per_item:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
+    percent_per_item: TODO_TRANSLATE
     permalink: "퍼마링크"
     phone: "전화번호"
-    place_order:
-    please_define_payment_methods:
-    populate_get_error:
-    powered_by:
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    place_order: TODO_TRANSLATE
+    please_define_payment_methods: TODO_TRANSLATE
+    please_enter_reasonable_quantity: TODO_TRANSLATE
+    populate_get_error: TODO_TRANSLATE
+    powered_by: TODO_TRANSLATE
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: "표시"
     previous: "이전"
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: "가격"
-    price_range:
-    price_sack:
+    price_range: TODO_TRANSLATE
+    price_sack: TODO_TRANSLATE
     process: "과정"
     product: "상품"
     product_details: "상품 상세"
-    product_has_no_description:
-    product_not_available_in_this_currency:
+    product_has_no_description: TODO_TRANSLATE
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: "상품 속성"
     product_rule:
       choose_products: "상품 선택"
-      label:
+      label: TODO_TRANSLATE
       match_all: "모두"
       match_any: "최소 하나"
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: "상품군에서"
-        manual:
+        manual: TODO_TRANSLATE
     products: "상품"
-    promotion:
-    promotion_action:
+    promotion: TODO_TRANSLATE
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: "이 규칙에 모두 일치"
         any: "이 규칙에 하나라도 일치"
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
-        description:
+        description: TODO_TRANSLATE
         name: "첫 주문"
       item_total:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       landing_page:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
-    promotions:
-    propagate_all_variants:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
+    promotions: TODO_TRANSLATE
+    propagate_all_variants: TODO_TRANSLATE
     properties: "속성"
     property: "속성"
     prototype: "견본"
     prototypes: "견본"
     provider: "제공자"
-    provider_settings_warning:
+    provider_settings_warning: TODO_TRANSLATE
     qty: "수량"
-    quantity:
-    quantity_returned:
-    quantity_shipped:
-    quick_search:
-    rate:
+    quantity: TODO_TRANSLATE
+    quantity_returned: TODO_TRANSLATE
+    quantity_shipped: TODO_TRANSLATE
+    quick_search: TODO_TRANSLATE
+    rate: TODO_TRANSLATE
     reason: "이유"
-    receive:
-    receive_stock:
-    received:
-    reception_status:
-    reference:
-    refund:
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
-    register:
+    receive: TODO_TRANSLATE
+    receive_stock: TODO_TRANSLATE
+    received: TODO_TRANSLATE
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
+    refund: TODO_TRANSLATE
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
+    register: TODO_TRANSLATE
     registration: "등록"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: "이메일 저장"
     remove: "삭제"
-    rename:
-    report:
+    rename: TODO_TRANSLATE
+    report: TODO_TRANSLATE
     reports: "리포트"
+    resellable: TODO_TRANSLATE
     resend: "재발송"
     reset_password: "비밀번호 재설정"
     response_code: "응답 코드"
-    resume:
-    resumed:
-    return:
-    return_authorization:
-    return_authorization_reasons:
-    return_authorization_updated:
-    return_authorizations:
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
-    returned:
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
-    rma_number: "RMA 번호"
-    rma_value: "RMA 값"
-    roles:
+    resume: TODO_TRANSLATE
+    resumed: TODO_TRANSLATE
+    return: TODO_TRANSLATE
+    return_authorization: TODO_TRANSLATE
+    return_authorization_reasons: TODO_TRANSLATE
+    return_authorization_updated: TODO_TRANSLATE
+    return_authorizations: TODO_TRANSLATE
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
+    return_quantity: TODO_TRANSLATE
+    returned: TODO_TRANSLATE
+    returns: TODO_TRANSLATE
+    review: TODO_TRANSLATE
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
+    rma_credit: TODO_TRANSLATE
+    rma_number: RMA 번호
+    rma_value: RMA 값
+    role_id: TODO_TRANSLATE
+    roles: TODO_TRANSLATE
     rules: "규칙"
-    safe:
-    sales_total:
-    sales_total_description:
-    sales_totals:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
+    sales_total: TODO_TRANSLATE
+    sales_total_description: TODO_TRANSLATE
+    sales_totals: TODO_TRANSLATE
     save_and_continue: "저장하고 계속"
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: false
     say_yes: true
     scope: "범위"
     search: "검색"
     search_results: "%{keywords}의 검색 결과"
     searching: "검색중"
-    secure_connection_type:
-    security_settings:
+    secure_connection_type: TODO_TRANSLATE
+    security_settings: TODO_TRANSLATE
     select: "선택"
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: "견본에서 선택"
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: "모든 메일 사본을 다음 주소로 보냄"
-    send_mails_as:
+    send_mails_as: TODO_TRANSLATE
     server: "서버"
-    server_error:
+    server_error: TODO_TRANSLATE
     settings: "설정"
-    ship:
+    ship: TODO_TRANSLATE
     ship_address: "배송 주소"
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: "배송"
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        shipment_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        track_information: TODO_TRANSLATE
+        track_link: TODO_TRANSLATE
     shipment_state: "배송 상태"
     shipment_states:
-      backorder:
-      canceled:
-      partial:
+      backorder: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      partial: TODO_TRANSLATE
       pending: "보류"
       ready: "대기"
-      shipped:
-    shipment_transfer_error:
-    shipment_transfer_success:
+      shipped: TODO_TRANSLATE
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: "배송"
     shipped: "배송됨"
     shipping: "배송료"
     shipping_address: "배송 주소"
     shipping_categories: "배송 분류"
     shipping_category: "배송 분류"
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
-    shipping_instructions:
-    shipping_method:
-    shipping_methods:
-    shipping_price_sack:
-    shipping_total:
-    shop_by_taxonomy:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
+    shipping_instructions: TODO_TRANSLATE
+    shipping_method: TODO_TRANSLATE
+    shipping_methods: TODO_TRANSLATE
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
+    shop_by_taxonomy: TODO_TRANSLATE
     shopping_cart: "장바구니"
     show: "보기"
-    show_active:
+    show_active: TODO_TRANSLATE
     show_deleted: "삭제 된 상품까지 보기"
     show_only_complete_orders: "완료 된 주문만 보기"
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku:
-    skus:
-    slug:
-    source:
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
+    sku: TODO_TRANSLATE
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
+    special_instructions: TODO_TRANSLATE
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
+    spree_gateway_error_flash_for_checkout: TODO_TRANSLATE
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: "시작"
-    state:
-    state_based:
+    start_date: TODO_TRANSLATE
+    state: TODO_TRANSLATE
+    state_based: TODO_TRANSLATE
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states:
-    states_required:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
+    states: TODO_TRANSLATE
+    states_required: TODO_TRANSLATE
     status: "상태"
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
     stop: "끝"
     store: "상점"
     street_address: Street 주소
     street_address_2: Street 주소 (cont'd)
-    subtotal:
-    subtract:
-    success:
-    successfully_created:
-    successfully_refunded:
-    successfully_removed:
-    successfully_signed_up_for_analytics:
-    successfully_updated:
-    summary:
+    subtotal: TODO_TRANSLATE
+    subtract: TODO_TRANSLATE
+    success: TODO_TRANSLATE
+    successfully_created: TODO_TRANSLATE
+    successfully_refunded: TODO_TRANSLATE
+    successfully_removed: TODO_TRANSLATE
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
+    successfully_updated: TODO_TRANSLATE
+    summary: TODO_TRANSLATE
     tax: "세금"
     tax_categories: "세금 분류"
     tax_category: "세금 분류"
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: "세율"
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: "분류군"
     taxon_edit: "분류군 편집"
-    taxon_placeholder:
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: "분류계"
     taxonomy: "분류군"
-    taxonomy_edit:
-    taxonomy_tree_error:
-    taxonomy_tree_instruction:
+    taxonomy_edit: TODO_TRANSLATE
+    taxonomy_tree_error: TODO_TRANSLATE
+    taxonomy_tree_instruction: TODO_TRANSLATE
     taxons: "종류"
     test: "테스트"
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
-        greeting:
-        message:
-        subject:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
     test_mode: "테스트 모드"
-    thank_you_for_your_order:
-    there_are_no_items_for_this_order:
+    thank_you_for_your_order: TODO_TRANSLATE
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: "다음 값들에 문제가 있습니다"
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: "미리보기"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: "품종을 추가하려면 먼저 정의해야 합니다"
     total: "합계"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
-    tracking:
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
-    tree:
-    type:
-    type_to_search:
-    unable_to_connect_to_gateway:
-    unable_to_create_reimbursements:
-    under_price:
-    unlock:
-    unrecognized_card_type:
-    unshippable_items:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
+    tracking: TODO_TRANSLATE
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
+    tree: TODO_TRANSLATE
+    type: TODO_TRANSLATE
+    type_to_search: TODO_TRANSLATE
+    unable_to_connect_to_gateway: TODO_TRANSLATE
+    unable_to_create_reimbursements: TODO_TRANSLATE
+    under_price: TODO_TRANSLATE
+    unlock: TODO_TRANSLATE
+    unrecognized_card_type: TODO_TRANSLATE
+    unshippable_items: TODO_TRANSLATE
     update: "수정"
-    updating:
-    usage_limit:
-    use_app_default:
+    updating: TODO_TRANSLATE
+    usage_limit: TODO_TRANSLATE
+    use_app_default: TODO_TRANSLATE
     use_billing_address: "배송받으실 분이 주문자와 동일합니다."
-    use_new_cc:
-    use_s3:
+    use_existing_cc: TODO_TRANSLATE
+    use_new_cc: TODO_TRANSLATE
+    use_new_cc_or_payment_method: TODO_TRANSLATE
+    use_s3: TODO_TRANSLATE
     user: "사용자"
     user_rule:
-      choose_users:
+      choose_users: TODO_TRANSLATE
     users: "사용자"
     validation:
-      cannot_be_less_than_shipped_units:
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
-      is_too_large:
-      must_be_int:
-      must_be_non_negative:
-      unpaid_amount_not_zero:
+      cannot_be_less_than_shipped_units: TODO_TRANSLATE
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
+      is_too_large: TODO_TRANSLATE
+      must_be_int: TODO_TRANSLATE
+      must_be_non_negative: TODO_TRANSLATE
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: "값"
-    variant:
-    variant_placeholder:
+    variant: TODO_TRANSLATE
+    variant_placeholder: TODO_TRANSLATE
     variants: "품종"
     version: "버전"
-    void:
+    void: TODO_TRANSLATE
     weight: "무게"
     what_is_a_cvv: "신용카드 코드(CVV)란?"
-    what_is_this:
+    what_is_this: TODO_TRANSLATE
     width: "가로"
     year: "년"
-    you_have_no_orders_yet:
+    you_have_no_orders_yet: TODO_TRANSLATE
     your_cart_is_empty: "장바구니가 비었습니다"
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: "우편번호"
     zipcode: "우편번호"
     zone: "지역"
     zones: "지역"
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,4 +1,6 @@
+---
 lv:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ lv:
         state: Rajons
         zipcode: Pasta indekss
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,12 +26,12 @@ lv:
         name: Nosaukums
         numcode: ISO kods
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tips
         month: Mēnesis
-        name:
+        name: TODO_TRANSLATE
         number: Numurs
-        verification_value:
+        verification_value: TODO_TRANSLATE
         year: Gads
       spree/inventory_unit:
         state: Apgabals
@@ -40,43 +42,44 @@ lv:
         name: Nosaukums
         presentation: Presentation
       spree/order:
-        checkout_complete:
-        completed_at:
-        considered_risky:
+        checkout_complete: TODO_TRANSLATE
+        completed_at: TODO_TRANSLATE
+        considered_risky: TODO_TRANSLATE
         coupon_code: Kupona Kods
-        created_at:
-        email:
-        ip_address:
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        created_at: TODO_TRANSLATE
+        email: TODO_TRANSLATE
+        ip_address: TODO_TRANSLATE
+        item_total: TODO_TRANSLATE
+        number: TODO_TRANSLATE
+        payment_state: TODO_TRANSLATE
+        shipment_state: TODO_TRANSLATE
+        special_instructions: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/payment:
-        amount:
+        amount: TODO_TRANSLATE
+        number: TODO_TRANSLATE
       spree/payment_method:
-        name:
+        name: TODO_TRANSLATE
       spree/product:
         available_on: Pieejams pēc
-        cost_currency:
+        cost_currency: TODO_TRANSLATE
         cost_price: Pašizmaksa
         description: Apraksts
         master_price: Gala cena/Master Price
@@ -85,17 +88,18 @@ lv:
         shipping_category: Piegādes kategorija
         tax_category: Nodokļu kategorija
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: TODO_TRANSLATE
+        code: TODO_TRANSLATE
+        description: TODO_TRANSLATE
+        event_name: TODO_TRANSLATE
+        expires_at: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        path: TODO_TRANSLATE
+        starts_at: TODO_TRANSLATE
+        usage_limit: TODO_TRANSLATE
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Nosaukums
         presentation: Prezentācija
@@ -105,24 +109,26 @@ lv:
         amount: Summa
       spree/role:
         name: Nosaukums
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Saīsinājums
         name: Nosaukums
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Apraksts
         name: Nosaukums
@@ -141,7 +147,7 @@ lv:
         password: Parole
         password_confirmation: Password Confirmation
       spree/variant:
-        cost_currency:
+        cost_currency: TODO_TRANSLATE
         cost_price: Pašizmaksa
         depth: Biezums
         height: Augstums
@@ -157,48 +163,54 @@ lv:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adrese
         other: Adreses
@@ -208,41 +220,43 @@ lv:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Krājuma vienība
         other: Krājuma vienības
       spree/line_item:
         one: Pozīcijas vienība
         other: Pozīcijas vienības
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Pasūtījums
         other: Pasūtījumi
       spree/payment:
         one: Maksājums
         other: Maksājumi
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Produkts
         other: Produkti
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Property
         other: Properties
       spree/prototype:
         one: Prototips
         other: Prototipi
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Atgriešanas autorizācija
         other: Atgriešanas autorizācijas
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Loma
         other: Lomas
       spree/shipment:
@@ -251,14 +265,14 @@ lv:
       spree/shipping_category:
         one: Piegādes kategorija
         other: Piegādes kategorijas
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: "Štats"
         other: "Štati"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Nodokļu kategorija
         other: Nodokļu kategorijas
@@ -266,348 +280,437 @@ lv:
         one: Nodokļu likme
         other: Nodokļu likmes
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
-      spree/tracker:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Lietotājs
         other: Lietotāji
       spree/variant:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/zone:
         one: Zona
         other: Zonas
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
-      inactive:
-      invalid:
-      invalid_token:
-      locked:
-      timeout:
-      unauthenticated:
-      unconfirmed:
+      inactive: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      invalid_token: TODO_TRANSLATE
+      locked: TODO_TRANSLATE
+      timeout: TODO_TRANSLATE
+      unauthenticated: TODO_TRANSLATE
+      unconfirmed: TODO_TRANSLATE
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Saīsinājums
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Konts
     account_updated: Konts izmainīts!
     action: Darbība
     actions:
       cancel: Atcelt
-      continue:
+      continue: TODO_TRANSLATE
       create: Izveidot
       destroy: Dzēst
-      edit:
+      edit: TODO_TRANSLATE
       list: Saraksts
       listing: Saraksts
       new: Jauns
-      refund:
-      save:
+      refund: TODO_TRANSLATE
+      save: TODO_TRANSLATE
       update: Atjauninājums
     activate: Activate
     active: Aktīvs
     add: Pievienot
     add_action_of_type: Add action of type
     add_country: Pievienot valsti
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: TODO_TRANSLATE
     add_option_value: Pievienot opcijas vērtību
     add_product: Pievienot produktu
     add_product_properties: Pievienot produkta īpašības
     add_rule_of_type: Add rule of type
     add_state: Pievienot rajonu
-    add_stock:
-    add_stock_management:
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: Pievienot grozam
-    add_variant:
+    add_variant: TODO_TRANSLATE
     additional_item: Papildus vienības maksa
-    address1:
-    address2:
-    adjustable:
+    address: TODO_TRANSLATE
+    address1: TODO_TRANSLATE
+    address2: TODO_TRANSLATE
+    adjustable: TODO_TRANSLATE
     adjustment: Piemērošana
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: Adjustment Total
     adjustments: Piemērošanas
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administrēšana
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
     all: Visi
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
     all_departments: Visas nodaļas
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    all_items_have_been_returned: TODO_TRANSLATE
+    allow_ssl_in_development_and_test: TODO_TRANSLATE
+    allow_ssl_in_production: TODO_TRANSLATE
+    allow_ssl_in_staging: TODO_TRANSLATE
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: Cits teksts
     alternative_phone: Cits telefons
     amount: Summa
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
-    analytics_trackers:
-    and:
-    approve:
-    approved_at:
-    approver:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
+    analytics_trackers: TODO_TRANSLATE
+    and: TODO_TRANSLATE
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Vai esiet pārliecināts?
     are_you_sure_delete: Vai esiet pārliecināts, ka vēlaties dzēst šo ierakstu?
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Autorizācija neizdevās
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Pieejams no
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Atpakaļ
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_end: TODO_TRANSLATE
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Atgriezties veikalā
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Atlikums
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Rēķina adrese
     billing: Rēķins
     billing_address: Rēķina adrese
     both: Abi
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Kalkulātors
     calculator_settings_warning: Ja tu maini kalkulatora tipu, vispirms saglabā esošos datus, pirms maini kalkulatora iestatījumus
     cancel: Atcelt
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
+    cannot_create_payment_without_payment_methods: TODO_TRANSLATE
     cannot_create_returns: Nevar izveidot atgriešanu, jo šis pasūtījums vēl nav izsūtīts.
-    cannot_perform_operation:
-    cannot_set_shipping_method_without_address:
+    cannot_perform_operation: TODO_TRANSLATE
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: Capture
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kartes kods
     card_number: Kartes numurs
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Kartes tips ir
     cart: Grozs
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategorijas
     category: Kategorija
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Pasūtīt
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: TODO_TRANSLATE
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: TODO_TRANSLATE
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
     city: Pilsēta
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Klonēt
-    close:
-    close_all_adjustments:
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
     code: Kods
-    company:
+    company: TODO_TRANSLATE
     complete: Pabeigts
     configuration: Konfigurācija
     configurations: Konfigurācijas
+    configure_s3: TODO_TRANSLATE
     confirm: Apstiprini
     confirm_delete: Apstiprināt izdzēšanu
     confirm_password: Paroles apstiprinājums
     continue: Turpināt
     continue_shopping: Turpināt iepirkšanos
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: Pašizmaksa
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
+    countries: TODO_TRANSLATE
     country: Valsts
     country_based: Valsts
-    country_name:
+    country_name: TODO_TRANSLATE
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Kupons
     coupon_code: Kupona kods
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
+    coupon_code_already_applied: TODO_TRANSLATE
+    coupon_code_applied: TODO_TRANSLATE
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
     coupon_code_not_found: Ievadītais kupona kods neeksistē. Lūdzu, mēģiniet vēlreiz.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Izveidot
     create_a_new_account: Izveidot jaunu kontu
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
     credit: Kredīts
     credit_card: Kredītkarte
-    credit_cards:
+    credit_cards: TODO_TRANSLATE
     credit_owed: Kredīta parāds
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
+    credits: TODO_TRANSLATE
+    currency: TODO_TRANSLATE
+    currency_decimal_mark: TODO_TRANSLATE
+    currency_settings: TODO_TRANSLATE
     currency_symbol_position: Put currency symbol before or after dollar amount?
-    currency_thousands_separator:
+    currency_thousands_separator: TODO_TRANSLATE
     current: Tagadējais
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Klients
     customer_details: Klienta detaļas
-    customer_details_updated:
-    customer_return:
-    customer_returns:
+    customer_details_updated: TODO_TRANSLATE
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Klienta meklēšana
-    cut:
-    cvv_response:
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
+    date_completed: TODO_TRANSLATE
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: Datuma diapazons
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default: TODO_TRANSLATE
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
     delete: Izdzēst
-    deleted_variants_present:
-    delivery:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
+    delivery: TODO_TRANSLATE
     depth: Dziļums
     description: Apraksts
-    destination:
+    destination: TODO_TRANSLATE
     destroy: Izdzēst
-    details:
-    discount_amount:
-    dismiss_banner:
+    details: TODO_TRANSLATE
+    discount_amount: TODO_TRANSLATE
+    dismiss_banner: TODO_TRANSLATE
     display: Rādīt
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: TODO_TRANSLATE
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Rediģēt
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Rediģēt lietotāju
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: E-pasts
-    empty:
+    empty: TODO_TRANSLATE
     empty_cart: Iztukšot grozu
     enable_mail_delivery: Atļaut pasta sūtīšanu
-    end:
-    ending_in:
+    end: TODO_TRANSLATE
+    ending_in: TODO_TRANSLATE
     environment: Vide
     error: Kļūda
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
+        could_not_create_taxon: TODO_TRANSLATE
+        no_payment_methods_available: TODO_TRANSLATE
+        no_shipping_methods_available: TODO_TRANSLATE
     errors_prohibited_this_record_from_being_saved:
       one: Dēļ 1 kļūdas ieraksts netika saglabāts
       other: Dēļ %{count} kļūdām ieraksts netika saglabāts
@@ -615,40 +718,42 @@ lv:
     events:
       spree:
         cart:
-          add:
+          add: TODO_TRANSLATE
         checkout:
-          coupon_code_added:
+          coupon_code_added: TODO_TRANSLATE
         content:
-          visited:
+          visited: TODO_TRANSLATE
         order:
-          contents_changed:
-        page_view:
+          contents_changed: TODO_TRANSLATE
+        page_view: TODO_TRANSLATE
         user:
-          signup:
+          signup: TODO_TRANSLATE
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Izbeigšanās
     extension: Paplašinājums
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Faila nosaukums
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
+    filter_results: TODO_TRANSLATE
     finalize: Pabeigt
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Pirmās vienības maksājums
     first_name: Vārds
     first_name_begins_with: Vārds sākas ar
     flat_percent: Pamatprocents
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Pamatlikme (par pasūtījumu)
     flexible_rate: Elastīga likme
     forgot_password: Parole aizmirsta
-    free_shipping:
-    free_shipping_amount:
+    free_shipping: TODO_TRANSLATE
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -661,117 +766,130 @@ lv:
     guest_user_account: Izrakstīties kā ciemiņam
     has_no_shipped_units: Nav nosūtītu vienību
     height: Augstums
-    hide_cents:
+    hide_cents: TODO_TRANSLATE
     home: Mājas
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: Latvijas (LV)
-      translations:
+      translations: TODO_TRANSLATE
     icon: Icon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Attēls
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Attēli
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
+    included_in_price: TODO_TRANSLATE
+    included_price_validation: TODO_TRANSLATE
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Aizpildiet formu zemāk un uz e-pastu tiks nosūtīta instrukcija kā atjaunot paroli:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
-    intercept_email_address:
-    intercept_email_instructions:
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    insufficient_stock_lines_present: TODO_TRANSLATE
+    intercept_email_address: TODO_TRANSLATE
+    intercept_email_instructions: TODO_TRANSLATE
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: Inventūra
     inventory_adjustment: Inventūras korekcija
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: nav pieejams sūtīšanas adresei
-    iso_name:
+    iso_name: TODO_TRANSLATE
     item: Vienība
     item_description: Vienības apraksts
     item_total: Kopējā vienība
     item_total_rule:
       operators:
-        gt:
-        gte:
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        gt: TODO_TRANSLATE
+        gte: TODO_TRANSLATE
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
-      path:
+      path: TODO_TRANSLATE
     last_name: Uzvārds
     last_name_begins_with: Uzvārds sākas ar
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Saraksts
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Lādējās
     locale_changed: Valoda nomainīta
-    location:
-    lock:
-    log_entries:
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
     logged_in_as: Pieslēgties kā
     logged_in_succesfully: Pieslēgšanās veiksmīga
     logged_out: Jūs esat atslēgts no sistēmas.
-    login:
+    login: TODO_TRANSLATE
     login_as_existing: Pieslēgties kā esošais klients
     login_failed: Pieslēgšanās sistēmai neizdevās.
     login_name: Pieslēgties
     logout: Atslēgties
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Meklēt līdzīgas preces
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
-    master_price:
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
+    make_refund: TODO_TRANSLATE
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
+    master_price: TODO_TRANSLATE
     match_choices:
-      all:
-      none:
-    max_items:
-    member_since:
-    memo:
+      all: TODO_TRANSLATE
+      none: TODO_TRANSLATE
+    max_items: TODO_TRANSLATE
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta apraksts
     meta_keywords: Meta atslēgas vārdi
-    meta_title:
-    metadata:
-    minimal_amount:
+    meta_title: TODO_TRANSLATE
+    metadata: TODO_TRANSLATE
+    minimal_amount: TODO_TRANSLATE
     month: Mēnesis
-    more:
-    move_stock_between_locations:
+    more: TODO_TRANSLATE
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: Mans konts
     my_orders: Mani pasūtījumi
     name: Nosaukums
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Vārds vai SKU
     new: Jauns
     new_adjustment: Jauns pielāgojums
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Jauns klients
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Jauns attēls
     new_option_type: Jauns opciju tips
     new_order: Jauns pasūtījums
@@ -779,21 +897,22 @@ lv:
     new_payment: Jauns maksājums
     new_payment_method: Jauna maksājuma metode
     new_product: Jauns produkts
-    new_promotion:
-    new_promotion_category:
-    new_property:
+    new_promotion: TODO_TRANSLATE
+    new_promotion_category: TODO_TRANSLATE
+    new_property: TODO_TRANSLATE
     new_prototype: Jauns prototips
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: New Return Authorization
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Jauna sūtījuma kategorija
     new_shipping_method: Jauna sūtījuma metode
     new_state: Jauns rajons
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: Jauna nodokļu kategorija
     new_tax_rate: Jauna nodokļu likme
     new_taxon: New Taxon
@@ -803,25 +922,31 @@ lv:
     new_variant: Jauns variants
     new_zone: Jauna zona
     next: Nākamais
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Neviens produkts netika atrasts
-    no_resource_found:
-    no_results:
-    no_returns_found:
-    no_rules_added:
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
+    no_results: TODO_TRANSLATE
+    no_returns_found: TODO_TRANSLATE
+    no_rules_added: TODO_TRANSLATE
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: Nekas
-    none_selected:
-    normal_amount:
-    not:
+    none_selected: TODO_TRANSLATE
+    normal_amount: TODO_TRANSLATE
+    not: TODO_TRANSLATE
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Produkts ir klonēts
       product_deleted: Produkts ir izdzēsts
@@ -829,115 +954,123 @@ lv:
       product_not_deleted: Produktu neizdevās izdzēst
       variant_deleted: Variants ir izdzēsts
       variant_not_deleted: Variants nav izdzēsts
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Ir uz vietas
-    open:
-    open_all_adjustments:
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Opciju tips
     option_value: Option Value
     option_values: Opciju vērtība
-    optional:
+    optional: TODO_TRANSLATE
     options: Iespējas
     or: vai
     or_over_price: "%{price} or over"
     order: Pasūtījums
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Pasūtījuma detaļas
     order_email_resent: Pasūtījuma e-pasts vēlreiz pārsūtīts
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Jūsu pasūtījums ir apstrādāts veiksmīgi
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
-      address:
-      awaiting_return:
-      canceled:
-      cart:
-      complete:
-      confirm:
-      considered_risky:
-      delivery:
-      payment:
-      resumed:
-      returned:
+      address: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      considered_risky: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
     order_summary: Pasūtījuma apkopojums
     order_sure_want_to: Vai esiet pārliecināts, ka vēlaties %{event} šo pasūtījumu?
     order_total: Kopējais pasūtījums
     order_updated: Pasūtījums atjaunots
     orders: Pasūtījumi
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Izpārdots
     overview: Pārskats
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
-      next_page:
-      previous_page:
+      first: TODO_TRANSLATE
+      next_page: TODO_TRANSLATE
+      previous: TODO_TRANSLATE
+      previous_page: TODO_TRANSLATE
       truncate: "…"
     password: Parole
     paste: Paste
     path: Ceļš
     pay: maksā
     payment: Maksājums
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Maksājumu informācija
     payment_method: Maksājuma metode
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Maksājuma metodes
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
+    payment_processing_failed: TODO_TRANSLATE
+    payment_processor_choose_banner_text: TODO_TRANSLATE
+    payment_processor_choose_link: TODO_TRANSLATE
     payment_state: Maksājuma statuss
     payment_states:
-      balance_due:
-      checkout:
-      completed:
-      credit_owed:
-      failed:
-      paid:
-      pending:
-      processing:
-      void:
+      balance_due: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      credit_owed: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      paid: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     payment_updated: Maksājums atjaunots
     payments: Maksājumi
-    pending:
-    percent:
-    percent_per_item:
-    permalink:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
+    percent_per_item: TODO_TRANSLATE
+    permalink: TODO_TRANSLATE
     phone: Telefons
     place_order: Veikt pasūtījumu
-    please_define_payment_methods:
-    populate_get_error:
-    powered_by:
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    please_define_payment_methods: TODO_TRANSLATE
+    please_enter_reasonable_quantity: TODO_TRANSLATE
+    populate_get_error: TODO_TRANSLATE
+    powered_by: TODO_TRANSLATE
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Prezentācija
     previous: Iepriekšējais
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Cena
     price_range: Price Range
     price_sack: Price Sack
@@ -945,71 +1078,76 @@ lv:
     product: Produkts
     product_details: Produkta detaļas
     product_has_no_description: "Šim produktam nav nosaukuma"
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Produkta īpašības
     product_rule:
-      choose_products:
-      label:
-      match_all:
-      match_any:
-      match_none:
+      choose_products: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
+      match_none: TODO_TRANSLATE
       product_source:
-        group:
-        manual:
+        group: TODO_TRANSLATE
+        manual: TODO_TRANSLATE
     products: Produkti
-    promotion:
-    promotion_action:
+    promotion: TODO_TRANSLATE
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: TODO_TRANSLATE
+        any: TODO_TRANSLATE
+    promotion_label: TODO_TRANSLATE
+    promotion_rule: TODO_TRANSLATE
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       item_total:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       landing_page:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Akcijas
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Parametri
     property: Parametrs
     prototype: Prototips
@@ -1017,87 +1155,96 @@ lv:
     provider: Piegādātājs
     provider_settings_warning: Ja tu maini piegādātāja tipu, tev vajag vispirms saglabāt pirms veikt izmaiņas piegādātāja uzstādījumiem
     qty: Daudzums
-    quantity:
+    quantity: TODO_TRANSLATE
     quantity_returned: Quantity Returned
     quantity_shipped: Daudzums nosūtīts
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Tarifs
     reason: Iemesls
     receive: saņemt
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: Saņemts
-    reception_status:
-    reference:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
     refund: Atmaksāt
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Reģistrēties kā jauns lietotājs
     registration: Reģistrācija
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Atcerēties mani
-    remove:
-    rename:
-    report:
+    remove: TODO_TRANSLATE
+    rename: TODO_TRANSLATE
+    report: TODO_TRANSLATE
     reports: Atskaites
+    resellable: TODO_TRANSLATE
     resend: Pārsūtīt
     reset_password: Nomainīt manu paroli
     response_code: Reakcijas kods
     resume: atsākt
     resumed: Atsākts
     return: atgriezties
-    return_authorization:
-    return_authorization_reasons:
-    return_authorization_updated:
-    return_authorizations:
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
+    return_authorization: TODO_TRANSLATE
+    return_authorization_reasons: TODO_TRANSLATE
+    return_authorization_updated: TODO_TRANSLATE
+    return_authorizations: TODO_TRANSLATE
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
+    return_quantity: TODO_TRANSLATE
     returned: Atgriezts
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
+    returns: TODO_TRANSLATE
+    review: TODO_TRANSLATE
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: RMA numurs
     rma_value: RMA vērtība
-    roles:
-    rules:
-    safe:
+    role_id: TODO_TRANSLATE
+    roles: TODO_TRANSLATE
+    rules: TODO_TRANSLATE
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Kopējā realizācija
     sales_total_description: Sales Total For All Orders
-    sales_totals:
+    sales_totals: TODO_TRANSLATE
     save_and_continue: Saglabāt un turpināt
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: TODO_TRANSLATE
+    say_no: TODO_TRANSLATE
+    say_yes: TODO_TRANSLATE
     scope: Scope
     search: Meklēšana
     search_results: Meklēšanas rezultāti '%{keywords}'
@@ -1105,10 +1252,11 @@ lv:
     secure_connection_type: Secure Connection Type
     security_settings: Security Settings
     select: Izvēlēties
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Izvēlēties no prototipiem
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Sūtīt visu vēstuļu kopijas uz
     send_mails_as: Sūtīt vēstules kā
     server: Servers
@@ -1116,218 +1264,250 @@ lv:
     settings: Uzstādījumi
     ship: sūtīt
     ship_address: Nosūtīšanas adrese
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: Sūtījums
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        shipment_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        track_information: TODO_TRANSLATE
+        track_link: TODO_TRANSLATE
     shipment_state: Piegādes statuss
     shipment_states:
-      backorder:
-      canceled:
-      partial:
-      pending:
-      ready:
-      shipped:
-    shipment_transfer_error:
-    shipment_transfer_success:
+      backorder: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      partial: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Sūtījumi
     shipped: Nosūtīts
     shipping: Sūtās
     shipping_address: Nosūtīšanas adrese
     shipping_categories: Sūtīšanas kategorijas
     shipping_category: Sūtīšanas kategorija
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: Sūtīšanas instrukcijas
     shipping_method: Sūtīšanas metode
     shipping_methods: Sūtīšanas metodes
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Pirkt pēc %{taxonomy}
     shopping_cart: Iepirkuma grozs
     show: Parādīt
     show_active: Parādīt aktīvos
     show_deleted: Parādīt izdzēstos
     show_only_complete_orders: Parādīt tikai pabeigtos pasūtījumus
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku:
-    skus:
-    slug:
-    source:
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
+    sku: TODO_TRANSLATE
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
+    special_instructions: TODO_TRANSLATE
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
+    spree_gateway_error_flash_for_checkout: TODO_TRANSLATE
     ssl:
-      change_protocol:
-    start:
+      change_protocol: TODO_TRANSLATE
+    start: TODO_TRANSLATE
+    start_date: TODO_TRANSLATE
     state: Stāvoklis
-    state_based:
+    state_based: TODO_TRANSLATE
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
-    states:
-    states_required:
-    status:
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
-    stop:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
+    states: TODO_TRANSLATE
+    states_required: TODO_TRANSLATE
+    status: TODO_TRANSLATE
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
+    stop: TODO_TRANSLATE
     store: Saglabāt
     street_address: Ielas adrese
     street_address_2: Ielas adrese (turpinājums)
     subtotal: Starpsumma
     subtract: Atskaitīt
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} tika veiksmīgi izveidots(-a)!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} tika veiksmīgi izdzēsts(-a)!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource} tika veiksmīgi saglabāts(-a)!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Nodokļi
     tax_categories: Nodokļu kategorijas
     tax_category: Nodokļu kategorija
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Nodokļu likmes
-    taxon:
-    taxon_edit:
-    taxon_placeholder:
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
+    taxon: TODO_TRANSLATE
+    taxon_edit: TODO_TRANSLATE
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Klasifikatori
-    taxonomy:
+    taxonomy: TODO_TRANSLATE
     taxonomy_edit: Labot klasifikatoru
     taxonomy_tree_error: Prasītās izmaiņas nav pieņemtas un koks ir atgriezts iepriekšējā stāvoklī, lūdzu, mēģiniet vēlreiz.
     taxonomy_tree_instruction: "* Ar labo peli uzklikšķiniet kokā, lai piekļūtu izvēlei: pievienošanai, izdzēšanai vai sortēšanai."
-    taxons:
-    test:
+    taxons: TODO_TRANSLATE
+    test: TODO_TRANSLATE
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
-        greeting:
-        message:
-        subject:
-    test_mode:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+    test_mode: TODO_TRANSLATE
     thank_you_for_your_order: Paldies par sadarbību. Lūdzu, izdrukājiet šo apstiprinājumu savai zināšanai.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: Problēmas ar sekojošiem laukiem
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: Lai pievienotu variantu, vispirms definējiet
     total: Kopā
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Koks
     type: Tips
     type_to_search: Type to search
     unable_to_connect_to_gateway: Nav spējīgs pievienoties gateway.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
-    unlock:
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: Neatpazīstams kartes tips
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: Atjaunot
     updating: Atjaunojas
     usage_limit: Lietotāja limits
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Lietot rēķina adresi
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Izmntot jaunu karti
-    use_s3:
+    use_new_cc_or_payment_method: TODO_TRANSLATE
+    use_s3: TODO_TRANSLATE
     user: Lietotājs
     user_rule:
-      choose_users:
+      choose_users: TODO_TRANSLATE
     users: Lietotāji
     validation:
       cannot_be_less_than_shipped_units: nevar būt mazāks par izsūtītām vienībām.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: ir par lielu - pieejamais daudzums nevar nodrošināt prasīto daudzumu!
       must_be_int: must be an integer
       must_be_non_negative: ir jābūt pozitīvai vērtībai
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Vērtība
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Varianti
     version: Versija
     void: Void
-    weight:
+    weight: TODO_TRANSLATE
     what_is_a_cvv: Kas ir (CVV) kredītkartes kods?
     what_is_this: Kas tas ir?
     width: Platums
     year: Gads
-    you_have_no_orders_yet:
+    you_have_no_orders_yet: TODO_TRANSLATE
     your_cart_is_empty: Jūsu iepirkuma grozs ir tukšs
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: Pasta indekss
-    zipcode:
+    zipcode: TODO_TRANSLATE
     zone: Zona
     zones: Zonas
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -1,4 +1,6 @@
+---
 nb:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ nb:
         state: Fylke
         zipcode: Postnummer
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -27,9 +29,9 @@ nb:
         base: Base
         cc_type: Type
         month: Måned
-        name:
+        name: TODO_TRANSLATE
         number: Nummer
-        verification_value:
+        verification_value: TODO_TRANSLATE
         year: "År"
       spree/inventory_unit:
         state: status
@@ -72,6 +74,7 @@ nb:
         zipcode: Postnummer
       spree/payment:
         amount: Beløp
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Navn
       spree/product:
@@ -95,7 +98,8 @@ nb:
         starts_at: Starter ved
         usage_limit: Bruksgrense
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Navn
         presentation: Presentasjon
@@ -105,24 +109,26 @@ nb:
         amount: Mengde
       spree/role:
         name: Navn
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Forkortelse
         name: Navn
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Beskrivelse
         name: Navn
@@ -139,9 +145,9 @@ nb:
       spree/user:
         email: Epost
         password: Passord
-        password_confirmation:
+        password_confirmation: TODO_TRANSLATE
       spree/variant:
-        cost_currency:
+        cost_currency: TODO_TRANSLATE
         cost_price: Kostpris
         depth: Dybde
         height: Høyde
@@ -157,48 +163,54 @@ nb:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: Utløpsdato
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adresse
         other: Adresser
@@ -208,41 +220,43 @@ nb:
       spree/credit_card:
         one: Kredittkort
         other: Kredittkort
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Lagerenhet
         other: Lagerenheter
       spree/line_item:
         one: Varelinje
         other: Varelinjer
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Ordre
         other: Ordrer
       spree/payment:
         one: Betaling
         other: Betalinger
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Produkt
         other: Produkter
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Egenskap
         other: Egenskaper
       spree/prototype:
         one: Prototype
         other: Prototyper
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Returautorisasjon
         other: Returautorisasjoner
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Rolle
         other: Roller
       spree/shipment:
@@ -251,13 +265,13 @@ nb:
       spree/shipping_category:
         one: Forsendelseskategori
         other: Forsendelseskategorier
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Status
         other: Statuser
-      spree/state_change:
+      spree/state_change: TODO_TRANSLATE
       spree/stock_location: Lagerlokasjon
-      spree/stock_movement:
+      spree/stock_movement: TODO_TRANSLATE
       spree/stock_transfer: Beholdningsendring
       spree/tax_category:
         one: Avgiftskategori
@@ -271,7 +285,7 @@ nb:
       spree/taxonomy:
         one: Gruppering
         other: Grupperinger
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Bruker
         other: Brukere
@@ -281,10 +295,13 @@ nb:
       spree/zone:
         one: Sone
         other: Soner
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
       inactive: Inaktiv
       invalid: Ugyldig
@@ -301,8 +318,8 @@ nb:
       unlock_instructions:
         subject: Opplåsningsinstruksjoner
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
       send_instructions: Send opplåsningsinstruksjoner
       unlocked: Ulåst
@@ -313,24 +330,45 @@ nb:
         updated: Oppdaterd
     user_registrations:
       destroyed: slettet
-      inactive_signed_up:
+      inactive_signed_up: TODO_TRANSLATE
       signed_up: registreringsdato
       updated: oppdatert
     user_sessions:
       signed_in: Logget inn
       signed_out: Logget ut
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: Allerede bekreftet
       not_found: Ikke funnet
       not_locked: Ikke låst
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Fortkortelse
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Konto
     account_updated: Konto oppdatert!
     action: Hendelse
@@ -343,7 +381,7 @@ nb:
       list: List opp
       listing: Viser
       new: Ny
-      refund:
+      refund: TODO_TRANSLATE
       save: Lagre
       update: Oppdater
     activate: Aktiver
@@ -351,7 +389,7 @@ nb:
     add: Legg til
     add_action_of_type: Legg til hendelsestype
     add_country: Legg til land
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Legg til nytt hode
     add_new_style: Legg til ny stil
     add_one: Legg til en
@@ -365,11 +403,16 @@ nb:
     add_to_cart: Legg i handlekurv
     add_variant: Legg til variant
     additional_item: Tillegskostnad
+    address: TODO_TRANSLATE
     address1: Adresselinje 1
     address2: Adresselinje 2
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Justering
     adjustment_amount: Justeringsbeløp
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Justering lukket vellykket
     adjustment_successfully_opened: Justering vellykket åpnet
     adjustment_total: Totaljustering
@@ -377,35 +420,35 @@ nb:
     admin:
       tab:
         configuration: Oppsett
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: Ordrer
         overview: Oversikt
         products: Produkter
         promotions: Kampanjer
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: Rapporter
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Brukere
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administrasjon
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Godta personvernsregler
     agree_to_terms_of_service: Godta bruksregler
     all: Alle
     all_adjustments_closed: Alle justeringer lukket
     all_adjustments_opened: Alle justeringer åpne
     all_departments: Alle avdelinger
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Tillat bruk av SSL i utviklings- og testmiljø
     allow_ssl_in_production: Tillat bruk av SSL i produksjonsmiljø
     allow_ssl_in_staging: Tillatt bruk av SSL i stagingmiljø
@@ -413,194 +456,248 @@ nb:
     alt_text: Alternativ tekst
     alternative_phone: Alternativ telefon
     amount: Beløp
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
     analytics_trackers: Analytics Trackers
     and: og
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: godkjenne
     approved_at: godkjent den
     approver: Godkjent av
     are_you_sure: Er du sikker
     are_you_sure_delete: Er du sikker på at du vil slette denne?
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Autorisering feilet
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Tilgjengelig fra
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Tilbake
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Tilbake til butikken
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Tilbake til brukere
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Restordre
-    backorderable_default:
+    backorderable_default: TODO_TRANSLATE
     backordered: I restordre
     backorders_allowed: Kan settes på restordre
     balance_due: Forfallsdato
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Fakturaadresse
     billing: Fakturering
     billing_address: Fakturaadresse
     both: Begge
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Kalkulator
     calculator_settings_warning: Hvis du endrer kalkulasjonsmåte, må du lagre før du kan endre kalkulasjonsinstillinger
     cancel: Avbryt
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: Du kan ikke opprette en betaling for en ordre før det er definert en betalingsmåte
     cannot_create_returns: Kan ikke opprette retur, da denne ordren ikke er sendt ennå
     cannot_perform_operation: Kan ikke utføre handlingen
     cannot_set_shipping_method_without_address: Kan ikke sette fraktmåte uten adresse
     capture: Utfør
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: CVV-kode
     card_number: Kortnummer
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Korttype er
     cart: Handlekurv
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategorier
     category: Kategori
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Til kassen
     choose_a_customer: Velg kunde
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Velg valuta
-    choose_dashboard_locale:
+    choose_dashboard_locale: TODO_TRANSLATE
     choose_location: Velg lokasjon
     city: Sted
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Klon
     close: Lukk
-    close_all_adjustments:
+    close_all_adjustments: TODO_TRANSLATE
     code: Code
     company: Firma
     complete: Fullført
     configuration: Konfigurasjon
     configurations: Konfigurasjoner
+    configure_s3: TODO_TRANSLATE
     confirm: Bekreft
     confirm_delete: Bekreft sletting
     confirm_password: Bekreft passord
     continue: Fortsett
     continue_shopping: Fortsett å handle
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: Kostpris
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
     countries: Land
     country: Land
     country_based: Landsbasert
     country_name: Landnavn
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Rabattkupong
     coupon_code: Rabattkode
     coupon_code_already_applied: Rabattkupong er allerede brukt
     coupon_code_applied: Rabattkupong ble lagt til på ordren
-    coupon_code_better_exists:
+    coupon_code_better_exists: TODO_TRANSLATE
     coupon_code_expired: Rabattkoden er utgått på dato
     coupon_code_max_usage: Maksgrensen for rabattkupongen er nådd
     coupon_code_not_eligible: Rabattkoden er ikke gyldig
     coupon_code_not_found: Rabattkoden ble ikke funnet
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Opprett
     create_a_new_account: Opprett ny konto
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Opprettet
     credit: Kreditt
     credit_card: Kredittkort
     credit_cards: Kredittkort
     credit_owed: Skyldig kreditt
-    credits:
+    credits: TODO_TRANSLATE
     currency: Valuta
     currency_decimal_mark: Valuta kommaplassering
     currency_settings: Valuttainstillinger
     currency_symbol_position: Plasser valutasymbol foran eller etter beløp?
     currency_thousands_separator: Separator for tusenedeler
     current: Nå
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Kunde
     customer_details: Kundedetaljer
     customer_details_updated: Kundedetaljer
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Kundesøk
     cut: Klipp up
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
     date: dato
     date_completed: Fullføringsdato
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: Datoområde
     default: Default
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Standardavgift
     default_tax_zone: Standard avgiftsnivå
     delete: Slett
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Levering
     depth: Dybde
     description: Beskrivelse
     destination: Destinasjon
     destroy: Fjern
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Rabattbeløp
     dismiss_banner: Nei takk! Ikke vis dette igjen, takk!
     display: Vis
     display_currency: Vis valutta
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Endre
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Endre bruker
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Epost
     empty: Tom
     empty_cart: Tøm handlekurv
@@ -632,30 +729,31 @@ nb:
         user:
           signup: Brukerregistrering
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Utgår
     extension: Utvidelse
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Filnavn
     fill_in_customer_info: Fyll ut kundeinformasjon
     filter: Filter
     filter_results: Filtrer resultater
     finalize: Ferdigstill
-    finalized:
+    finalized: TODO_TRANSLATE
     find_a_taxon: Finn en gruppe
     first_item: Pris på første vare
     first_name: Fornavn
     first_name_begins_with: Fornavn begynner med
     flat_percent: Flat prosenrate
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Fast pris (per ordre)
     flexible_rate: Varierende pris
     forgot_password: Glemt Passord
     free_shipping: Gratis frakt
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front end
     gateway: Tjeneste
     gateway_config_unavailable: Tilganstjenesten utilgjengelig for miljøet
@@ -671,45 +769,49 @@ nb:
     hide_cents: Hele kroner?
     home: Hjem
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: Norsk
-      translations:
+      translations: TODO_TRANSLATE
     icon: Ikon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Bilde
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Bilder
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Inkludert i pris
     included_price_validation: kan ikke velges med mindre du har definert en standard avgiftsområde
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Fyll ut skjemaet under og du vil motta instruksjoner for hvordan du tilbakestiller passordet ditt per epost:'
     insufficient_stock: Manglende lagerbeholdning, kun %{on_hand} gjenstår
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Overstyr epostadresse
     intercept_email_instructions: Overstyr epostmottaker og bytt ut med følgende adresse.
     internal_name: Internt navn
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Ugyldig betalingsleverandør
     invalid_promotion_action: Ugyldig kampanjehendelse
     invalid_promotion_rule: Ugyldig kampanjeregel
     inventory: Varelager
     inventory_adjustment: Justering av varelager
     inventory_error_flash_for_insufficient_quantity: Ikke nok beholdning
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: er ikke tilgjengelig for levering
     iso_name: ISO Navn
     item: Artikkel
@@ -719,26 +821,32 @@ nb:
       operators:
         gt: større enn
         gte: større enn, eller er lik
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: Varene kan ikke sendes!
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
       path: Path
     last_name: Etternavn
     last_name_begins_with: Etternavn begynner med
     learn_more: Finn ut mer
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Liste
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Laster
     locale_changed: Endret språk
     location: Lokasjon
     lock: Låst
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Innlogget som
     logged_in_succesfully: Logget inn
     logged_out: Du har blitt utlogget.
@@ -747,23 +855,26 @@ nb:
     login_failed: Brukerautentisering feilet.
     login_name: Brukernavn
     logout: Logg ut
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Finn lignende varer
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Opprett refusjon
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Ordinær pris
     match_choices:
       all: Alle
       none: Ingen
     max_items: Maks antall
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Metabeskrivelse
     meta_keywords: Metanøkkelord
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Minimumsantall
     month: Måned
@@ -772,13 +883,13 @@ nb:
     my_account: Min konto
     my_orders: Mine ordrer
     name: Navn
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Navn eller varenr
     new: Ny
     new_adjustment: Ny justering
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Ny kunde
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nytt bilde
     new_option_type: Ny variasjonstype
     new_order: Ny ordre
@@ -787,14 +898,15 @@ nb:
     new_payment_method: Ny betalingsmåte
     new_product: Nytt produkt
     new_promotion: Ny kampanje
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Ny egenskap
     new_prototype: Ny prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Ny returgodkjenning
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Ny fraktkategori
     new_shipping_method: Ny leveransemåte
     new_state: Nytt fylke
@@ -811,24 +923,30 @@ nb:
     new_zone: Ny sone
     next: Neste
     no_actions_added: Ingen hendelse lagt til
+    no_orders_found: TODO_TRANSLATE
     no_payment_found: Ingen betalinger funnet
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: Ingen utestående betalinger
     no_products_found: Ingen produkter tilgjengelig
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Ingen resultat
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Ingen regler lagt til
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Sporing ikke tilgjengelig
     none: Ingen
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normalt antall
     not: ikke
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource} ble ikke funnet"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Produktet ble kopiert
       product_deleted: Produktet ble slettet
@@ -836,7 +954,7 @@ nb:
       product_not_deleted: Produktet kunne ikke slettes
       variant_deleted: Variant ble slettet
       variant_not_deleted: Variant kunne ikke slettes
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Tilgjengelig
     open: "Åpen"
     open_all_adjustments: "Åpne alle justeringer"
@@ -851,12 +969,13 @@ nb:
     or_over_price: "%{price} eller høyere"
     order: Ordre
     order_adjustments: Ordrejustering
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Ordredetaljer
     order_email_resent: Ordre-epost sent på nytt
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Kjære kunde,
@@ -876,11 +995,11 @@ nb:
     order_not_found: Ordren ble ikke funnet
     order_number: Ordre %{number}
     order_populator:
-      out_of_stock:
+      out_of_stock: TODO_TRANSLATE
       please_enter_reasonable_quantity: Vennligst oppgi et fornuftig antall
-      selected_quantity_not_available:
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Din ordre har blitt behandlet
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: adresse
       awaiting_return: venter på retur
@@ -888,7 +1007,7 @@ nb:
       cart: handlekurv
       complete: ferdig
       confirm: bekreftelse
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: levering
       payment: betaling
       resumed: gjenopptatt
@@ -898,12 +1017,14 @@ nb:
     order_total: Ordresum
     order_updated: Ordre oppdatert
     orders: Ordrer
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Ikke på lager
     overview: Oversikt
     package_from: Pakke fra
     pagination:
+      first: TODO_TRANSLATE
       next_page: neste side &raquo;
+      previous: TODO_TRANSLATE
       previous_page: "&laquo; forrige side"
       truncate: "&hellip;"
     password: Passord
@@ -911,8 +1032,8 @@ nb:
     path: Sti
     pay: betal
     payment: Betaling
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Betalingsinformasjon
     payment_method: Betalingsform
     payment_method_not_supported: Betalingsformen er ikke støttet
@@ -933,22 +1054,23 @@ nb:
       void: Avvis
     payment_updated: Betaling oppdatert
     payments: Betalinger
-    pending:
+    pending: TODO_TRANSLATE
     percent: prosent
     percent_per_item: Prosent per enhet
     permalink: Permalenke
     phone: Telefon
     place_order: Bekreft ordre
     please_define_payment_methods: Vennligst legg til betalingsmetode først.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Noe gikk galt. Prøv å legg til igjen.
     powered_by: Bygget på
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentasjon
     previous: Forrige
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Pris
     price_range: Prisområde
     price_sack: Price Sack
@@ -956,14 +1078,14 @@ nb:
     product: Produkt
     product_details: Produktdetaljer
     product_has_no_description: Product has not description
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Produktegenskaper
     product_rule:
       choose_products: Velg produkter
-      label:
+      label: TODO_TRANSLATE
       match_all: alle
       match_any: minst en
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Fra produktgruppe
         manual: Velg manuelt
@@ -975,19 +1097,24 @@ nb:
         description: Opprett en kampanjekreditt på ordren
         name: Opprett en justering
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Fyller handlekurv med det spesifiserte antallet av varianten
         name: Opprett varelinjer
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Handling
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Treff på hvilken som helst av disse reglene
         any: Treff på alle regler
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Kampanjeregel
     promotion_rule_types:
       first_order:
@@ -1000,27 +1127,27 @@ nb:
         description: Kunden må ha besøkt den spesifiserte siden
         name: Landingsiden
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Ordren inkluderer spesifikke produkt(er)
         name: Produkt(er)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Tilgjengelig kun for spesifiserte brukere
         name: Brukere
       user_logged_in:
         description: Kun tilgjengelig for innloggede brukere
         name: Bruker innlogget
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Kampanjer
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Egenskaper
     property: Egenskap
     prototype: Prototype
@@ -1028,7 +1155,7 @@ nb:
     provider: Tilbyder
     provider_settings_warning: Hvis du endrer tilbydertype, må du lagre før du kan endre tilbyderinstillingene
     qty: Antall
-    quantity:
+    quantity: TODO_TRANSLATE
     quantity_returned: Antall returnert
     quantity_shipped: Antall sendt
     quick_search: Hurtigsøk..
@@ -1037,41 +1164,43 @@ nb:
     receive: motta
     receive_stock: Varemottak
     received: Motatt
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Referansje
+    reference_contains: TODO_TRANSLATE
     refund: Refusjon
-    refund_amount_must_be_greater_than_zero:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
     refund_reasons: Refusjonsgrunner
-    refunded_amount:
-    refunds:
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registrer som ny bruker
     registration: Registrering
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Husk meg
     remove: Fjern
     rename: Gi nytt navn
-    report:
+    report: TODO_TRANSLATE
     reports: Rapporter
+    resellable: TODO_TRANSLATE
     resend: Send på nytt
     reset_password: Nullstill passord
     response_code: Responskode
@@ -1082,16 +1211,17 @@ nb:
     return_authorization_reasons: Grunner for returautorisasjon
     return_authorization_updated: Returautorisasjon oppdatert
     return_authorizations: Returautorisasjoner
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Returantall
     returned: Returnert
-    returns:
+    returns: TODO_TRANSLATE
     review: Omtale
     risk: Risko
     risk_analysis: Risikoanalyse
@@ -1099,8 +1229,14 @@ nb:
     rma_credit: RMA Kreditt
     rma_number: RMA Nummer
     rma_value: RMA Verdi
+    role_id: TODO_TRANSLATE
     roles: Roller
     rules: Regler
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
     safe: Sikker
     sales_total: Brutto omsetning
     sales_total_description: Brutto omsetning for alle ordrer
@@ -1119,7 +1255,8 @@ nb:
     select_a_return_authorization_reason: Grunnlag for retur..
     select_a_stock_location: Velg lagerlokasjon..
     select_from_prototype: Velg fra prototype
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Send kopi av all epost til
     send_mails_as: Send epost som
     server: Server
@@ -1129,8 +1266,9 @@ nb:
     ship_address: Leveringsadresse
     ship_total: Leveringskostnader
     shipment: Levering
-    shipment_adjustments:
+    shipment_adjustments: TODO_TRANSLATE
     shipment_details: Leveringsdetaljer
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Kjære kunde,
@@ -1148,22 +1286,26 @@ nb:
       pending: venter
       ready: klar
       shipped: sendt
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Forsendelser
     shipped: Sendt
     shipping: Frakt
     shipping_address: Leveringsadresse
     shipping_categories: Fraktkategorier
     shipping_category: Shipping Category
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: Sendingsinstruks
     shipping_method: Leveransemåte
     shipping_methods: Leveransemåter
     shipping_price_sack: Fast forsendelsespris
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Handle etter %{taxonomy}
     shopping_cart: Handlekurv
     show: Vis
@@ -1175,47 +1317,59 @@ nb:
     sku: Varenummer
     skus: Varenumre
     slug: Slug
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Kilde
     special_instructions: Spesielle instrukser
     split: Del
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Det er en feil med betalingsinformasjonen din - Se over å prøv igjen
     ssl:
       change_protocol: Endre protokoll
     start: Start
+    start_date: TODO_TRANSLATE
     state: Fylke
     state_based: Tilstandsbasert
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Fylker
     states_required: Fylke påkrevd
     status: Status
@@ -1223,11 +1377,11 @@ nb:
     stock_location: Varelokasjon
     stock_location_info: Varelokasjoninformasjon
     stock_locations: Varelokasjoner
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Lagerstyring
     stock_management_requires_a_stock_location: Lagerstyring krever en lagerlokasjon
     stock_movements: Beholdningsendring
-    stock_movements_for_stock_location:
+    stock_movements_for_stock_location: TODO_TRANSLATE
     stock_successfully_transferred: Beholdning vellykket flyttet
     stock_transfer: Beholdningsendring
     stock_transfers: Beholdningsendringer
@@ -1237,28 +1391,30 @@ nb:
     street_address_2: Adresselinje 2
     subtotal: Sum
     subtract: Trekk fra
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} ble opprettet!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} ble fjernet!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource} ble oppdatert!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Avgift
     tax_categories: Avgiftsklasser
     tax_category: Avgiftsklasse
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Avgiftsnivå (0.10 = 10%)
     tax_rates: Avgiftsnivå
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Gruppe
     taxon_edit: Endre gruppe
     taxon_placeholder: Grupper
     taxon_rule:
       choose_taxons: Velg grupper
-      label:
-      match_all:
-      match_any:
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Grupperinger
     taxonomy: Gruppering
     taxonomy_edit: Endre grupperinger
@@ -1267,6 +1423,9 @@ nb:
     taxons: Klasser
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Gratulerer!
         message: Hvis du leser dette er epostinnstillingene dine konfigurert korrekt.
@@ -1275,24 +1434,24 @@ nb:
     thank_you_for_your_order: Takk for bestillingen. Vennligst skriv ut og ta vare på denne bekreftelsen.
     there_are_no_items_for_this_order: Det er ingen enheter for denne ordren
     there_were_problems_with_the_following_fields: Det er problemer med følgende felter
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: tidspunkt
     to_add_variants_you_must_first_define: For å legge til varianter, må du først definere
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Sporing
     tracking_number: Sporingsnummer
     tracking_url: Sporingslenke
     tracking_url_placeholder: http://..
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Flytt fra lokasjon
     transfer_stock: Flytt varebeholdning
     transfer_to_location: Flytt til lokasjon
@@ -1300,7 +1459,7 @@ nb:
     type: Type
     type_to_search: Skriv for å søke..
     unable_to_connect_to_gateway: Kunne ikke koble til systemport.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
     unlock: Lås opp
     unrecognized_card_type: Ukjent korttype
@@ -1308,9 +1467,11 @@ nb:
     update: Oppdater
     updating: Oppdaterer
     usage_limit: Bruksgrense
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Bruk fakturaadressen
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Use a new card
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Bruk Amazon S3 for bilder
     user: Bruker
     user_rule:
@@ -1318,12 +1479,13 @@ nb:
     users: Brukere
     validation:
       cannot_be_less_than_shipped_units: kan ikke være lavere en antall sendte enheter.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: er for stor -- varebeholdningen kan ikke dekke forespurt antall!
       must_be_int: må være et heltall
       must_be_non_negative: må være en ikke-negativ verdi
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Verdi
     variant: Variant
     variant_placeholder: Varianter
@@ -1342,3 +1504,10 @@ nb:
     zipcode: Postnummer
     zone: Sone
     zones: Soner
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,4 +1,6 @@
+---
 nl:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ nl:
         state: Provincie
         zipcode: Postcode
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ nl:
         name: Naam
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Type
         month: Maand
-        name:
+        name: TODO_TRANSLATE
         number: Nummer
         verification_value: Veiligheidscode
         year: Jaar
@@ -42,7 +44,7 @@ nl:
       spree/order:
         checkout_complete: Bestelling afgerond
         completed_at: Voltooid op
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: Kortingscode
         created_at: Besteldatum
         email: Klant e-mail
@@ -72,6 +74,7 @@ nl:
         zipcode: Postcode
       spree/payment:
         amount: Bedrag
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Naam
       spree/product:
@@ -95,7 +98,8 @@ nl:
         starts_at: Begint op
         usage_limit: Gebruikslimiet
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Naam
         presentation: Presentatie
@@ -105,24 +109,26 @@ nl:
         amount: Aantal
       spree/role:
         name: Naam
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Afkorting
         name: Naam
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Omschrijving
         name: Naam
@@ -157,48 +163,54 @@ nl:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: Kaart is verlopen
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adres
         other: Adressen
@@ -208,43 +220,45 @@ nl:
       spree/credit_card:
         one: Kredietkaart
         other: Kredietkaarten
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Voorraadeenheid
         other: Voorraadeenheden
       spree/line_item:
         one: Regel
         other: Regels
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Bestelling
         other: Bestellingen
       spree/payment:
         one: Betaling
         other: Betalingen
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Product
         other: Producten
       spree/promotion:
         one: Promotie
         other: Promoties
-      spree/promotion_category:
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Eigenschap
         other: Eigenschappen
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Retour
         other: Retouren
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Rol
         other: Rollen
       spree/shipment:
@@ -253,14 +267,14 @@ nl:
       spree/shipping_category:
         one: Verzendcategorie
         other: Verzendcategorieën
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Provincie
         other: Provincies
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Belastingscategorie
         other: Belastingscategorieën
@@ -273,7 +287,7 @@ nl:
       spree/taxonomy:
         one: Taxonomie
         other: Taxonomieën
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Gebruiker
         other: Gebruikers
@@ -283,6 +297,9 @@ nl:
       spree/zone:
         one: Zone
         other: Zones
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Je account is succesvol bevestigd. Je bent nu aangemeld.
@@ -321,6 +338,7 @@ nl:
     user_sessions:
       signed_in: Succesvol aangemeld.
       signed_out: Succesvol afgemeld.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: was reeds bevestigd
@@ -329,12 +347,30 @@ nl:
       not_saved:
         one: '1 fout voorkwam dat deze %{resource} werd opgeslagen:'
         other: "%{count} fouten voorkwamen dat deze %{resource} werd opgeslagen:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Afkorting
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Account
     account_updated: Account bijgewerkt!
     action: Actie
@@ -347,7 +383,7 @@ nl:
       list: Lijst
       listing: Opsomming
       new: Nieuw
-      refund:
+      refund: TODO_TRANSLATE
       save: Opslaan
       update: Bijwerken
     activate: Activeer
@@ -355,7 +391,7 @@ nl:
     add: Toevoegen
     add_action_of_type: Voeg actie toe van type
     add_country: Land toevoegen
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Voeg nieuwe header toe
     add_new_style: Voeg nieuwe stijl toe
     add_one: Voeg één toe
@@ -369,11 +405,16 @@ nl:
     add_to_cart: Toevoegen aan winkelwagen
     add_variant: Variant toevoegen
     additional_item: Toegevoegde artikel kosten
+    address: TODO_TRANSLATE
     address1: Adres
     address2: Adres (vervolg)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Aanpassing
     adjustment_amount: Hoeveelheid
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Aanpassing is met succes afgesloten!
     adjustment_successfully_opened: Aanpassing is met succes geopend!
     adjustment_total: Totaal toevoegingen
@@ -387,29 +428,29 @@ nl:
         products: Producten
         promotions: Promoties
         properties: Eigenschappen
-        prototypes:
+        prototypes: TODO_TRANSLATE
         reports: Rapportages
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Gebruikers
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administratie
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Akkoord met privacy beleid
     agree_to_terms_of_service: Akkoord met algemene voorwaarden
     all: Alle
     all_adjustments_closed: Alle aanpassingen succesvol gesloten!
     all_adjustments_opened: Alle aanpassingen succesvol geopend
     all_departments: Alle afdelingen
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Sta toe SSL te gebruiken in ontwikkel en test modus
     allow_ssl_in_production: Sta toe SSL te gebruiken in productie modus
     allow_ssl_in_staging: Sta toe SSL te gebruikten in staging modus
@@ -425,58 +466,92 @@ nl:
     analytics_desc_list_4: Het is volledig gratis
     analytics_trackers: Analytics trackers
     and: en
-    approve:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
     approved_at: Goedgekeurd op
     approver: Door
     are_you_sure: Weet je het zeker
     are_you_sure_delete: Wilt je dit record echt verwijderen?
     associated_adjustment_closed: De bijbehorende aanpassing is gesloten, en wordt niet herberekend. Wil je de aanpassing openen?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Autorisatie mislukt
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Beschikbaar op
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Terug
     back_end: Backend
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Verder winkelen
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Terug naar gebruikers lijst
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Nabestelbaar
-    backorderable_default:
+    backorderable_default: TODO_TRANSLATE
     backordered: Nabestelling
     backorders_allowed: Nabestellingen toegestaan
     balance_due: Te betalen
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Factuuradres
     billing: Factuur
     billing_address: Factuuradres
     both: Beide
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculator
     calculator_settings_warning: Als je de calculator verandert, dien je eerst op te slaan voordat je de calculator instellingen kan wijzigen
     cancel: Annuleer
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: Je kunt geen betaling aanmaken voor een bestelling als er geen betaalmethodes gedefinieerd zijn.
     cannot_create_returns: Kan geen retour aanmaken aangezien de bestelling nog niet is verstuurd
     cannot_perform_operation: Kan deze opdracht niet uitvoeren
     cannot_set_shipping_method_without_address: Kan geen verzendmethode kiezen totdat klant details bekend zijn.
     capture: betaling vastleggen
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kaartcode
     card_number: Kaartnummer
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Kaarttype is
     cart: Winkelwagen
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categorieën
     category: Categorie
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Controleer op Spree Alerts
     checkout: Afrekenen
     choose_a_customer: Kies een klant
@@ -485,10 +560,10 @@ nl:
     choose_dashboard_locale: Kies dashboard regio-instelling
     choose_location: Kies locatie
     city: Stad
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Dupliceren
     close: Sluiten
     close_all_adjustments: Sluit alle aanpassingen
@@ -497,6 +572,7 @@ nl:
     complete: Voltooid
     configuration: Configuratie
     configurations: Configuraties
+    configure_s3: TODO_TRANSLATE
     confirm: Bevestig
     confirm_delete: Bevestig verwijderen
     confirm_password: Wachtwoord bevestigen
@@ -505,7 +581,7 @@ nl:
     cost_currency: Kosten valuta
     cost_price: Kostprijs
     could_not_connect_to_jirafe: Kon geen verbinding maken met Jirafe. Dit wordt later automatisch nogmaals geprobeerd.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Er is een fout opgetreden bij het bewaren van deze voorraad verplaatsing. Probeer het nogmaals.
     count_on_hand: Aantal in voorraad
     countries: Landen
@@ -513,10 +589,10 @@ nl:
     country_based: Gebaseerd op land
     country_name: Naam
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Kortingscode
     coupon_code: Kortingscode
     coupon_code_already_applied: Deze kortingscode is al toegepast op deze bestelling
@@ -526,17 +602,17 @@ nl:
     coupon_code_max_usage: Kortingscode is te vaak gebruikt
     coupon_code_not_eligible: Kortingscode is niet geldig voor deze bestelling
     coupon_code_not_found: Deze kortingscode bestaat niet. Probeer het nogmaals.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Aanmaken
     create_a_new_account: Maak een nieuwe account aan
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Aangemaakt op
     credit: Krediet
     credit_card: Kredietkaart
     credit_cards: Kredietkaart
     credit_owed: Credits ontvangen
-    credits:
+    credits: TODO_TRANSLATE
     currency: Valuta
     currency_decimal_mark: Scheidingsteken voor decimalen
     currency_settings: Valuta instellingen
@@ -547,64 +623,83 @@ nl:
     customer: Klant
     customer_details: Klant details
     customer_details_updated: Klant details bijgewerkt
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Klant zoeken
     cut: Knippen
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable:
+        currently_unavailable: TODO_TRANSLATE
         explanation: De onderstaande velden kunnen al ingevuld zijn als je via het dashboard hebt gekozen om te registreren met Jirafe.
         header: Jirafe Analytics instellingen
-        site_id:
-        token:
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
       jirafe_settings_updated: Jirafe instellingen bijgewerkt.
     date: Datum
     date_completed: Datum voluit
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%d/%m/%Y"
       js_format: dd/mm/yy
     date_range: Datumbereik
     default: Standaard
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Standaardbelasting
     default_tax_zone: Standaardbelastingszone
     delete: Verwijder
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Bezorging
     depth: Diepte
     description: Omschrijving
     destination: Bestemming
     destroy: Verwijder
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Kortingsbedrag
     dismiss_banner: Nee. Bedankt! Ik heb geen interesse. Laat dit bericht niet meer zien.
     display: Weergeven
     display_currency: Weergave valuta
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Wijzig
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Bewerk gebruikers
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: E-mail
     empty: Leeg
     empty_cart: Winkelwagen legen
@@ -637,28 +732,30 @@ nl:
           signup: Gebruiker registratie
     exceptions:
       count_on_hand_setter: 'Kan count_on_hand niet handmatig instellen, omdat het automatisch wordt ingesteld door de recalculate_count_on_hand callback. Gebruik  `update_column (: count_on_hand, waarde)` in plaats hier van.'
-    exchange_for:
-    excl:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
     existing_shipments: Bestaande verzendingen
-    expedited_exchanges_warning:
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Verval
     extension: Extensie
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Bestandsnaam
     fill_in_customer_info: Vul klant informatie in aub.
+    filter: TODO_TRANSLATE
     filter_results: Filter resultaten
     finalize: Afronden
-    finalized:
+    finalized: TODO_TRANSLATE
     find_a_taxon: Zoek een taxon
     first_item: Kosten eerste item
     first_name: Voornaam
     first_name_begins_with: Voornaam begint met
     flat_percent: Vast percentage
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Vast  bedrag (per bestelling)
     flexible_rate: Flexibel bedrag
     forgot_password: Wachtwoord vergeten
     free_shipping: Gratis verzending
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Frontend
     gateway: Gateway
     gateway_config_unavailable: Gateway niet beschikbaar voor configuratie
@@ -682,37 +779,41 @@ nl:
       only_incomplete: Enkel onvolledige
       select_locale: Selecteer regio-instelling
       show_only: Toon enkel
+      store_translations: TODO_TRANSLATE
       supported_locales: Ondersteunde regio-instellingen
       this_file_language: Nederlands (NL)
       translations: Vertalingen
     icon: Icoon
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Afbeelding
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Afbeeldingen
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Inbegrepen in prijs
     included_price_validation: kan niet worden gekozen tenzij je een standaardbelastingszone hebt ingesteld.
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Vul je e-mailadres in. De instructies om je wachtwoord te resetten worden naar je verstuurd:'
     insufficient_stock: Onvoldoende voorraad beschikbaar, enkel %{on_hand} beschikbaar
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: E-mailadres opvangen
     intercept_email_instructions: Ontvanger van de e-mail overschrijven met dit e-mail adres.
     internal_name: Interne naam
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Ongeldige betaalprovider.
     invalid_promotion_action: Ongeldige promotieactie.
     invalid_promotion_rule: Ongeldige promotieregel.
     inventory: Voorraad
     inventory_adjustment: Voorraadaanpassing
     inventory_error_flash_for_insufficient_quantity: Een item in uw winkelwagen is niet meer beschikbaar zijn.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: is niet beschikbaar voor afleveradres
     iso_name: ISO Naam
     item: Product
@@ -722,26 +823,32 @@ nl:
       operators:
         gt: groter dan
         gte: groter dan of gelijk aan
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: Items kunnen niet worden verstuurd
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Pad
     last_name: Achternaam
     last_name_begins_with: Achternaam begint met
     learn_more: Lees meer
-    lifetime_stats:
+    lifetime_stats: TODO_TRANSLATE
     line_item_adjustments: Regel-aanpassingen
     list: Lijst
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Bezig met laden
     locale_changed: Regio-instelling gewijzigd
     location: Locatie
     lock: Vergrendel
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: aangemeld als
     logged_in_succesfully: Je bent aangemeld
     logged_out: Je bent nu afgemeld.
@@ -750,23 +857,26 @@ nl:
     login_failed: Aanmelden mislukt.
     login_name: Gebruikersnaam
     logout: Afmelden
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Zoek naar dezelfde items
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Terugboeking aanmaken
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Prijs
     match_choices:
       all: Alles
       none: Geen
     max_items: Maximaal aantal items
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta beschrijving
     meta_keywords: Meta sleutelwoorden
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Minimum afname
     month: Maand
@@ -775,13 +885,13 @@ nl:
     my_account: Mijn profiel
     my_orders: Mijn bestellingen
     name: Naam
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Naam of SKU
     new: Nieuw
     new_adjustment: Nieuwe toevoeging
     new_country: Land toevoegen
     new_customer: Nieuwe klant
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nieuwe afbeelding
     new_option_type: Nieuw optietype
     new_order: Nieuwe bestelling
@@ -790,13 +900,14 @@ nl:
     new_payment_method: Nieuwe betaalmethode
     new_product: Nieuw product
     new_promotion: Nieuwe promotie
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nieuwe eigenschap
     new_prototype: Nieuw prototype
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Nieuwe retour-autorisatie
-    new_rma_reason:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
     new_shipment_at_location: Nieuwe verzending vanaf locatie
     new_shipping_category: Nieuwe verzend categorie
     new_shipping_method: Nieuwe verzendwijze
@@ -814,24 +925,30 @@ nl:
     new_zone: Nieuwe zone
     next: Volgende
     no_actions_added: Geen acties toegevoegd
-    no_payment_found:
-    no_pending_payments:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Geen producten gevonden
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Geen resultaten
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Geen regels toegevoegd
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Geen tracking details opgegeven.
     none: Geen
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normaal aantal
     not: Niet
     not_available: Niet beschikbaar
     not_enough_stock: Er is niet voldoende voorraad op de locatie van afkomst om deze overdracht te voltooien.
     not_found: "%{resource} is niet gevonden"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Product is gedupliceerd
       product_deleted: Product is verwijderd
@@ -839,7 +956,7 @@ nl:
       product_not_deleted: Product kon niet worden verwijderd
       variant_deleted: Variant is verwijderd
       variant_not_deleted: Variant kon niet worden verwijderd
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Op voorraad
     open: Open
     open_all_adjustments: Open alle aanpassingen
@@ -854,32 +971,37 @@ nl:
     or_over_price: Of meer dan %{price}
     order: Bestelling
     order_adjustments: Bestellingstoevoegingen
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Bestellingsdetails
     order_email_resent: Verstuur bevestigings e-mail opnieuw
     order_information: Bestellingsinformatie
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Beste klant
         instructions: Je order is GEANNULEERD. Bewaar deze annulering voor je administratie.
         order_summary_canceled: Besteloverzicht [GEANNULEERD]
         subject: Bestelling is geannuleerd
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Beste klant,
         instructions: Controleer je bestelling en bewaar deze mail.
         order_summary: Besteloverzicht
         subject: Bestelling is bevestigd
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Bedankt voor je bestelling.
-        total:
+        total: TODO_TRANSLATE
     order_not_found: We konden je bestelling niet vinden. Probeer het nogmaals.
     order_number: Bestelling %{number}
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Je bestelling is succesvol verwerkt
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: adres
       awaiting_return: wachten op retour
@@ -887,7 +1009,7 @@ nl:
       cart: winkelwagen
       complete: voltooid
       confirm: bevestigen
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: verzendmethode
       payment: betalen
       resumed: hervatten
@@ -897,12 +1019,14 @@ nl:
     order_total: Bestelling totaal
     order_updated: Bestelling gewijzigd
     orders: Bestellingen
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Niet op voorraad
     overview: Overzicht
     package_from: pakketje van
     pagination:
+      first: TODO_TRANSLATE
       next_page: volgende pagina »
+      previous: TODO_TRANSLATE
       previous_page: "« vorige pagina"
       truncate: "…"
     password: Wachtwoord
@@ -910,8 +1034,8 @@ nl:
     path: Pad
     pay: Betalen
     payment: Betaling
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Betaalmethode
     payment_method: Betaalmethode
     payment_method_not_supported: Betaalmethode wordt niet ondersteund
@@ -932,22 +1056,23 @@ nl:
       void: Ongeldig
     payment_updated: Betaling bijgewerkt
     payments: Betalingen
-    pending:
+    pending: TODO_TRANSLATE
     percent: Procent
     percent_per_item: Procent per item
     permalink: Permalink
     phone: Telefoon
     place_order: Bestellen
     please_define_payment_methods: Definieer eerst een betaalmethode.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Er ging iets mis. Probeer het nogmaals.
     powered_by: Mede mogelijk gemaakt door
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Presentatie
     previous: vorige
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Prijs
     price_range: Prijsklasse
     price_sack: Prijsvork
@@ -959,10 +1084,10 @@ nl:
     product_properties: Producteigenschappen
     product_rule:
       choose_products: Kies producten
-      label:
+      label: TODO_TRANSLATE
       match_all: alle
       match_any: op zijn minst één
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Van productgroep
         manual: Handmatige keuze
@@ -974,19 +1099,24 @@ nl:
         description: Past de prijs van een order aan gebaseerd op een promotie.
         name: Maak aanpassing
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Vult de kar met de aangegeven hoeveelheid van variant
         name: Maak regel
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Acties
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Moet overeenkomen met één van deze regels
         any: Moet overeenkomen met alle regels
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotieregel
     promotion_rule_types:
       first_order:
@@ -999,27 +1129,27 @@ nl:
         description: Klant moet een specifieke pagina bezocht hebben
         name: Landings Pagina
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Bestelling bevat de volgende producten
         name: Product(en)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Alleen beschikbaar voor de volgende gebruikers
         name: Gebruiker
       user_logged_in:
         description: Alleen beschikbaar voor aangemelde gebruikers
         name: Gebruik aangemeld
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Acties
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Eigenschappen
     property: Eigenschap
     prototype: Prototype
@@ -1030,47 +1160,49 @@ nl:
     quantity: Hoeveelheid
     quantity_returned: Aantal geretourneerd
     quantity_shipped: Aantal verzonden
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Tarief
     reason: Reden
     receive: ontvangen
     receive_stock: Ontvang voorraad
     received: Ontvangen
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Verwijzing
+    reference_contains: TODO_TRANSLATE
     refund: Terugbetaling
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registreer als een nieuwe gebruiker
     registration: Registratie
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Onthouden
     remove: Verwijderen
     rename: Hernoemen
-    report:
+    report: TODO_TRANSLATE
     reports: Rapporten
+    resellable: TODO_TRANSLATE
     resend: Opnieuw verzenden
     reset_password: Reset mijn wachtwoord
     response_code: Antwoordcode
@@ -1078,29 +1210,36 @@ nl:
     resumed: Hervat
     return: Terugzenden
     return_authorization: Retour
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Retour bijgewerkt
     return_authorizations: Retouren
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Retour aantal
     returned: Teruggezonden
-    returns:
+    returns: TODO_TRANSLATE
     review: Beoordeel
     risk: Risico
     risk_analysis: Risicoanalyse
-    risky:
+    risky: TODO_TRANSLATE
     rma_credit: RMA krediet
     rma_number: RMA nummer
     rma_value: RMA waarde
+    role_id: TODO_TRANSLATE
     roles: Rollen
     rules: Regels
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Omzet
     sales_total_description: Totaalbedrag van alle verkopen
     sales_totals: Verkoopstotaal
@@ -1115,10 +1254,11 @@ nl:
     secure_connection_type: Type beveiligde verbinding
     security_settings: Beveiligingsinstellingen
     select: Selecteer
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Selecteer vanuit prototype
     select_stock: Kies voorraad
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Verstuur kopie van alle e-mails naar
     send_mails_as: Verstuur e-mail als
     server: Server
@@ -1129,7 +1269,8 @@ nl:
     ship_total: Verzend totaal
     shipment: Verzending
     shipment_adjustments: Verzending aanpassingen
-    shipment_details:
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Beste klant
@@ -1142,13 +1283,13 @@ nl:
     shipment_state: Verzendstatus
     shipment_states:
       backorder: nabestelling
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: gedeeltelijk
       pending: in afwachting
       ready: voltooid
       shipped: verzonden
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Verzendingen
     shipped: verzonden
     shipping: Verzenden
@@ -1162,67 +1303,83 @@ nl:
     shipping_method: Verzendwijze
     shipping_methods: Verzendwijzen
     shipping_price_sack: Prijsvork
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Winkelen per %{taxonomy}
     shopping_cart: Winkelwagen
     show: Toon
     show_active: Toon actieve
     show_deleted: Toon verwijderde items
     show_only_complete_orders: Toon enkel afgewerkte bestellingen
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Toon tarief naast naam
     sku: Sku
-    skus:
+    skus: TODO_TRANSLATE
     slug: Verkorte URL
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Bron
     special_instructions: Speciale instructies
     split: Splits
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Er was een probleem met je betaal gegevens. Controleer je gegevens en probeer het opnieuw.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Start
+    start_date: TODO_TRANSLATE
     state: Status
     state_based: Status gebaseerd
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Statussen
     states_required: Vereiste statussen
     status: Status
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Voorraadlocatie
     stock_location_info: Voorraadlocatie info
     stock_locations: Voorraadlocaties
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Voorraadbeheer
     stock_management_requires_a_stock_location: Voorraadbeheer vereist een voorraadlocatie
     stock_movements: Voorraadverplaatsing
@@ -1236,28 +1393,30 @@ nl:
     street_address_2: Adres 2
     subtotal: Subtotaal
     subtract: Verreken
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} is succesvol aangemaakt!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} is succesvol verwijderd!"
     successfully_signed_up_for_analytics: Succesvol aangemeld voor Spree Analytics
     successfully_updated: "%{resource} is succesvol bijgewerkt!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Belasting
     tax_categories: Belastingcategorieën
     tax_category: Belastingcategorie
-    tax_code:
+    tax_code: TODO_TRANSLATE
     tax_included: Inclusief belasting
     tax_rate_amount_explanation: 'Belastingtarieven zijn een decimaal getal. (bijvoorbeeld: als het tarief 21% is vul je 0.21 in)'
     tax_rates: Belastingtarieven
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxon
     taxon_edit: Bewerk taxon
     taxon_placeholder: Taxonomie toevoegen
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomieën
     taxonomy: Taxonomie
     taxonomy_edit: Bewerk taxonomie
@@ -1266,6 +1425,9 @@ nl:
     taxons: Taxa
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Gefeliciteerd!
         message: Als je deze mail ontvangt, zijn je instellingen correct.
@@ -1274,24 +1436,24 @@ nl:
     thank_you_for_your_order: Hartelijk dank voor je bestelling. Je kan deze pagina afdrukken als bewijs van bestelling.
     there_are_no_items_for_this_order: Er zijn geen items voor deze bestelling
     there_were_problems_with_the_following_fields: Er zijn problemen met de volgende velden
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Thumbnail
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Tijd
     to_add_variants_you_must_first_define: Om varianten toe te voegen dien je er eerst te definiëren
     total: Totaal
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
     track_inventory: Voorraadbeheer
     tracking: Tracking
     tracking_number: Tracking nummer
     tracking_url: Tracking URL
     tracking_url_placeholder: bv. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Overdracht van
     transfer_stock: Voorraadoverdracht
     transfer_to_location: Overdracht naar
@@ -1299,7 +1461,7 @@ nl:
     type: Type
     type_to_search: Typ om te zoeken
     unable_to_connect_to_gateway: Kon geen verbinding maken met de betaalserver.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Minder dan %{price}
     unlock: Ontgrendel
     unrecognized_card_type: Niet herkend kaart type
@@ -1307,9 +1469,11 @@ nl:
     update: Aanpassen
     updating: Aan het bijwerken
     usage_limit: Gebruikslimiet
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Gebruik factuuradres
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Gebruik een nieuwe kaart
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Gebruik Amazon S3 Voor Afbeeldingen
     user: Gebruiker
     user_rule:
@@ -1317,12 +1481,13 @@ nl:
     users: Gebruikers
     validation:
       cannot_be_less_than_shipped_units: kan niet minder zijn dan het aantal verzonden producten.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: overschrijdt beschikbare voorraad. Zorg dat je een juiste hoeveelheid hebt ingevuld per bestelregel.
       is_too_large: is te veel - voorraad kan de aanvraag niet aan!
       must_be_int: moet een getal zijn
       must_be_non_negative: moet een positief getal zijn
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Waarde
     variant: Variant
     variant_placeholder: Kies een variant
@@ -1341,3 +1506,10 @@ nl:
     zipcode: Postcode
     zone: Gebied
     zones: Gebieden
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,4 +1,6 @@
+---
 pl:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ pl:
         state: Województwo
         zipcode: Kod pocztowy
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ pl:
         name: Nazwa
         numcode: Kod ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Typ
         month: Miesiąc
-        name:
+        name: TODO_TRANSLATE
         number: Numer
         verification_value: Wartość weryfikacyjna
         year: Rok
@@ -72,8 +74,9 @@ pl:
         zipcode: Kod pocztowy do wysyłki
       spree/payment:
         amount: Wartość
+        number: TODO_TRANSLATE
       spree/payment_method:
-        name:
+        name: TODO_TRANSLATE
       spree/product:
         available_on: Dostępne od
         cost_currency: Waluta kosztu
@@ -95,7 +98,8 @@ pl:
         starts_at: Data rozpoczęcia
         usage_limit: Limit wykorzystania
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Nazwa
         presentation: Prezentacja
@@ -105,24 +109,26 @@ pl:
         amount: Ilość
       spree/role:
         name: Nazwa
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Skrót
         name: Nazwa
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Opis
         name: Nazwa
@@ -157,48 +163,54 @@ pl:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: Ważność karty wygasła
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adres
         other: Adresy
@@ -208,43 +220,45 @@ pl:
       spree/credit_card:
         one: Karta kredytowa
         other: Karty kredytowe
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Jednostka magazynowa
         other: Jednostki magazynowe
       spree/line_item:
         one: Jednostka linii
         other: Jednostki linii
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Zamówienie
         other: Zamówienia
       spree/payment:
         one: Płatność
         other: Płatności
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Produkt
         other: Produkty
       spree/promotion:
         one: Promocja
         other: Promocje
-      spree/promotion_category:
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Własność
         other: Własności
       spree/prototype:
         one: Prototyp
         other: Prototypy
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Autoryzacja zwrotna
         other: Autoryzacje zwrotne
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Rola
         other: Role
       spree/shipment:
@@ -253,16 +267,16 @@ pl:
       spree/shipping_category:
         one: Kategoria wysyłki
         other: Kategorie wysyłki
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Stan
         other: Stany
-      spree/state_change:
+      spree/state_change: TODO_TRANSLATE
       spree/stock_location:
         one: Lokalizacja magazynu
         other: Lokalizacje magazynu
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Kategoria podatku
         other: Kategorie podatku
@@ -275,7 +289,7 @@ pl:
       spree/taxonomy:
         one: Taksonomia
         other: Taksonomie
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Użytkownik
         other: Użytkownicy
@@ -285,6 +299,9 @@ pl:
       spree/zone:
         one: Strefa
         other: Strefy
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Twoje konto zostało potwierdzone. Zostałeś zalogowany.
@@ -323,6 +340,7 @@ pl:
     user_sessions:
       signed_in: Zostałeś zalogowany.
       signed_out: Zostałeś wylogowany.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: już zostało potwierdzone
@@ -331,12 +349,30 @@ pl:
       not_saved:
         one: '1 błąd uniemożliwił zachowanie tego %{resource}:'
         other: "%{count} błędy(-ów) uniemożliwiło zachowanie tego %{resource}:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Skrót
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Konto
     account_updated: Konto uaktualnione
     action: Działanie
@@ -349,7 +385,7 @@ pl:
       list: Lista
       listing: Wypisuje
       new: Nowy
-      refund:
+      refund: TODO_TRANSLATE
       save: Zachowaj
       update: Uaktualnij
     activate: Uaktywnij
@@ -357,7 +393,7 @@ pl:
     add: Dodaj
     add_action_of_type: Dodaj działanie typu
     add_country: Dodaj kraj
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Dodaj nowy nagłówek
     add_new_style: Dodaj nowy styl
     add_one: Dodaj jeden
@@ -371,11 +407,16 @@ pl:
     add_to_cart: Dodaj do koszyka
     add_variant: Dodaj odmianę
     additional_item: Dodatkowy koszt jednostki
+    address: TODO_TRANSLATE
     address1: Adres
     address2: Adres (cd.)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Poprawka
     adjustment_amount: Ilość
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Zamknięto poprawkę!
     adjustment_successfully_opened: Otwarto poprawkę!
     adjustment_total: Poprawka razem
@@ -383,35 +424,35 @@ pl:
     admin:
       tab:
         configuration: Konfiguracja
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: Zamówienia
         overview: Przegląd
         products: Produkty
         promotions: Promocje
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: Raporty
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Użytkownicy
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administracja
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Zgoda na politykę prywatności
     agree_to_terms_of_service: Zgoda na warunki serwisu
     all: Wszystko
     all_adjustments_closed: Zamknięto wszystkie poprawki!
     all_adjustments_opened: Otwarto wszystkie poprawki!
     all_departments: Wszystkie działy
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Wykorzystuj SSL w trybie rozwojowym i testowym
     allow_ssl_in_production: Wykorzystuj SSL w trybie produkcyjnym
     allow_ssl_in_staging: Wykorzystuj SSL w trybie postoju
@@ -427,70 +468,104 @@ pl:
     analytics_desc_list_4: Całkiem za darmo!
     analytics_trackers: "Śledzenie analizy"
     and: i
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Na pewno?
     are_you_sure_delete: Na pewno chcesz usunąć ten wpis?
     associated_adjustment_closed: Powiązana poprawka jest zamknięta i nie zostanie przeliczona. Czy chcesz ją otworzyć?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Błąd autoryzacji
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Dostępne od
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Powrót
     back_end: Zaplecze
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Powrót do sklepu
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Powrót do listy użytkowników
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Możliwość cofnięcia zamówienia
-    backorderable_default:
-    backordered:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
     backorders_allowed: Cofnięcie zamówienia dozwolone
     balance_due: Do zapłaty
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Adres do zapłatya
     billing: Zapłata
     billing_address: Adres do zapłaty
     both: Oba
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Kalkulator
     calculator_settings_warning: Jeśli zmieniasz typ kalkulatora, musisz najpierw zachować dane przed edycją ustawień.
     cancel: Rezygnuj
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: Nie możesz utworzyć płatności dla zamówienia, jeżeli nie zdefiniowano żadnych metod płatności.
     cannot_create_returns: Nie można utworzyć zwrotu ponieważ w tym zamówieniu nie wysłano żadnego towaru.
     cannot_perform_operation: Nie można wykonać żądanej operacji
     cannot_set_shipping_method_without_address: Nie można ustawić metody wysyłki bez uzupełnienie danych klienta.
     capture: Przechwyć
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kod karty
     card_number: Numer karty
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Typ karty to
     cart: Koszyk
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategorie
     category: Kategoria
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Sprawdź alarmy Spree
     checkout: Złożenie zamówienia
     choose_a_customer: Wybierz klienta
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Wybierz walutę
     choose_dashboard_locale: Wybierz ustawienia regionalne konsoli
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Miasto
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Powiel
     close: Zamknij
     close_all_adjustments: Zamknij wszystkie poprawki
@@ -499,6 +574,7 @@ pl:
     complete: zakończono
     configuration: Konfiguracja
     configurations: Konfiguracje
+    configure_s3: TODO_TRANSLATE
     confirm: Potwierdź
     confirm_delete: Potwierdź usunięcie
     confirm_password: Potwierdzenie hasła
@@ -507,7 +583,7 @@ pl:
     cost_currency: Waluta kosztu
     cost_price: Cena kosztu
     could_not_connect_to_jirafe: Nie można połączyć się z Jirafe w celu synchronizacji danych. Próba zostanie automatycznie ponowiona.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Wystąpił błąd przy próbie zachowania tego przesunięcia magazynowego. Spróbuj ponownie później.
     count_on_hand: Policz dostępne
     countries: Kraje
@@ -528,17 +604,17 @@ pl:
     coupon_code_max_usage: Przekroczono limit wykorzystania kodu kuponu
     coupon_code_not_eligible: Podany kod kuponu nie jest możliwy do wykorzystania z tym zamówieniem
     coupon_code_not_found: Podany kod kuponu nie istnieje. Spróbuj ponownie.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Utwórz
     create_a_new_account: Utwórz nowe konto
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Utworzono
     credit: Kredyt
     credit_card: Karta kredytowa
     credit_cards: Karty kredytowe
     credit_owed: Należny kredyt
-    credits:
+    credits: TODO_TRANSLATE
     currency: Waluta
     currency_decimal_mark: Znak dziesiętny waluty
     currency_settings: Ustawienia waluty
@@ -549,11 +625,11 @@ pl:
     customer: Klient
     customer_details: Dane klienta
     customer_details_updated: Uaktualniono dane klienta
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Przeszukaj bazę klientów
     cut: Wytnij
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: Identyfikator aplikacji
@@ -572,41 +648,60 @@ pl:
       js_format: yy/mm/dd
     date_range: Zakres dat
     default: Domyślny
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Domyślny podatek
     default_tax_zone: Domyślna strefa podatkowe
     delete: Usuń
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Dostawa
     depth: Głębokość
     description: Opis
     destination: Przeznaczenie
     destroy: Zniszcz
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Wielkość rabatu
     dismiss_banner: Dziękuję, ale nie! Nie interesuje mnie to i nie wyświetlaj więcej tej wiadomości
     display: Wyświetl
     display_currency: Wyświetl walutę
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Edycja
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Edycja użytkownika
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: E-mail
     empty: Pusty
     empty_cart: Pusty koszyk
@@ -639,28 +734,30 @@ pl:
           signup: Rejestracja użytkownika
     exceptions:
       count_on_hand_setter: Nie można ręcznie ustawić count_on_hand, ponieważ jest ustawione automatycznie przez wywołanie recalculate_count_on_hand. Zamiast tego użyj `update_column(:count_on_hand, value)`.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Wygaśnięcie
     extension: Rozszerzenie
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Nazwa pliku
     fill_in_customer_info: Uzupełnij informację o kliencie
+    filter: TODO_TRANSLATE
     filter_results: Wyniki filtra
     finalize: Zakończ
-    finalized:
+    finalized: TODO_TRANSLATE
     find_a_taxon: Znajdź takson
     first_item: Koszt pierwszej sztuki
     first_name: Imię
     first_name_begins_with: Imię zaczyna się na
     flat_percent: jednolitr oprocentowanie
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: jednolita stawka (za zamówienie)
     flexible_rate: Stawka elastyczna
     forgot_password: Zapomniałeś hasła?
     free_shipping: Darmowa wysyłka
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Przód
     gateway: Brama
     gateway_config_unavailable: Brak bramy dla środowiska
@@ -684,37 +781,41 @@ pl:
       only_incomplete: Tylko niepełne
       select_locale: Wybierz ustawienia regionalne
       show_only: Pokaż tylko
+      store_translations: TODO_TRANSLATE
       supported_locales: Wspierane ustawienia lokalne
       this_file_language: Polski (PL)
       translations: Tłumaczenia
     icon: Ikona
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Obraz
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Obrazy
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Cena zawiera
     included_price_validation: nie można wybrać dopóki nie ustawiono domyślnej strefy podatkoej
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: Podaj swój e-mail w poniższym formularzu
     insufficient_stock: Zbyt mały stan magazynowy, zostało jedynie %{on_hand}
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Przechwyć adres e-mail
     intercept_email_instructions: Nadpisz e-mail odbiorcy tym adresem.
     internal_name: Nazwa wewnętrzna
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Niepoprawny dostawca płatności.
     invalid_promotion_action: Niepoprawna działanie promocyjne.
     invalid_promotion_rule: Niepoprawna reguła promocyjna.
     inventory: Inwentarz
     inventory_adjustment: Poprawka inwentarza
     inventory_error_flash_for_insufficient_quantity: Pozycja w Twoim koszyku nie jest już dostępna.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: nie jest dostępny dla adresu wysyłki
     iso_name: Nazwa Iso
     item: Pozycja
@@ -727,23 +828,29 @@ pl:
         lt: mniej niż
         lte: mniejszy lub równy
     items_cannot_be_shipped: Nie można było obliczyć stawek wysyłki dla wybranych pozycji.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Scieżka
     last_name: Nazwisko
     last_name_begins_with: Nazwisko zaczyna się na
     learn_more: Dowiedz się więcej
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "Ładuję"
     locale_changed: Zmieniono ustawienia regionalne
     location: Lokalizacja
     lock: Zablokuj
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Zalogowano jako
     logged_in_succesfully: Zalogowano
     logged_out: Wylogowano.
@@ -752,23 +859,26 @@ pl:
     login_failed: Uwierzytelnienie nie powiodło się.
     login_name: Zaloguj
     logout: Wyloguj
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Szukaj podobnych pozycji
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Wykonaj zwrot kosztów
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Cena główna
     match_choices:
       all: Wszystkie
       none: Nic
     max_items: Maksymalna ilość pozycji
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Metaopis
     meta_keywords: Metasłowa kluczowe
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadane
     minimal_amount: Minimalna ilość
     month: Miesiąc
@@ -777,13 +887,13 @@ pl:
     my_account: Moje konto
     my_orders: Moje zamówienia
     name: Nazwa
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Nazwa lub SKU (wprowadź przynajmniej 4 pierwsze litery nazwy produktu)
     new: Nowy
     new_adjustment: Nowa poprawka
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Nowy klient
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nowy obraz
     new_option_type: Nowy typ opcji
     new_order: Nowe zamówienie
@@ -792,14 +902,15 @@ pl:
     new_payment_method: Nowa metoda płatności
     new_product: Nowy produkt
     new_promotion: Nowa promocja
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nowa własność
     new_prototype: Nowy prototyp
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Nowa autoryzacja powrotna
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Nowa kategoria wysyłki
     new_shipping_method: Nowa metoda wysyłki
     new_state: Nowy stan
@@ -816,24 +927,30 @@ pl:
     new_zone: Nowa strefa
     next: Następny
     no_actions_added: Nie dodano działania
-    no_payment_found:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: Brak zawieszonych płatności
     no_products_found: Nie znaleziono produktów
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: Nie znaleziono %{resource}
     no_results: Brak wyników
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Nie dodano reguł
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Nie wprowadzono żadneych danych śledzących.
     none: Brak
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Zwykład ilość
     not: nie
     not_available: Niedostępne
     not_enough_stock: Zbyt mała ilość towaru w lokalizacji źródłowej, by dokończyć to przeniesienie.
     not_found: Nie znaleziono %{resource}
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Produkt został powielony
       product_deleted: Produkt został usunięty
@@ -841,7 +958,7 @@ pl:
       product_not_deleted: Nie można było usunąć produktu
       variant_deleted: Odmiana została usunięta
       variant_not_deleted: Nie można było usunąć odmiany
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: na stanie
     open: Otwórz
     open_all_adjustments: Otwórz wszystkie poprawki
@@ -856,36 +973,37 @@ pl:
     or_over_price: "%{price} lub więcej"
     order: Zamówienie
     order_adjustments: Poprawki zamówienia
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Szczegóły zamówienia
     order_email_resent: Wysłano ponownie e-mail z zamówieniem
     order_information: Informacja o zamówieniu
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Szanowny Kliencie,\n
         instructions: Twoje zamówienie zostało anulowane. Zachowaj na wszelki wypadek tę infromację.
         order_summary_canceled: Podsumowanie zamówienia [ANULOWANO]
         subject: Anulowanie zamówienia
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
         thanks: Dziękujemy za zakupy.
-        total:
+        total: TODO_TRANSLATE
     order_not_found: Nie mogliśmy odnaleźć Twojego zamówienia. Prosimy spróbować ponownie.
-    order_number:
+    order_number: TODO_TRANSLATE
     order_populator:
       out_of_stock: Brak %{item} w magazynie.
       please_enter_reasonable_quantity: Podaj rozsądną ilość.
-      selected_quantity_not_available: ! 'wybrana dla %{item} nie jest dostępna.'
+      selected_quantity_not_available: wybrana dla %{item} nie jest dostępna.
     order_processed_successfully: Twoje zamówienie zostało przetworzone
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: adres
       awaiting_return: czeka na zwrot
@@ -903,12 +1021,14 @@ pl:
     order_total: Całkowita wartość zamówienia
     order_updated: Uaktualniono zamówienie
     orders: Zamówienia
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Brak w magazynie
     overview: Przegląd
     package_from: paczka z
     pagination:
+      first: TODO_TRANSLATE
       next_page: następna strona »
+      previous: TODO_TRANSLATE
       previous_page: "« poprzednia strona"
       truncate: "…"
     password: Hasło
@@ -916,11 +1036,11 @@ pl:
     path: "Ścieżka"
     pay: zapłać
     payment: Płatność
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Informacja o płatności
     payment_method: Metoda płatności
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Metody płatności
     payment_processing_failed: Nie udało się przetworzyć płatności, sprawdź podane przez Ciebie dane
     payment_processor_choose_banner_text: Jeśli potrzebujesz pomocy przy wyborze sposobu przetwarzania płatności, odwiedź
@@ -938,22 +1058,23 @@ pl:
       void: nieważny
     payment_updated: Płatność uaktualniona
     payments: Płatności
-    pending:
+    pending: TODO_TRANSLATE
     percent: procent
     percent_per_item: Procent na pozycję
     permalink: Permalink
     phone: Telefon
     place_order: Złóż zamówienie
     please_define_payment_methods: Zdefiniuj najpierw jakieś metody płatności.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Coś poszło źle. Spróbuj ponownie dodać pozycję.
     powered_by: Działa dzięki
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Prezentacja
     previous: Poprzedni
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Cena
     price_range: Zakres cen
     price_sack: Worek cenowy
@@ -965,10 +1086,10 @@ pl:
     product_properties: Własności produktu
     product_rule:
       choose_products: Wybierz produkty
-      label:
+      label: TODO_TRANSLATE
       match_all: wszystkie
       match_any: co najmniej jeden
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Z grupy produktów
         manual: Wybierz ręcznie
@@ -980,19 +1101,24 @@ pl:
         description: Tworzy poprawkę kredytu promocyjnego w zamówieniu
         name: Utwórz poprawkę
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Zapełnia koszyk określoną ilością odmiany
         name: Utwórz pozycje linii
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Działania
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Dopasuj do wszystkich tych reguł
         any: Dopasuj do którejkolwiek reguły
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Reguła promocji
     promotion_rule_types:
       first_order:
@@ -1005,27 +1131,27 @@ pl:
         description: Klient musiał odwiedzić konkretną stronę
         name: Strona przekierowująca
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Zamówienie zawiera określone produkty
         name: Produkt(y)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Dostępne tylko dla okreśłonych użytkowników
         name: Użytkownik
       user_logged_in:
         description: Dostępne tylko dla zalogowanych użytkowników
         name: Zalogowany użytkownik
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promocje
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Właściwości
     property: Własność
     prototype: Prototyp
@@ -1042,41 +1168,43 @@ pl:
     receive: Odbierz
     receive_stock: Odbierz magazyn
     received: Odebrane
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Odnośnik
+    reference_contains: TODO_TRANSLATE
     refund: Zwrot funduszy
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Zarejestruj
     registration: Rejestracja
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Zapamiętaj mnie
     remove: Usuń
     rename: Zmień nazwę
-    report:
+    report: TODO_TRANSLATE
     reports: Raporty
+    resellable: TODO_TRANSLATE
     resend: Prześlij ponownie
     reset_password: Ponownie ustaw moje hasło
     response_code: Kod odpowiedzi
@@ -1084,16 +1212,17 @@ pl:
     resumed: Wznowiono
     return: zwróć
     return_authorization: Autoryzacja zwrotu
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Uaktualniono autoryzację zwrotu
     return_authorizations: Autoryzacje zwrotu
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Zwracana ilość
     returned: Zwrócono
     returns: Zwroty
@@ -1104,14 +1233,20 @@ pl:
     rma_credit: Kredyt RMA
     rma_number: Numer RMA
     rma_value: Wartość RMA
+    role_id: TODO_TRANSLATE
     roles: Role
     rules: Reguły
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
     safe: Bezpieczne
     sales_total: Sprzedaż razem
     sales_total_description: Sprzedaż razem dla wszystkich zamówień
     sales_totals: Suma sprzedaży
     save_and_continue: Zachowaj i kontynuuj
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: Nie
     say_yes: Tak
     scope: Zakres
@@ -1121,11 +1256,11 @@ pl:
     secure_connection_type: Typ bezpiecznego połączenia
     security_settings: Ustawienia bezpieczeństwa
     select: Wybierz
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Wybierz z prototypu
     select_stock: Wybierz magazyn
-    selected_quantity_not_available: ! 'wybrana dla %{item} nie jest dostępna.'
+    selected_quantity_not_available: wybrana dla %{item} nie jest dostępna.
     send_copy_of_all_mails_to: Wyślij kopię wszystkich wiadomości do
     send_mails_as: Wyślij wiadomości jako
     server: Serwer
@@ -1135,8 +1270,9 @@ pl:
     ship_address: Adres wysyłki
     ship_total: Wartość wysyłki
     shipment: Wysyłka
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Szanowny Kliencie,\n
@@ -1149,13 +1285,13 @@ pl:
     shipment_state: Stan wysyłki
     shipment_states:
       backorder: cofnięcie zamówienia
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: częściowe
       pending: oczekujące
       ready: gotowe
       shipped: wysłane
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Wysyłki
     shipped: Wysłane
     shipping: Koszt wysyłki
@@ -1169,7 +1305,11 @@ pl:
     shipping_method: Metoda wysyłki
     shipping_methods: Metody wysyłki
     shipping_price_sack: Worek cenowy
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: Koszyk
     show: Pokaż
@@ -1179,49 +1319,61 @@ pl:
     show_only_considered_risky: Pokaż tylko zamówienia ryzykowne
     show_rate_in_label: Pokaż stawkę w etykiecie
     sku: SKU
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: "Źródło"
     special_instructions: Specjalne instrukcje
     split: Podziel
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Był problem z Twoimi informacjami, dotyczącymi płatności. Sprawdź dane i spróbuj ponownie.
     ssl:
-      change_protocol: "Proszę zmienić protokół na HTTP (zamiast HTTPS) i powtórzyć żądanie"
+      change_protocol: Proszę zmienić protokół na HTTP (zamiast HTTPS) i powtórzyć żądanie
     start: Start
+    start_date: TODO_TRANSLATE
     state: Stan
     state_based: Stan oparty na
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Stany
     states_required: Wymagane stany
     status: Status
@@ -1229,7 +1381,7 @@ pl:
     stock_location: Lokalizacja magazynu
     stock_location_info: Informacja o lokalizacji magazynu
     stock_locations: Lokalizacje magazynów
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Zarządzanie magazynami
     stock_management_requires_a_stock_location: Aby zarządzać magazynami utwórz lokalizację magazynu.
     stock_movements: Przesunięcia magazynowe
@@ -1243,28 +1395,30 @@ pl:
     street_address_2: Adres ulicy (cd.)
     subtotal: Suma częściowa
     subtract: Odejmij
-    success:
+    success: TODO_TRANSLATE
     successfully_created: Utworzono %{resource}!
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: Usunięto %{resource}!
     successfully_signed_up_for_analytics: Zarejestrowano w Analityce Spree
     successfully_updated: Uaktualniono %{resource}!
-    summary:
+    summary: TODO_TRANSLATE
     tax: Podatek
     tax_categories: Kategorie podatkowe
     tax_category: Kategoria podatkowa
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: By ułatwić wyliczenia stawki podatku podane są w notacji dziesiętnej (np. jeśli stawka wynosi 5% wprowadź 0.05)
     tax_rates: Stawki podatku
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Takson
     taxon_edit: Edycja taksona
     taxon_placeholder: Dodaj takson
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taksonomie
     taxonomy: Taksonomia
     taxonomy_edit: Edycja taksonomii
@@ -1273,6 +1427,9 @@ pl:
     taxons: Taksony
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Gratulacje!
         message: Twoje ustawienia poczty są poprawne.
@@ -1281,24 +1438,24 @@ pl:
     thank_you_for_your_order: Dziękujemy za Twoje zainteresowanie. Wydrukuj kopię tej strony na wszelki wypadek.
     there_are_no_items_for_this_order: W zamówieniu brak pozycji. Aby kontynuować, dodaj towar.
     there_were_problems_with_the_following_fields: Wystąpiły problemy z następującymi polami
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Miniatura
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Czas
     to_add_variants_you_must_first_define: Aby dodać odmiany musisz najpierw zdefiniować
     total: razem
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: "Śledzenie przesyłki"
     tracking_number: Numer przesyłki
     tracking_url: URL do śledzenia przesyłki
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Przeniesienie z
     transfer_stock: Przenieś magazyn
     transfer_to_location: Przenieś do
@@ -1306,7 +1463,7 @@ pl:
     type: Typ
     type_to_search: Wpisz wyszukiwaną frazę
     unable_to_connect_to_gateway: Nie można połączyć się z bramą.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Poniżej %{price}
     unlock: Odblokuj
     unrecognized_card_type: Nierozpoznany typ karty
@@ -1314,9 +1471,11 @@ pl:
     update: Uaktualnij
     updating: Uaktualnienie
     usage_limit: Limit wykorzystania
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Taki sam jak do zapłaty
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Wprowadź nową kartę
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Wykorzystaj Amazon S3 do obrazów
     user: Użytkownik
     user_rule:
@@ -1324,12 +1483,13 @@ pl:
     users: Użytkownicy
     validation:
       cannot_be_less_than_shipped_units: nie może być mniejsza niż liczba wysłanych jednostek.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: przekracza dostępny stan magazynowy. Upewnij się, że podano właściwe ilości.
       is_too_large: to zbyt dużo -- dostępny stan w magazynie nie może pokryć zapotrzebowania!
       must_be_int: musi być liczbą całkowitą
       must_be_non_negative: musi być dodatnie
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Wartość
     variant: Odmiana
     variant_placeholder: Wybierz odmianę
@@ -1348,3 +1508,10 @@ pl:
     zipcode: Kod pocztowy
     zone: Strefa
     zones: Strefy
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,4 +1,6 @@
+---
 pt-BR:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ pt-BR:
         state: Estado
         zipcode: CEP
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,7 +26,7 @@ pt-BR:
         name: Nome
         numcode: Código ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tipo de Cartão
         month: Mês
         name: Nome no Cartão
@@ -72,6 +74,7 @@ pt-BR:
         zipcode: CEP
       spree/payment:
         amount: Valor
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nome
       spree/product:
@@ -95,6 +98,7 @@ pt-BR:
         starts_at: Início em
         usage_limit: Limite de uso
       spree/promotion_category:
+        code: TODO_TRANSLATE
         name: Categorias de Promoções
       spree/property:
         name: Nome
@@ -105,17 +109,19 @@ pt-BR:
         amount: Quantidade
       spree/role:
         name: Nome
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Abreviação
         name: Nome
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
         mail_from_address: E-mail para envio de mensagens
         meta_description: Descrição
@@ -157,16 +163,16 @@ pt-BR:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
@@ -179,26 +185,32 @@ pt-BR:
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Endereço
         other: Endereços
@@ -208,7 +220,7 @@ pt-BR:
       spree/credit_card:
         one: Cartão de Crédito
         other: Cartões de Crédito
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Unidade de Inventário
         other: Unidades de Inventário
@@ -218,7 +230,7 @@ pt-BR:
       spree/option_type:
         one: Tipo de opção
         other: Tipos de opção
-      spree/option_value:
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Pedido
         other: Pedidos
@@ -234,16 +246,16 @@ pt-BR:
       spree/promotion:
         one: Promoção
         other: Promoções
-      spree/promotion_category:
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Propriedade
         other: Propriedades
       spree/prototype:
         one: Protótipo
         other: Protótipos
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Autorização de Retorno
         other: Autorização de Retornos
@@ -251,6 +263,8 @@ pt-BR:
         one: Razão de retorno
         other: Razões de retorno
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Função
         other: Funções
       spree/shipment:
@@ -265,11 +279,11 @@ pt-BR:
       spree/state:
         one: Estado
         other: Estados
-      spree/state_change:
+      spree/state_change: TODO_TRANSLATE
       spree/stock_location:
         one: Depósito
         other: Depósito
-      spree/stock_movement:
+      spree/stock_movement: TODO_TRANSLATE
       spree/stock_transfer:
         one: Transferência de estoque
         other: Transferências de estoque
@@ -280,8 +294,8 @@ pt-BR:
         one: Taxa do Imposto
         other: Taxa dos Impostos
       spree/taxon:
-        one: Árvore de Categorias
-        other: Árvores de Categorias
+        one: "Árvore de Categorias"
+        other: "Árvores de Categorias"
       spree/taxonomy:
         one: Categoria
         other: Categorias
@@ -297,6 +311,9 @@ pt-BR:
       spree/zone:
         one: Zona
         other: Zonas
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Sua conta foi confirmada com sucesso. Você já está logado.
@@ -335,6 +352,7 @@ pt-BR:
     user_sessions:
       signed_in: Login realizado com sucesso.
       signed_out: Logout realizado com sucesso.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: já foi confirmado
@@ -343,12 +361,30 @@ pt-BR:
       not_saved:
         one: '1 erro impediu %{resource} de ser salvo:'
         other: "%{count} erros impediram o %{resource} de ser salvo:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abreviação
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Conta
     account_updated: Conta atualizada!
     action: Ação
@@ -361,7 +397,7 @@ pt-BR:
       list: Listar
       listing: Listando
       new: Novo
-      refund:
+      refund: TODO_TRANSLATE
       save: Salvar
       update: Atualizar
     activate: Activate
@@ -383,11 +419,16 @@ pt-BR:
     add_to_cart: Adicionar ao Carrinho
     add_variant: Adicionar Variante
     additional_item: Item Adicional
+    address: TODO_TRANSLATE
     address1: Endereço
     address2: Endereço (cont.)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Ajuste
     adjustment_amount: Valor
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Ajuste foi salvo com sucesso!
     adjustment_successfully_opened: Ajuste foi aberto com sucesso!
     adjustment_total: Total de Ajustes
@@ -404,7 +445,7 @@ pt-BR:
         prototypes: Protótipos
         reports: Relatórios
         taxonomies: Categorias
-        taxons:  Árvores de Categorias
+        taxons: "Árvores de Categorias"
         users: Usuários
       user:
         account: Conta
@@ -416,14 +457,14 @@ pt-BR:
         orders: Pedidos
         user_information: Informações do usuário
     administration: Administração
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Concordo com a politica de privacidade
     agree_to_terms_of_service: Concordo com os termos de serviço
     all: Todos
     all_adjustments_closed: Todos os ajustes foram fechados!
     all_adjustments_opened: Todos os ajustes foram abertos com sucesso!
     all_departments: Todos Departamentos
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Permitir SSL em desenvolvimento e teste
     allow_ssl_in_production: Permitir SSL em Produção
     allow_ssl_in_staging: Permitir SSL em Staging
@@ -439,70 +480,104 @@ pt-BR:
     analytics_desc_list_4: Completamente gratuito!
     analytics_trackers: Rastreadores de Análise
     and: E
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Tem Certeza?
     are_you_sure_delete: Tem certeza que deseja remover este registro?
     associated_adjustment_closed: O ajuste relacionado está fechado e não será recalculado. Você que deixar o ajuste em aberto?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Falha na Autorização
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Disponível em
     average_order_value: Média de valor por compra
     avs_response: Resposta do AVS
     back: Voltar
-    back_end:
+    back_end: TODO_TRANSLATE
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
     back_to_payment: Voltar para lista de Pagamentos
-    back_to_resource_list: "Voltar para lista de %{resource}"
-    back_to_rma_reason_list:
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: Voltar para lista de %{resource}
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Voltar Para a Loja
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Voltar a lista de usuários
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Aceita pedido pendente
-    backorderable_default:
-    backordered:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
     backorders_allowed: permite pedido em espera
     balance_due: Saldo Devedor
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Endereço da Conta
     billing: Faturamento
     billing_address: Endereço de Cobrança
     both: Ambos
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculadora
     calculator_settings_warning: Se você alterar o tipo de calculadora, deve-se primeiro confirmar a alteração antes de editar as configurações.
     cancel: Cancelar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: Você não pode efetuar o pagamento sem definir a forma de pagamento.
     cannot_create_returns: Não é possível criar um retorno para esse pedido, pois ele ainda não foi enviado.
     cannot_perform_operation: Não foi possível realizar esta operação
     cannot_set_shipping_method_without_address: Insira os detalhes do cliente para escolher o método de envio
     capture: Copiar
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Código do Cartão
     card_number: Número do Cartão
     card_type: Tipo do Cartão
     card_type_is: O Tipo do Cartão é
     cart: Carrinho
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categorias
     category: Categoria
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Receber alertas do Spree
     checkout: Finalizar Compra
     choose_a_customer: Escolha um cliente
     choose_a_taxon_to_sort_products_for: Selecione uma árvore de categorias para ordenar os produtos
     choose_currency: Escolha moeda
     choose_dashboard_locale: Escolha idioma do painel
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Cidade
     clear_cache: Limpar cache
     clear_cache_ok: Cache foi limpado
     clear_cache_warning: Atenção ao limpar o cache
-    click_and_drag_on_the_products_to_sort_them:
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Cópia
     close: Fechar
     close_all_adjustments: Fechar todos os Ajustes
@@ -511,6 +586,7 @@ pt-BR:
     complete: Completo
     configuration: Configuração
     configurations: Configurações
+    configure_s3: TODO_TRANSLATE
     confirm: Confirme
     confirm_delete: Confirmar Deleção
     confirm_password: Confirmação da Senha
@@ -519,7 +595,7 @@ pt-BR:
     cost_currency: Moeda
     cost_price: Preço de Custo
     could_not_connect_to_jirafe: Não foi possivel se conectar ao Jirafe para sincronizar dados. Será feita outra tentativa mais tarde.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Ocorreu um problema ao salvar a transferência. Por favor tente novamente.
     count_on_hand: Disponíveis
     countries: Países
@@ -527,10 +603,10 @@ pt-BR:
     country_based: País de Origem
     country_name: Nome
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Cupom
     coupon_code: Código do Cupom
     coupon_code_already_applied: O cupom já foi adicionado ao pedido
@@ -540,29 +616,29 @@ pt-BR:
     coupon_code_max_usage: O limite de uso do cupom foi excedido
     coupon_code_not_eligible: O cupom não é válido para esse pedido
     coupon_code_not_found: O código do cupom não existe. Por favor tente novamente
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Criar
     create_a_new_account: Criar uma Nova Conta
     create_new_order: Criar novo pedido
-    create_reimbursement:
+    create_reimbursement: TODO_TRANSLATE
     created_at: Criado
     credit: Crédito
     credit_card: Cartão de Crédito
     credit_cards: Cartões de Crédito
     credit_owed: Crédito Devedor
-    credits:
+    credits: TODO_TRANSLATE
     currency: Moeda
     currency_decimal_mark: Marca decimal da moeda
     currency_settings: Configurações de Moeda
     currency_symbol_position: Colocar o símbolo da moeda antes ou depois da quantia?
     currency_thousands_separator: Separador de milhares da moeda
     current: Atual
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Cliente
     customer_details: Detalhes do Cliente
     customer_details_updated: Os Detalhes do Cliente Foram Atualizados
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Busca de Clientes
     cut: Recortar
     cvv_response: Resposta do CVV
@@ -584,11 +660,15 @@ pt-BR:
       js_format: dd/mm/yy
     date_range: Entre as Datas
     default: Padrão
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Imposto Padrão
     default_tax_zone: Imposto de Zona Padrão
     delete: Apagar
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Entrega
     depth: Profundidade
     description: Descrição
@@ -599,26 +679,41 @@ pt-BR:
     dismiss_banner: Não, obrigado! Eu não estou interessado, não mostre essa mensagem novamente!
     display: Mostrar
     display_currency: Mostrar Moeda
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Editar
-    editing_resource: "Editando %{resource}"
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: Editando %{resource}
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editando Usuário
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
         no_matching_taxons: Nenhuma árvore de categoria correspondente
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Vazio
     empty_cart: Esvaziar o Carrinho
@@ -651,28 +746,30 @@ pt-BR:
           signup: Usuário Cadastrado
     exceptions:
       count_on_hand_setter: Não pode setar coun_on_hand manualmente, esse valor é automaticamente gerado do método recalculate_count_on_hand. Por favor use `update_column(:count_on_hand, value)`.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Validade
     extension: Extensão
     failed_payment_attempts: Tentativas fracassadas de pagamento
     filename: Nome do arquivo
     fill_in_customer_info: Por favor insira as informações do cliente
+    filter: TODO_TRANSLATE
     filter_results: Filtrar resultados
     finalize: Finalizar
-    finalized:
+    finalized: TODO_TRANSLATE
     find_a_taxon: Procurar uma árvore de categorias
     first_item: Custo do primeiro item
     first_name: Nome
     first_name_begins_with: Primeiro nome começa com
     flat_percent: Porcentagem
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Aliquota por pedido
     flexible_rate: Aliquita flexivel
     forgot_password: Esqueci a senha
     free_shipping: Entrega grátis
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway não disponível para este ambiente
@@ -696,37 +793,41 @@ pt-BR:
       only_incomplete: Apenas incompletas
       select_locale: Selecione o idioma
       show_only: Mostrar apenas
+      store_translations: TODO_TRANSLATE
       supported_locales: Idiomas suportados
       this_file_language: Português (BR)
       translations: Traduções
     icon: "Ícone"
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Imagem
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Imagens
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
     inactive: Inativo
-    incl:
+    incl: TODO_TRANSLATE
     included_in_price: Incluso no preço
     included_price_validation: Não pode ser selecionado a menos que você tenha escolhido zona de imposto padrão
     incomplete: Incompleto
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Preencha o formulário abaixo e enviaremos instruções de como resetar sua senha por email:'
     insufficient_stock: Estoque insuficiente, apenas %{on_hand} em estoque
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Interceptar endereço de email
     intercept_email_instructions: Interceptar Instruções de Email
     internal_name: Nome interno
     invalid_credit_card: Cartão de Crédito Inválido
-    invalid_exchange_variant:
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Provedor de pagamento inválido
     invalid_promotion_action: Ação de promoção inválida
     invalid_promotion_rule: Regra de promoção inválida
     inventory: Inventário
     inventory_adjustment: Ajuste de Inventário
     inventory_error_flash_for_insufficient_quantity: Um item no seu carrinho está indisponível
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: Não está disponível para endereço de entrega
     iso_name: Nome ISO
     item: Item
@@ -739,7 +840,7 @@ pt-BR:
         lt: Menor que
         lte: Maior ou igual que
     items_cannot_be_shipped: Estamos impossibilitados de enviar os itens selecionados para seu endereço de entrega. Por favor, escolha outro endereço.
-    items_in_rmas:
+    items_in_rmas: TODO_TRANSLATE
     items_reimbursed: Itens reembolsados
     items_to_be_reimbursed: Itens a ser reembolsados
     jirafe: Jirafe
@@ -749,8 +850,14 @@ pt-BR:
     last_name_begins_with: 'Sobrenome Começa Com:'
     learn_more: Aprenda Mais
     lifetime_stats: Histórico
-    line_item_adjustments:
+    line_item_adjustments: TODO_TRANSLATE
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Carregando
     locale_changed: Local Alterado
     location: Local
@@ -766,10 +873,13 @@ pt-BR:
     logout: Sair
     logs: Logs
     look_for_similar_items: Procurar Artigos Similares
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Extornar
-    make_sure_the_above_reimbursement_amount_is_correct:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
     manage_promotion_categories: Gerenciar categoria de promoções
-    manage_variants:
+    manage_variants: TODO_TRANSLATE
     manual_intervention_required: Intervenção manual necessária
     master_price: Preço Principal
     match_choices:
@@ -777,10 +887,10 @@ pt-BR:
       none: Nenhum
     max_items: Artigos máximos
     member_since: Membro desde
-    memo:
+    memo: TODO_TRANSLATE
     meta_description: Descrição
     meta_keywords: Palavras-Chave
-    meta_title: 
+    meta_title: TODO_TRANSLATE
     metadata: Metadados
     minimal_amount: Quantidade Mínima
     month: Mês
@@ -795,7 +905,7 @@ pt-BR:
     new_adjustment: Novo Ajuste
     new_country: Novo país
     new_customer: Novo Cliente
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nova Imagem
     new_option_type: Novo Tipo de Opção
     new_order: Novo Pedido
@@ -811,7 +921,8 @@ pt-BR:
     new_refund_reason: Criar razão para reembolso
     new_return_authorization: Nova Autorização de Retorno
     new_rma_reason: Nova razão para autorização de retorno
-    new_shipment_at_location:
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Nova Categoria de Entrega
     new_shipping_method: Novo Método de Entrega
     new_state: Novo Estado
@@ -828,15 +939,21 @@ pt-BR:
     new_zone: Nova Zona
     next: Próximo
     no_actions_added: Nenhuma ação adicionada
+    no_orders_found: TODO_TRANSLATE
     no_payment_found: Nenhum pagamento encontrado
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: Sem pagamentos pendentes
     no_products_found: Não existem produtos
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: Não existe %{resource}
     no_results: Não existem resultados
     no_returns_found: Nenhum retorno encontrado
     no_rules_added: Nenhuma regra adicionada
     no_shipping_method_selected: Nenhum método de entrega selecionado
-    no_state_changes:
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Detalhes de localização não foram fornecidos
     none: Nenhum
     none_selected: Nenhum selecionado
@@ -845,7 +962,7 @@ pt-BR:
     not_available: Indisponível
     not_enough_stock: Não há inventório suficiente no estoque para complete essa transferência
     not_found: "%{resource} não encontrado"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Produto Clonado
       product_deleted: Produto Deletado
@@ -874,6 +991,7 @@ pt-BR:
     order_details: Detalhes do Pedido
     order_email_resent: Email de confirmação reenviado
     order_information: Informações do pedido
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Caro Cliente,\n
@@ -892,8 +1010,12 @@ pt-BR:
         total: Total
     order_not_found: Não conseguimos encontrar seu pedido. Por favor tente novamente.
     order_number: Número do Pedido %{number}
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Seu pedido foi processado com sucesso.
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: Endereço
       awaiting_return: Aguardando Retorno
@@ -901,7 +1023,7 @@ pt-BR:
       cart: Carrinho
       complete: Completo
       confirm: Confirmação
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: Entrega
       payment: Pagamento
       resumed: Resumido
@@ -911,12 +1033,14 @@ pt-BR:
     order_total: Total do Pedido
     order_updated: Pedido Atualizado
     orders: Pedidos
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Esgotado
     overview: Resumo
     package_from: pacote de
     pagination:
+      first: TODO_TRANSLATE
       next_page: Próxima Página »
+      previous: TODO_TRANSLATE
       previous_page: "« Página Anterior"
       truncate: "…"
     password: Senha
@@ -953,15 +1077,16 @@ pt-BR:
     phone: Telefone
     place_order: Fazer Pedido
     please_define_payment_methods: Por favor, defina algum método de pagamento.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Algo está trrado. Tente adicionar o item novamente.
     powered_by: Feito por
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Apresentação
     previous: Anterior
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Preço
     price_range: Faixa de Preço
     price_sack: Preço da Embalagem
@@ -973,7 +1098,7 @@ pt-BR:
     product_properties: Propriedades do Produto
     product_rule:
       choose_products: Escolher Produtos
-      label:
+      label: TODO_TRANSLATE
       match_all: Todos
       match_any: Pelo Menos Um
       match_none: Nenhum
@@ -994,13 +1119,18 @@ pt-BR:
         description: Preencher o carrinho com a quantidade especificada de variantes
         name: Criar Itens
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Ações das Promoções
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Combinar todas regras
         any: Combinar algumas regras
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Regras da Promoção
     promotion_rule_types:
       first_order:
@@ -1013,27 +1143,27 @@ pt-BR:
         description: O cliente deve visitar a página especificada
         name: Página de Destino
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Pedido inclui produto(s) específico(s)
         name: Produto(s)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Disponível apenas para usuários específicos
         name: Usuários
       user_logged_in:
         description: Disponível apenas para usuários logados
         name: Usuário Logado
-    promotion_uses:
+    promotion_uses: TODO_TRANSLATE
     promotionable: Em promoção
     promotions: Promoções
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Propriedades
     property: Propriedade
     prototype: Protótipo
@@ -1044,47 +1174,49 @@ pt-BR:
     quantity: Quantidade
     quantity_returned: Quantidade Retornada
     quantity_shipped: Quantidade Enviada
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Taxa
     reason: Razões
     receive: Receber
     receive_stock: Receber estoque
     received: Recebido
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Referência
+    reference_contains: TODO_TRANSLATE
     refund: Restituição
-    refund_amount_must_be_greater_than_zero:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
     refund_reasons: Razões para restituição
-    refunded_amount:
-    refunds:
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registrar-se
     registration: Registro
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
     reimbursement_types: Tipos de restituição
-    reimbursements:
-    reject:
-    rejected:
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Lembrar
     remove: Remover
     rename: Renomear
-    report:
+    report: TODO_TRANSLATE
     reports: Relatórios
+    resellable: TODO_TRANSLATE
     resend: Reenviar
     reset_password: Restaurar minha senha
     response_code: Código de Resposta
@@ -1095,26 +1227,33 @@ pt-BR:
     return_authorization_reasons: Razões para autorização de devolução
     return_authorization_updated: Autorização de devolução atualizada
     return_authorizations: Autorizações de devolução
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Quantidade a ser devolvida
     returned: Devolvido
-    returns:
+    returns: TODO_TRANSLATE
     review: Revisar
     risk: Risco
     risk_analysis: Análise de Risco
-    risky:
+    risky: TODO_TRANSLATE
     rma_credit: Crédito RMA
     rma_number: Número RMA
     rma_value: Valor RMA
+    role_id: TODO_TRANSLATE
     roles: Funções
     rules: Regras
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Total de Vendas
     sales_total_description: Total de vendas por todos os pedidos
     sales_totals: Total de vendas
@@ -1129,10 +1268,11 @@ pt-BR:
     secure_connection_type: Tipo de conexão segura
     security_settings: Configurações de segurança
     select: Selecionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Selecionar a partir de protótipo
     select_stock: Selecione estoque
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Enviar cópias de todos emails para
     send_mails_as: Enviar email como
     server: Servidor
@@ -1142,8 +1282,9 @@ pt-BR:
     ship_address: Endereço da entrega
     ship_total: Total no envio
     shipment: Distribuição
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Caro cliente,\n
@@ -1161,8 +1302,8 @@ pt-BR:
       pending: Pendente
       ready: Pronta
       shipped: Enviado
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Entregas
     shipped: Despachado
     shipping: Entrega
@@ -1176,7 +1317,11 @@ pt-BR:
     shipping_method: Método de entrega
     shipping_methods: Métodos de entrega
     shipping_price_sack: Preço
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrinho de compra
     show: Mostrar
@@ -1186,57 +1331,69 @@ pt-BR:
     show_only_considered_risky: Mostrar apenas os considerados de Risco
     show_rate_in_label: Mostrar valor no label
     sku: SKU
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Fonte
     special_instructions: Instruções especiais
     split: Dividir
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Existe um problema com seus dados de pagamento. por favor, verifique seus dados e tente novamente.
     ssl:
       change_protocol: Por favor troque para HTTP (ao invés de HTTPS) e faça essa requisição novamente.
     start: Início
+    start_date: TODO_TRANSLATE
     state: Estado
     state_based: Estado de Origem
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Estados
     states_required: Estados obrigatórios
     status: Status
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Local de Estoque
     stock_location_info: Local de estoque
     stock_locations: Locais de estoque
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Gerenciamento de estoque
     stock_management_requires_a_stock_location: Por favor, crie um local de estoque para poder gerenciar o estoque.
     stock_movements: Movimentos de estoque
@@ -1252,52 +1409,57 @@ pt-BR:
     subtract: Subtrair
     success: Sucesso
     successfully_created: "%{resource} Foi criado com sucesso!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} Foi removido com sucesso!"
     successfully_signed_up_for_analytics: Registrado com sucesso no Spree Analytics
     successfully_updated: "%{resource} Foi atualizado com sucesso!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Imposto
     tax_categories: Categorias de imposto
     tax_category: Categoria de imposto
     tax_code: Código do imposto
-    tax_included:
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Valores das taxas são em décimos. (ex. se o valor é 5% insira 0.05)
     tax_rates: Aliquotas de imposto
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Categoria
     taxon_edit: Editar categoria
     taxon_placeholder: Adicionar uma árvore de categorias
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Categorias
     taxonomy: Categoria
     taxonomy_edit: Editar Categoria
     taxonomy_tree_error: A modificação não foi aceita e a árvore retornou ao seu estado anterior, por favor tente novamente.
     taxonomy_tree_instruction: "* Clique com o botão direito sobre um nó da árvore para ver o menu."
-    taxons: Árvores de Categorias
+    taxons: "Árvores de Categorias"
     test: Teste
     test_mailer:
-      test_email: Email de Teste
       greeting: Parabéns
       message: Se você recebeu esse email, suas configurações estão corretas!
       subject: Email de teste!
+      test_email:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
     test_mode: Modo de teste
     thank_you_for_your_order: Obrigado por sua compra. Por favor, imprima uma cópia desta página de confirmação para seu controle.
     there_are_no_items_for_this_order: Não existem itens para esse pedido. Por favor adicione um item ao pedido para continuar.
     there_were_problems_with_the_following_fields: 'Existem problemas com os seguintes campos:'
     this_order_has_already_received_a_refund: Esse pedindo já recebeu um reembolso
     thumbnail: Miniatura
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Horário
     to_add_variants_you_must_first_define: Para adicionar variantes você deve primeiro definir
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
     total_price: Preço total
     total_sales: Total em compras
     track_inventory: Rastrear Inventário
@@ -1313,7 +1475,7 @@ pt-BR:
     type: Tipo
     type_to_search: Tipo de busca
     unable_to_connect_to_gateway: Impossível se conectar no gateway
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Sob %{price}
     unlock: Destravar
     unrecognized_card_type: Tipo de cartão desconhecido
@@ -1323,7 +1485,9 @@ pt-BR:
     usage_limit: Limite de uso
     use_app_default: Usar Padrão da Aplicação
     use_billing_address: Usar endereço de cobrança
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Usar um novo cartão
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Usar Amazon S3 para imagens
     user: Usuário
     user_rule:
@@ -1331,12 +1495,13 @@ pt-BR:
     users: Usuários
     validation:
       cannot_be_less_than_shipped_units: Não pode ser menor que o número de unidades enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: excede estoque disponível. Por favor confira se os items tem uma quantia válida.
       is_too_large: "É Muito Grande -- Quantidade em estoque não consegue cobrir este pedido!"
       must_be_int: Deve ser um inteiro
       must_be_non_negative: Deve ser um valor positivo ou zero
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Valor
     variant: Variante
     variant_placeholder: Escolha um produto
@@ -1355,3 +1520,10 @@ pt-BR:
     zipcode: Código zip
     zone: Zona
     zones: Zonas
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,4 +1,6 @@
+---
 pt:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ pt:
         state: Estado
         zipcode: Código Postal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,545 +26,684 @@ pt:
         name: Nome
         numcode: Código ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tipo
         month: Mês
-        name:
+        name: TODO_TRANSLATE
         number: Número
-        verification_value:
-        year:
+        verification_value: TODO_TRANSLATE
+        year: TODO_TRANSLATE
       spree/inventory_unit:
-        state:
+        state: TODO_TRANSLATE
       spree/line_item:
         price: Preço
         quantity: Quantidade
       spree/option_type:
         name: Nome
-        presentation:
+        presentation: TODO_TRANSLATE
       spree/order:
-        checkout_complete:
-        completed_at:
-        considered_risky:
-        coupon_code:
-        created_at:
-        email:
-        ip_address:
-        item_total:
+        checkout_complete: TODO_TRANSLATE
+        completed_at: TODO_TRANSLATE
+        considered_risky: TODO_TRANSLATE
+        coupon_code: TODO_TRANSLATE
+        created_at: TODO_TRANSLATE
+        email: TODO_TRANSLATE
+        ip_address: TODO_TRANSLATE
+        item_total: TODO_TRANSLATE
         number: Número
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        payment_state: TODO_TRANSLATE
+        shipment_state: TODO_TRANSLATE
+        special_instructions: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/payment:
         amount: Quantia
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nome
       spree/product:
-        available_on:
-        cost_currency:
+        available_on: TODO_TRANSLATE
+        cost_currency: TODO_TRANSLATE
         cost_price: Cost Price
         description: Descrição
         master_price: Master Price
         name: Nome
-        on_hand:
-        shipping_category:
-        tax_category:
+        on_hand: TODO_TRANSLATE
+        shipping_category: TODO_TRANSLATE
+        tax_category: TODO_TRANSLATE
       spree/promotion:
         advertise: Advertise
         code: Código
         description: Descrição
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        event_name: TODO_TRANSLATE
+        expires_at: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        path: TODO_TRANSLATE
+        starts_at: TODO_TRANSLATE
+        usage_limit: TODO_TRANSLATE
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
-        name:
-        presentation:
+        name: TODO_TRANSLATE
+        presentation: TODO_TRANSLATE
       spree/prototype:
-        name:
+        name: TODO_TRANSLATE
       spree/return_authorization:
-        amount:
+        amount: TODO_TRANSLATE
       spree/role:
-        name:
+        name: TODO_TRANSLATE
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
-        abbr:
-        name:
+        abbr: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: TODO_TRANSLATE
+        included_in_price: TODO_TRANSLATE
+        show_rate_in_label: TODO_TRANSLATE
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: TODO_TRANSLATE
+        permalink: TODO_TRANSLATE
+        position: TODO_TRANSLATE
       spree/taxonomy:
-        name:
+        name: TODO_TRANSLATE
       spree/user:
-        email:
-        password:
-        password_confirmation:
+        email: TODO_TRANSLATE
+        password: TODO_TRANSLATE
+        password_confirmation: TODO_TRANSLATE
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        depth: TODO_TRANSLATE
+        height: TODO_TRANSLATE
+        price: TODO_TRANSLATE
+        sku: TODO_TRANSLATE
+        weight: TODO_TRANSLATE
+        width: TODO_TRANSLATE
       spree/zone:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/country:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/credit_card:
-      spree/customer_return:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/line_item:
-      spree/option_type:
-      spree/option_value:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/payment:
-      spree/payment_method:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
-      spree/promotion:
-      spree/promotion_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
-      spree/return_authorization_reason:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipment:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipping_category:
-      spree/shipping_method:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/tax_rate:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
-      spree/tracker:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/tracker: TODO_TRANSLATE
       spree/user:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/variant:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/zone:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
-      inactive:
-      invalid:
-      invalid_token:
-      locked:
-      timeout:
-      unauthenticated:
-      unconfirmed:
+      inactive: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      invalid_token: TODO_TRANSLATE
+      locked: TODO_TRANSLATE
+      timeout: TODO_TRANSLATE
+      unauthenticated: TODO_TRANSLATE
+      unconfirmed: TODO_TRANSLATE
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Abreviação
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Conta
     account_updated: Conta atualizada!
     action: Ação
     actions:
       cancel: Cancelar
-      continue:
+      continue: TODO_TRANSLATE
       create: Criar
       destroy: Destruir
-      edit:
+      edit: TODO_TRANSLATE
       list: Lista
       listing: Listagem
       new: Nova
-      refund:
-      save:
+      refund: TODO_TRANSLATE
+      save: TODO_TRANSLATE
       update: Atualizar
     activate: Activate
     active: Ativo
     add: Adicionar
     add_action_of_type: Add action of type
     add_country: Adicionar País
-    add_coupon_code:
-    add_new_header:
-    add_new_style:
-    add_one:
+    add_coupon_code: TODO_TRANSLATE
+    add_new_header: TODO_TRANSLATE
+    add_new_style: TODO_TRANSLATE
+    add_one: TODO_TRANSLATE
     add_option_value: Adicionar Valor da Opção
     add_product: Adicionar Produtp
     add_product_properties: Adicionar Propriedades do Produto
     add_rule_of_type: Adicionar regra de tipo
     add_state: Adicionar Distrito
-    add_stock:
-    add_stock_management:
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: Adicionar ao Carrinho de Compras
-    add_variant:
+    add_variant: TODO_TRANSLATE
     additional_item: Artigo adicional
-    address1:
-    address2:
-    adjustable:
+    address: TODO_TRANSLATE
+    address1: TODO_TRANSLATE
+    address2: TODO_TRANSLATE
+    adjustable: TODO_TRANSLATE
     adjustment: Acerto
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: Total do Acerto
     adjustments: Acertos
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administração
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
-    all:
-    all_adjustments_closed:
-    all_adjustments_opened:
-    all_departments:
-    all_items_have_been_returned:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
+    all: TODO_TRANSLATE
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
+    all_departments: TODO_TRANSLATE
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
     allow_ssl_in_production: Allow SSL to be used in production mode
     allow_ssl_in_staging: Allow SSL to be used in staging mode
-    already_signed_up_for_analytics:
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: Texto alternativo
     alternative_phone: Telefone alternativo
     amount: Montante
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
     analytics_trackers: Analytics Trackers
-    and:
-    approve:
-    approved_at:
-    approver:
+    and: TODO_TRANSLATE
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Tem a certeza?
     are_you_sure_delete: Tem a certeza que deseja remover este registo?
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Falha na autorização
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Disponível em
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Voltar
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Voltar para a loja
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Saldo devedor
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Endereço para Faturação
     billing: Faturação
     billing_address: Endereço para Faturação
     both: Ambos
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculadora
     calculator_settings_warning: Se alterar o tipo de calculadora, deve primeiro confirmar a alteração antes de editar as configurações.
     cancel: cancelar
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Não é possível criar um retorno para esse pedido, pois ele ainda não foi enviado.
     cannot_perform_operation: Não foi possível realizar esta operação
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: Capturar
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Código do cartão
     card_number: Número do cartão
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: A bandeira do cartão é
     cart: Carrinho de Compras
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categorias
     category: Categoria
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Finalizar compra
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: TODO_TRANSLATE
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: TODO_TRANSLATE
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
     city: Cidade
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clone
-    close:
-    close_all_adjustments:
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
     code: Código
-    company:
+    company: TODO_TRANSLATE
     complete: completo
     configuration: Configuração
     configurations: Configurações
+    configure_s3: TODO_TRANSLATE
     confirm: Confirme
     confirm_delete: Confirmar que deseja remover
     confirm_password: Confirmação da password
     continue: Continuar
     continue_shopping: Continuar a comprar
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: Preço de custo
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
+    countries: TODO_TRANSLATE
     country: País
     country_based: Baseado em País
-    country_name:
+    country_name: TODO_TRANSLATE
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Cupão
     coupon_code: Código do cupão de desconto
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_already_applied: TODO_TRANSLATE
+    coupon_code_applied: TODO_TRANSLATE
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Criar
     create_a_new_account: Criar uma nova conta
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
     credit: Crédito
     credit_card: Cartão de Crédito
     credit_cards: Credit Cards
     credit_owed: Crédito Devedor
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credits: TODO_TRANSLATE
+    currency: TODO_TRANSLATE
+    currency_decimal_mark: TODO_TRANSLATE
+    currency_settings: TODO_TRANSLATE
+    currency_symbol_position: TODO_TRANSLATE
+    currency_thousands_separator: TODO_TRANSLATE
     current: Atual
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Cliente
     customer_details: Detalhes do cliente
-    customer_details_updated:
-    customer_return:
-    customer_returns:
+    customer_details_updated: TODO_TRANSLATE
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Busca de clientes
-    cut:
-    cvv_response:
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: Entre as Datas
     default: Padrão
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
     delete: Apagar
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Entrega
     depth: Espessura
     description: Descrição
-    destination:
+    destination: TODO_TRANSLATE
     destroy: Destruir
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Desconto
-    dismiss_banner:
+    dismiss_banner: TODO_TRANSLATE
     display: Mostrar
-    display_currency:
-    doesnt_track_inventory:
+    display_currency: TODO_TRANSLATE
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Editar de Imposto
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Editando Utilizador
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Vazio
     empty_cart: Esvaziar o Carro
     enable_mail_delivery: Habilitar envio de email
-    end:
-    ending_in:
+    end: TODO_TRANSLATE
+    ending_in: TODO_TRANSLATE
     environment: Ambiente
     error: erro
     errors:
@@ -577,40 +718,42 @@ pt:
     events:
       spree:
         cart:
-          add:
+          add: TODO_TRANSLATE
         checkout:
-          coupon_code_added:
+          coupon_code_added: TODO_TRANSLATE
         content:
-          visited:
+          visited: TODO_TRANSLATE
         order:
-          contents_changed:
-        page_view:
+          contents_changed: TODO_TRANSLATE
+        page_view: TODO_TRANSLATE
         user:
-          signup:
+          signup: TODO_TRANSLATE
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Expiração
     extension: Extensão
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Nome do arquivo
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
+    filter_results: TODO_TRANSLATE
     finalize: Finalizar
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Custo do primeiro item
     first_name: Nome
     first_name_begins_with: Primeiro nome começa com
     flat_percent: Percentagem (flat)
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: "(Flat) taxa (por pedido)"
     flexible_rate: Taxa Flexivel
     forgot_password: Esqueci-me da minha password
     free_shipping: Entrega grátis
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Gateway não está disponível
@@ -623,50 +766,54 @@ pt:
     guest_user_account: Comprar como visitante
     has_no_shipped_units: não tem unidades entregues
     height: Altura
-    hide_cents:
+    hide_cents: TODO_TRANSLATE
     home: Início
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: Português (PT)
-      translations:
+      translations: TODO_TRANSLATE
     icon: Icone
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Imagem
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Imagens
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
+    included_in_price: TODO_TRANSLATE
+    included_price_validation: TODO_TRANSLATE
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Preencha o formulário abaixo e enviaremos instruções de como redefinir a sua password por email:'
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Interceptar endereço de email
     intercept_email_instructions: Sobreescrever destinatários por este endereço de email.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: Inventário
     inventory_adjustment: Ajuste de Inventário
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: Não está disponível para endereço de entrega
-    iso_name:
+    iso_name: TODO_TRANSLATE
     item: Artigo
     item_description: Descrição do Artigo
     item_total: Total do Artigo
@@ -674,26 +821,32 @@ pt:
       operators:
         gt: maior que
         gte: maior ou igual que
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
       path: Path
     last_name: Sobrenome
     last_name_begins_with: Sobrenome começa com
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Carregando
     locale_changed: Localização Alterada
-    location:
-    lock:
-    log_entries:
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
     logged_in_as: Registado como
     logged_in_succesfully: Autenticação feita com sucesso, obrigado!
     logged_out: Você saiu.
@@ -702,38 +855,41 @@ pt:
     login_failed: Falha na autenticação.
     login_name: Nome de Utilizador
     logout: Sair
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Procurar artigos similares
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Devolução
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Preço Principal
     match_choices:
-      all:
-      none:
+      all: TODO_TRANSLATE
+      none: TODO_TRANSLATE
     max_items: Artigos máximos
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Descrição
     meta_keywords: Palavras-Chave
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadados
     minimal_amount: Quantidade mínima
     month: Mês
     more: More
-    move_stock_between_locations:
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: Minha Conta
     my_orders: As Minhas Encomendas
     name: Nome
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Nome ou SKU
     new: Novo
     new_adjustment: Novo Ajuste
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Novo Cliente
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nova Imagem
     new_option_type: Novo Tipo de Opção
     new_order: Novo Pedido
@@ -742,20 +898,21 @@ pt:
     new_payment_method: Nova Forma de Pagamento
     new_product: Novo Produto
     new_promotion: Nova Promoção
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nova Propriedade
     new_prototype: Novo Protótipo
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Nova Autorização de Devolução
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Nova Categoria de Entrega
     new_shipping_method: Novo Método de Entrega
     new_state: Novo Estado
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: Nova Categoria de Imposto
     new_tax_rate: Nova Taxa de Imposto
     new_taxon: Novo Táxon
@@ -765,25 +922,31 @@ pt:
     new_variant: Nova Variante
     new_zone: Nova Zona
     next: Próximo
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Não existem produtos
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Não existem resultados
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Nenhuma regra adicionada
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: Nenhum
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Quantidade Normal
     not: não
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Produto clonado
       product_deleted: Produto apagado
@@ -791,47 +954,52 @@ pt:
       product_not_deleted: Produto não pode ser apagado
       variant_deleted: Variante deletada
       variant_not_deleted: Variante não pode ser apagada
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Em Stock
-    open:
-    open_all_adjustments:
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
     option_type: Tipo de Opção
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Tipos de Opção
     option_value: Valor da Opção
     option_values: Valores das Opções
-    optional:
+    optional: TODO_TRANSLATE
     options: Opções
     or: ou
     or_over_price: "%{price} ou mais"
     order: Pedido
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Detalhes do Pedido
     order_email_resent: Email de Confirmação Reenviado
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
         subject: Cancelamento da Encomenda
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: O seu pedido foi processado com sucesso.
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: endereço
       awaiting_return: aguardando retorno
@@ -839,7 +1007,7 @@ pt:
       cart: carrinho de compras
       complete: completo
       confirm: confirmação
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: entrega
       payment: pagamento
       resumed: resumido
@@ -849,24 +1017,26 @@ pt:
     order_total: Total do Pedido
     order_updated: Pedido Atualizado
     orders: Encomendas
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Esgotado
     overview: Resumo
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
-      next_page:
-      previous_page:
+      first: TODO_TRANSLATE
+      next_page: TODO_TRANSLATE
+      previous: TODO_TRANSLATE
+      previous_page: TODO_TRANSLATE
       truncate: "…"
-    password:
-    paste:
+    password: TODO_TRANSLATE
+    paste: TODO_TRANSLATE
     path: Caminho
     pay: Pague
     payment: Pagamento
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Dados do Pagamento
     payment_method: Método de Pagamento
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Métodos de Pagamento
     payment_processing_failed: Pagamento não foi processado, por favor verifique os detalhes informados.
     payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
@@ -884,22 +1054,23 @@ pt:
       void: nulo
     payment_updated: Pagamento Atualizado
     payments: Pagamentos
-    pending:
-    percent:
-    percent_per_item:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
+    percent_per_item: TODO_TRANSLATE
     permalink: Link Permanente
     phone: Telefone
     place_order: Fazer Pedido
-    please_define_payment_methods:
-    populate_get_error:
-    powered_by:
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    please_define_payment_methods: TODO_TRANSLATE
+    please_enter_reasonable_quantity: TODO_TRANSLATE
+    populate_get_error: TODO_TRANSLATE
+    powered_by: TODO_TRANSLATE
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Apresentação
     previous: anterior
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Preço
     price_range: Intervalo de Preço
     price_sack: Saco de Preço
@@ -907,38 +1078,43 @@ pt:
     product: Produto
     product_details: Detalhes do Produto
     product_has_no_description: Produto não tem descrição
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Propriedades do Produto
     product_rule:
       choose_products: Escolher produtos
-      label:
+      label: TODO_TRANSLATE
       match_all: todos
       match_any: pelo menos um
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: de grupo de produto
         manual: escolha manual
     products: Produtos
     promotion: Promoção
-    promotion_action:
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Combinar todas regras
         any: Combinar algumas regras
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
@@ -946,32 +1122,32 @@ pt:
         name: Primeiro pedido
       item_total:
         description: Total do pedio fecha com estes critérios
-        name:
+        name: TODO_TRANSLATE
       landing_page:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Pedido inclui produto(s) específico(s)
         name: Produto(s)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Disponível apenas para utilizadores específicos
         name: Utilizadores
       user_logged_in:
         description: Available only to logged in users
         name: User Logged In
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promoções
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Propriedades
     property: Propriedade
     prototype: Protótipo
@@ -979,50 +1155,52 @@ pt:
     provider: Provedor
     provider_settings_warning: Se está a alterar o tipo de provedor, deve guardar antes de editar as configurações
     qty: Qtde.
-    quantity:
+    quantity: TODO_TRANSLATE
     quantity_returned: Quantidade devolvida
     quantity_shipped: Quantidade enviada
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Taxa
     reason: Razões
     receive: receber
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: Recebido
-    reception_status:
-    reference:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
     refund: Restituição
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registrar-se
     registration: Registo
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Lembre-se de mim
     remove: Remover
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: Relatórios
+    resellable: TODO_TRANSLATE
     resend: Reenviar
     reset_password: Repôr a minha password
     response_code: Código de Resposta
@@ -1030,34 +1208,41 @@ pt:
     resumed: Resumido
     return: Devolução
     return_authorization: Autorização de devolução
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Autorização de devolução atualizada
     return_authorizations: Autorizações de devolução
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Quantidade a ser devolvido
     returned: Devolvido
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: Crédito RMA
     rma_number: Número RMA
     rma_value: Valor RMA
+    role_id: TODO_TRANSLATE
     roles: Funções
     rules: Regras
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Total de Vendas
     sales_total_description: Total de vendas por todos os pedidos
-    sales_totals:
+    sales_totals: TODO_TRANSLATE
     save_and_continue: Guardar e Continuar
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: false
     say_yes: true
     scope: Scopo
@@ -1067,10 +1252,11 @@ pt:
     secure_connection_type: Tipo de conexão segura
     security_settings: Security Settings
     select: Selecionar
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Selecionar a partir de Protótipo
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Enviar cópias de todos emails para
     send_mails_as: Enviar email como
     server: Servidor
@@ -1078,138 +1264,157 @@ pt:
     settings: Configurações
     ship: entrega
     ship_address: Endereço da Entrega
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: Distribuição
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        shipment_summary: TODO_TRANSLATE
         subject: Notificação de Envio
-        thanks:
-        track_information:
-        track_link:
+        thanks: TODO_TRANSLATE
+        track_information: TODO_TRANSLATE
+        track_link: TODO_TRANSLATE
     shipment_state: Estado da entrega
     shipment_states:
       backorder: fora do sistema
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: parcial
       pending: pendente
       ready: pronta
       shipped: entregue
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Entregas
     shipped: enviado
     shipping: Entrega
     shipping_address: Endereço de Entrega
     shipping_categories: Categorias de Entrega
     shipping_category: Categoria de Entrega
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: Instruções de entrega
     shipping_method: Método de Entrega
     shipping_methods: Métodos de Entrega
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Comprar por %{taxonomy}
     shopping_cart: Carrinho de Compra
     show: Mostrar
     show_active: Mostrar ativos
     show_deleted: Mortra Eliminados
     show_only_complete_orders: Mostrar apenas pedidos completos
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
     sku: SKU
-    skus:
-    slug:
-    source:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
     special_instructions: Instruções Especiais
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Houve um problema com a informação de pagamentp. Por favor verifique a informação e tente novamente.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Início
+    start_date: TODO_TRANSLATE
     state: Distrito
     state_based: Baseado no Distrito
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Distritos
-    states_required:
+    states_required: TODO_TRANSLATE
     status: Estado
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
     stop: Final
     store: Loja
     street_address: Endereço
     street_address_2: Endereço (compl.)
     subtotal: Sub-total
     subtract: Subtrair
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} foi criado com sucesso!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} foi removido com sucesso!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource} foi atualizado com sucesso!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Imposto
     tax_categories: Categorias de Imposto
     tax_category: Categoria de Imposto
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Taxas de imposto
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxón
     taxon_edit: Editar taxón
-    taxon_placeholder:
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomias
     taxonomy: Taxonomy
     taxonomy_edit: Editar taxonomia
@@ -1218,50 +1423,55 @@ pt:
     taxons: Taxons
     test: Teste
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
-        greeting:
-        message:
-        subject:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
     test_mode: Modo de Teste
     thank_you_for_your_order: Obrigado pela sua compra. Por favor, imprima uma cópia desta página de confirmação.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: Houve um problema com os seguintes campos
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Miniatura
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: Para adicionar variantes você deve primeiro definir
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Rastreio
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: "Árvore"
     type: Tipo
     type_to_search: Tipo de pesquisa
     unable_to_connect_to_gateway: Impossível conectar-se ao Gateway
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Menos de %{price}
-    unlock:
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: Tipo de cartão desconhecido
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: Atualizar
     updating: Atualizando
     usage_limit: Limite de utilização
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Utilizar endereço de faturação
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Utilizar um novo cartão
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Use Amazon S3 For Images
     user: utilizador
     user_rule:
@@ -1269,15 +1479,16 @@ pt:
     users: utilizadores
     validation:
       cannot_be_less_than_shipped_units: não pode ser menor que o número de unidades enviadas.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: "é muito grande -- quantidade em stock não consegue cobrir este pedido!"
       must_be_int: deve ser um inteiro
       must_be_non_negative: deve ser um valor positivo ou zero
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Valor
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Variantes
     version: Versão
     void: Vazio
@@ -1288,8 +1499,15 @@ pt:
     year: Ano
     you_have_no_orders_yet: Ainda não tem pedidos.
     your_cart_is_empty: O carrinho de compras está vazio
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: Código Postal
-    zipcode:
+    zipcode: TODO_TRANSLATE
     zone: Zona
     zones: Zonas
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,4 +1,6 @@
+---
 ro:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ ro:
         state: Județ / Regiune
         zipcode: Cod poștal
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -27,7 +29,7 @@ ro:
         base: Bază
         cc_type: Tip
         month: Luna
-        name:
+        name: TODO_TRANSLATE
         number: Număr
         verification_value: Cod de verificare
         year: An
@@ -42,7 +44,7 @@ ro:
       spree/order:
         checkout_complete: Comandă finalizată
         completed_at: Finalizată la
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: Cod Cupon
         created_at: Data comenzii
         email: E-Mail Client
@@ -72,6 +74,7 @@ ro:
         zipcode: Cod poștal adresă de livrare
       spree/payment:
         amount: Valoare
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Nume
       spree/product:
@@ -95,7 +98,8 @@ ro:
         starts_at: "Începe la"
         usage_limit: Limită de folosire
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Nume
         presentation: Descriere
@@ -105,24 +109,26 @@ ro:
         amount: Suma
       spree/role:
         name: Nume
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Prescurtare
         name: Nume
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Descriere
         name: Nume
@@ -157,48 +163,54 @@ ro:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: Cartela a expirat
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adresă
         other: Adrese
@@ -208,41 +220,43 @@ ro:
       spree/credit_card:
         one: Card de credit
         other: Carduri de credit
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: Unitatea de inventar
         other: Unități de inventar
       spree/line_item:
         one: Element
         other: Elemente
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: Comandă
         other: Comenzi
       spree/payment:
         one: Plată
         other: Plăți
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: Produs
         other: Produse
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: Proprietate
         other: Proprietăți
       spree/prototype:
         one: Prototip
         other: Prototipuri
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: Autorizație de retur
         other: Autorizații de retur
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Roluri
         other: Roluri
       spree/shipment:
@@ -251,14 +265,14 @@ ro:
       spree/shipping_category:
         one: Categorie de expediție
         other: Categorii de expediții
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: Județ / Regiune
         other: Județe / Regiuni
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: Categorie de taxare
         other: Categorii de taxare
@@ -271,7 +285,7 @@ ro:
       spree/taxonomy:
         one: Clasificare
         other: Clasificări
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: Utilizator
         other: Utilizatori
@@ -281,6 +295,9 @@ ro:
       spree/zone:
         one: Zonă
         other: Zone
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Contul dumneavoastră a fost confirmat cu succes. Sunteți autentificat.
@@ -301,8 +318,8 @@ ro:
       unlock_instructions:
         subject: Instrucțiuni deblocare
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
       send_instructions: Veți primi un email cu instrucțiuni pentru a vă debloca contul în câteva minute.
       unlocked: Contul dumneavoastră a fost deblocat cu succes. Puteți să vă autentificați.
@@ -319,6 +336,7 @@ ro:
     user_sessions:
       signed_in: Autentificare cu succes.
       signed_out: Deautentificare cu success.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: a fost deja confirmat
@@ -327,12 +345,30 @@ ro:
       not_saved:
         one: 'o eroare a împiedicat acest %{resource} să fie salvat:'
         other: "%{count} erori au împiedicat acest %{resource} să fie salvat:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Prescurtare
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Cont
     account_updated: Cont actualizat!
     action: Acțiune
@@ -345,7 +381,7 @@ ro:
       list: Listează
       listing: Listare
       new: Nou
-      refund:
+      refund: TODO_TRANSLATE
       save: Salvează
       update: Actualizează
     activate: Activează
@@ -353,7 +389,7 @@ ro:
     add: Adaugă
     add_action_of_type: Adaugă tip acțiune
     add_country: Adaugă țară
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Adaugă header nou
     add_new_style: Adaugă stil nou
     add_one: Adaugă unul
@@ -367,11 +403,16 @@ ro:
     add_to_cart: Adaugă în coș
     add_variant: Adaugă variantă
     additional_item: Cost adițional pe articol
+    address: TODO_TRANSLATE
     address1: Adresă
     address2: Adresă (continuare)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Re-evaluare
     adjustment_amount: Valoare
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Ajustarea a fost închisă cu succes!
     adjustment_successfully_opened: Ajustarea a fost deschisă cu succes!
     adjustment_total: Total re-evaluare
@@ -387,27 +428,27 @@ ro:
         properties: Proprietăți
         prototypes: Prototipuri
         reports: Rapoarte
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Utilizatori
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administrare
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Acceptă Politica de Confidențialitate
     agree_to_terms_of_service: Acceptă Condițiile de Utilizare
     all: Toate
     all_adjustments_closed: Toate ajustările au fost  închise cu succes!
     all_adjustments_opened: Toate ajustările au fost deschise cu succes!
     all_departments: Toate departamentele
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Permite utilizare SSL în modurile de dezvoltare și testare
     allow_ssl_in_production: Permite utilizare SSL în modul producție
     allow_ssl_in_staging: Permite utilizare în modul staging
@@ -423,70 +464,104 @@ ro:
     analytics_desc_list_4: Este complet gratuit!
     analytics_trackers: Analytics Trackers
     and: "și"
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Ești sigur(ă)
     are_you_sure_delete: Ești sigur(ă) că vrei să ștergi această înregistrare?
     associated_adjustment_closed: Ajustarea asociată este închisă și nu va fi recalculată. Doriți să o deschideți?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Autorizare nereușită
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Disponibil de la
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: "Înapoi"
     back_end: Interfața de administrare
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: "Înapoi la magazin"
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: "Înapoi la lista de utilizatori"
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Permite comenzi în așteptare
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Sold datorat
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Adresă de facturare
     billing: Facturare
     billing_address: Adresă facturare
     both: Ambele
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Calculator
     calculator_settings_warning: Dacă schimbi tipul de calculator, trebuie mai întâi să salvezi, ca să poți edita setările calculatorului
     cancel: anulează
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: Nu puteți crea o plată pentru o comandă fără a defini o metodă de plată.
     cannot_create_returns: Nu poți genera un retur deoarece această comandă nu a fost livrată încă.
     cannot_perform_operation: Operațiunea cerută nu poate fi îndeplinită
     cannot_set_shipping_method_without_address: Metoda de livrare nu poate fi setată înaintea furnizării datelor clientului.
     capture: "Înregistrare"
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Codul cardului
     card_number: Numărul cardului
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Tipul cardului este
     cart: Coșul meu
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Categorii
     category: Categorie
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Verifică alerte Spree
     checkout: Efectuați plata
     choose_a_customer: Alege un client
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Alege valuta
     choose_dashboard_locale: Alege localizare panou de administrare
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Oraș / Localitate
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clonă
     close: "Închide"
     close_all_adjustments: "Închide toate ajustările"
@@ -495,6 +570,7 @@ ro:
     complete: complet
     configuration: Configurare
     configurations: Configurări
+    configure_s3: TODO_TRANSLATE
     confirm: Confirmă
     confirm_delete: Confirmă ștergerea
     confirm_password: Confirmă parola
@@ -503,7 +579,7 @@ ro:
     cost_currency: Valută preț de cost
     cost_price: Preț de cost
     could_not_connect_to_jirafe: Conexiunea la Jirafe pentru a sincroniza datele nu a putut fi realizată. Se va reîncerca conexiunea mai târziu.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: A apărut o problemă la salvarea mișcării de stoc. Vă rog reîncercați.
     count_on_hand: Valoare stoc
     countries: "Țări"
@@ -511,10 +587,10 @@ ro:
     country_based: Bazat pe țară
     country_name: Nume
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Cupon
     coupon_code: Cod cupon
     coupon_code_already_applied: Codul voucher a fost deja aplicat acestei comenzi
@@ -524,17 +600,17 @@ ro:
     coupon_code_max_usage: Limita de utilizare a acestui voucher a fost depășită
     coupon_code_not_eligible: Acest cod voucher nu este eligibil pentru această comandă
     coupon_code_not_found: Codoul voucherului introdus nu există. Încercați din nou.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Creează
     create_a_new_account: Creează un nou cont
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Creat la
     credit: Credit
     credit_card: Card de credit
     credit_cards: Carduri de credit
     credit_owed: Credit datorat
-    credits:
+    credits: TODO_TRANSLATE
     currency: Valuta
     currency_decimal_mark: Separator zecimale
     currency_settings: Setări valută
@@ -545,16 +621,16 @@ ro:
     customer: Client
     customer_details: Detalii client
     customer_details_updated: Detaliile clientului au fost actualizate
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Căutare client
     cut: Taie
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: ID Aplicație
         app_token: Cod Aplicație
-        currently_unavailable:
+        currently_unavailable: TODO_TRANSLATE
         explanation: Câmpurile de mai jos pot fi deja populate în cazul în care doriți să vă înregistrați cu Jirafe din panoul de administrare.
         header: Setări Jirafe Analytics
         site_id: ID Site
@@ -563,46 +639,65 @@ ro:
     date: Data
     date_completed: Data efectuării
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%d.%m.%Y"
       js_format: "%d.%m.%Y"
     date_range: Perioada
     default: Standard
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Taxă prestabilită
     default_tax_zone: Zonă de taxare prestabilită
     delete: "Șterge"
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Livrare
     depth: Adâncime
     description: Descriere
     destination: Destinație
     destroy: "Șterge"
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Valoare reducere
     dismiss_banner: Nu, mulțumesc! Nu sunt interesat, nu mai afișa acest mesaj din nou.
     display: Arată
     display_currency: Afișează cod valută
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Modifică
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Modificarea utilizatorului
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Gol
     empty_cart: Golește coșul
@@ -634,29 +729,31 @@ ro:
         user:
           signup: "Înregistrare utilizator"
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Expirare
     extension: Extensie
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Nume fișier
     fill_in_customer_info: Vă rugăm introduceți informațiile de client
+    filter: TODO_TRANSLATE
     filter_results: Rezultate filtrare
     finalize: Finalizează
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Cost primul articol
     first_name: Prenume
     first_name_begins_with: Prenumele începe cu
     flat_percent: Procentaj net
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Procentaj net (pe comandă)
     flexible_rate: Rată flexibilă
     forgot_password: Ai uitat parola?
     free_shipping: Livrare gratuită
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Interfață utilizatori
     gateway: Metodă de plată
     gateway_config_unavailable: Metodă de plată indisponibilă în acest context
@@ -680,37 +777,41 @@ ro:
       only_incomplete: Doar nefinalizate
       select_locale: Setează localizare
       show_only: Afișează doar
+      store_translations: TODO_TRANSLATE
       supported_locales: Localizări sprijinite
       this_file_language: Romanian (RO)
       translations: Traduceri
     icon: Icoană
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Imagine
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Imagini
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Inclus în preț
     included_price_validation: nu poate fi selectat doar dacă ați ales o zonă de taxare prestabilită
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Completează formularul și instrucțiunile de mai jos, ca să resetezi parola, care îți va fi trimisă de email:'
     insufficient_stock: Stoc insuficient, doar %{on_hand} rămase
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Interceptează adresa de email
     intercept_email_instructions: Schimbă recipientul emailului cu această adresă.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Furnizor de plăți nevalid.
     invalid_promotion_action: Acțiune de promoție nevalidă
     invalid_promotion_rule: Regulă de promoție nevalidă.
     inventory: Inventar
     inventory_adjustment: Re-evaluare inventar
     inventory_error_flash_for_insufficient_quantity: Un articol din coșul dumneavoastră de cumpărături a devenit indisponibil.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: nu este disponibil pentru adresa de expediție
     iso_name: Nume ISO
     item: Articol
@@ -720,26 +821,32 @@ ro:
       operators:
         gt: mai mare de
         gte: mai mare de sau egal cu
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: Itemii nu pot fi cumpărați
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Cale
     last_name: Nume
     last_name_begins_with: Numele începe cu
     learn_more: "Învață mai multe"
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Listă
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "Încarcă"
     locale_changed: Localizare schimbat
     location: Locație
     lock: Blochează
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: Autentificat ca
     logged_in_succesfully: Autentificat cu succes
     logged_out: V-ați deconectat.
@@ -748,23 +855,26 @@ ro:
     login_failed: Autentificare nereușită.
     login_name: Autentificare
     logout: Deconectare
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Caută articole similare
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Fă o restituire
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Preț de bază
     match_choices:
       all: Toate
       none: Nici una
     max_items: Max articole
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Descriere meta
     meta_keywords: Cuvinte cheie meta
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadate
     minimal_amount: Suma minimă
     month: Luna
@@ -773,13 +883,13 @@ ro:
     my_account: Contul meu
     my_orders: Comenzile mele
     name: Nume
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Nume sau cod produs
     new: Nou
     new_adjustment: Re-evaluare nouă
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Client nou
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Imagine nouă
     new_option_type: Tip nou de opțiune
     new_order: Comandă nouă
@@ -788,14 +898,15 @@ ro:
     new_payment_method: Metodă nouă de plată
     new_product: Produs nou
     new_promotion: Promoție nouă
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Proprietate nouă
     new_prototype: Prototip nou
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Autorizație nouă de retur
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Categorie nouă de livrare
     new_shipping_method: Metodă nouă de livrare
     new_state: Județ nou / regiune nouă
@@ -812,24 +923,30 @@ ro:
     new_zone: Zonă nouă
     next: Următorul
     no_actions_added: Nicio acțiune adăugată
-    no_payment_found:
-    no_pending_payments:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Nu am găsit produse
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Nu există rezultate
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Nicio regulă adăugată
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Nu au fost furnizate detalii de tracking
     none: Niciuna
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Suma normală
     not: nu
     not_available: Indisponibil
     not_enough_stock: Nu există stoc suficient la locația sursă pentru a finaliza transferul.
     not_found: "%{resource} nu a fost găsit"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Produsul a fost clonat
       product_deleted: Produsul a fost șters
@@ -837,12 +954,12 @@ ro:
       product_not_deleted: Produsul nu a putut fi șters
       variant_deleted: Varianta a fost ștearsă
       variant_not_deleted: Varianta nu a putut fi ștearsă
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Pe stoc
     open: Deschis
     open_all_adjustments: Deschide toate ajustările
     option_type: Tip opțiune
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Tipuri opțiune
     option_value: Valoarea opțiune
     option_values: Valori opțiuni
@@ -852,31 +969,37 @@ ro:
     or_over_price: "%{price} sau peste"
     order: Comanda
     order_adjustments: Ajustări comandă
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Detaliile comenzii
     order_email_resent: Mail comandă retrimis
     order_information: Informații comandă
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Stimate client,\n
         instructions: Comanda Dvs. a fost anulată. Vă rugăm păstrați această notă de anulare.
         order_summary_canceled: Sumarul comenzii [ANULATE]
         subject: Anularea comenzii
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Stimate client,\n
         instructions: Vă rugăm să verificați și să păstrați informațiile despre comanda Dvs.
         order_summary: Sumarul comenzii
         subject: Confirmarea comenzii
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Vă mulțumim pentru comanda efectuată.
-        total:
+        total: TODO_TRANSLATE
     order_not_found: Nu am putut găsi comanda dumneavoastră. Vă rugăm încercați din nou.
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Comanda a fost procesată cu succes
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: adresă
       awaiting_return: "în așteptarea returului"
@@ -884,7 +1007,7 @@ ro:
       cart: coș cumpărături
       complete: procesat
       confirm: confirmă
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: livrare
       payment: plată
       resumed: reluat
@@ -894,12 +1017,14 @@ ro:
     order_total: Total comandă
     order_updated: Comandă salvată
     orders: Comenzi
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Nu mai este pe stoc
     overview: Sumar
     package_from: pachet din
     pagination:
+      first: TODO_TRANSLATE
       next_page: pagina următoare »
+      previous: TODO_TRANSLATE
       previous_page: "« pagina anterioară"
       truncate: "…"
     password: Parola
@@ -907,11 +1032,11 @@ ro:
     path: Rută
     pay: plătește
     payment: Plată
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Informații plată
     payment_method: Metodă de plată
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Metode de plată
     payment_processing_failed: Plata nu a putut fi procesată, te rugăm verifică dacă datele introduse sunt corecte
     payment_processor_choose_banner_text: Dacă aveți nevoie de ajutor pentru a alege un procesor de plați, vă rugăm vizitați
@@ -929,22 +1054,23 @@ ro:
       void: void
     payment_updated: Plată salvată
     payments: Plăți
-    pending:
+    pending: TODO_TRANSLATE
     percent: Procent
     percent_per_item: Procent per articol
     permalink: Permalink
     phone: Telefon
     place_order: Plasează comanda
     please_define_payment_methods: Vă rugăm, definiție metode de plată prima dată.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Ceva a mers prost. Vă rugăm încercați să adăugați articolul din nou.
     powered_by: Realizat de
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Descriere
     previous: Precedent
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Preț
     price_range: Gamă de preț
     price_sack: Sac de preț
@@ -956,10 +1082,10 @@ ro:
     product_properties: Proprietăți produs
     product_rule:
       choose_products: Alege produse
-      label:
+      label: TODO_TRANSLATE
       match_all: toate
       match_any: cel puțin unul
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Din grup de produse
         manual: Alege de mână
@@ -971,19 +1097,24 @@ ro:
         description: Crează o ajustare de credit promoțională la comandă
         name: Crează ajustare
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Populează coșul cu cantitatea specificată a variantei
         name: Adaugă articole la comandă
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Acțiuni
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Să corespundă cu oricare dintre aceste reguli
         any: Să corespundă cu toate aceste reguli
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Regulă de promoție
     promotion_rule_types:
       first_order:
@@ -996,27 +1127,27 @@ ro:
         description: Clientul trebuie să fi vizitat pagina specificată
         name: Pagina de aterizare
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Comanda include produsul / produsele specificate
         name: Produs(e)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Disponibil doar pentru utilizatorii specificați
         name: Utilizator
       user_logged_in:
         description: Valabil doar utilzatorilor autentificați
         name: Utilizator autentificat
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promoții
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Proprietăți
     property: Proprietate
     prototype: Prototip
@@ -1027,47 +1158,49 @@ ro:
     quantity: Cantitate
     quantity_returned: Cantitate retururi
     quantity_shipped: Cantitate livrări
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Rată
     reason: Motiv
     receive: primește
     receive_stock: Primește stoc
     received: Primit
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Referință
+    reference_contains: TODO_TRANSLATE
     refund: Restituire
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: "Înregistrează-te ca utilizator nou"
     registration: "Înregistrare"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: "Ține-mi minte datele"
     remove: "Șterge"
     rename: Redenumește
-    report:
+    report: TODO_TRANSLATE
     reports: Rapoarte
+    resellable: TODO_TRANSLATE
     resend: Trimite din nou
     reset_password: Resetează parola
     response_code: Cod răspuns
@@ -1075,34 +1208,41 @@ ro:
     resumed: Reluat
     return: retur
     return_authorization: Aviz de retur
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Aviz de retur salvată
     return_authorizations: Aviz de retur
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Cantitate retur
     returned: Returnat
-    returns:
+    returns: TODO_TRANSLATE
     review: Revizuie
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: Credit pentru avizul de retur a mărfii
     rma_number: Număr pentru avizul de retur a mărfii
     rma_value: Valoare pentru avizul de retur a mărfii
+    role_id: TODO_TRANSLATE
     roles: Roluri
     rules: Reguli
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Total vânzări
     sales_total_description: Total vânzări pentru toate comenzile
     sales_totals: Total vânzări
     save_and_continue: Salvează și continuă
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: Nu
     say_yes: Da
     scope: Gamă
@@ -1112,10 +1252,11 @@ ro:
     secure_connection_type: Tip de conexiune securizată
     security_settings: Setări de siguranță
     select: Selectează
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Selectează din prototip
     select_stock: Selectează stoc
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Trimite o copie a tuturor emailurilor către
     send_mails_as: Trimite emailuri ca
     server: Server
@@ -1125,8 +1266,9 @@ ro:
     ship_address: Adresa de livrare
     ship_total: Total livrare
     shipment: Livrare
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Dragă client,\n
@@ -1139,13 +1281,13 @@ ro:
     shipment_state: Stare livrare
     shipment_states:
       backorder: comandă în afara stocului
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: parțial
       pending: "în așteptare"
       ready: pregătit
       shipped: livrat
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Livrări
     shipped: Livrare
     shipping: Livrare
@@ -1159,69 +1301,85 @@ ro:
     shipping_method: Metodă livrare
     shipping_methods: Metode livrare
     shipping_price_sack: Sac de preț
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: Coș cumpărături
     show: Afișează
     show_active: Afișează produsele active
     show_deleted: Afișează și produsele care au fost șterse
     show_only_complete_orders: Afișează doar comenzile neprocesate
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Afișează rata în etichetă
     sku: Cod produs
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Sursa
     special_instructions: Instrucțiuni speciale
     split: Divide
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: A apărut o problemă legat de informațiile de plată. Te rugăm verifică dacă informațiile sunt corecte și mai încearcă odaată.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: De la
+    start_date: TODO_TRANSLATE
     state: Județ / regiune
     state_based: Bazat pe un județ / regiune
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Județe
     states_required: Județe obligatorii
     status: Status
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: Locație stoc
     stock_location_info: Informații locație stoc
     stock_locations: Locații stoc
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Gestionare stoc
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
     stock_movements: Mișcări stoc
     stock_movements_for_stock_location: Mișcări stoc pentru %{stock_location_name}
     stock_successfully_transferred: Stoc transferat cu succes între locații
@@ -1233,28 +1391,30 @@ ro:
     street_address_2: Strada (cont.)
     subtotal: Subtotal
     subtract: Scade
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} a fost creată cu succes!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} a fost ștearsă cu succes!"
     successfully_signed_up_for_analytics: Ați fost înregistrat cu success la Spree Analytics
     successfully_updated: "%{resource} a fost salvată cu succes!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Taxe
     tax_categories: Categorii taxe
     tax_category: Categorie Taxe
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Ratele de taxe sunt o valoare decimală folosită pentru ajutorarea calculelor, (ex. dacă rata taxei este 5% atunci introduceți 0.05)
     tax_rates: Tarif taxe
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Clasă
     taxon_edit: Editare clasă
     taxon_placeholder: Adaugă un taxon
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Clasificări
     taxonomy: Taxonomie
     taxonomy_edit: Modifică clasificări
@@ -1263,32 +1423,35 @@ ro:
     taxons: Clase
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Felicitări!
         message: Dacă ați primit acest email, atunci setările dumneavoastră de email sunt corecte.
         subject: Email de test
     test_mode: Mod Testare
     thank_you_for_your_order: Mulțumim pentru comandă. Te rugăm să tipărești o copie a acestei pagini de confirmare pentru registrele tale.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: Au apărut probleme la următoarele câmpuri
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: miniatură
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Timp
     to_add_variants_you_must_first_define: Pentru a adăuga variante, trebuie mai întâi să le definești
     total: Total
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
     tracking_number: Număr de tracking
     tracking_url: URL de tracking
     tracking_url_placeholder: ex. http://quickship.com/package?num=:tracking
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Transferă din
     transfer_stock: Transfer stoc
     transfer_to_location: Transferă către
@@ -1296,7 +1459,7 @@ ro:
     type: Tastează
     type_to_search: Tastează pentru căutare
     unable_to_connect_to_gateway: Nu se poate conecta la procesator de plăți.
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Sub %{price}
     unlock: Deblochează
     unrecognized_card_type: Acest tip de card nu este recunoscut
@@ -1304,9 +1467,11 @@ ro:
     update: Salvează
     updating: Se salvează
     usage_limit: Limită de utilizare
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Folosește adresa de facturare
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Folosește alt card
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Folosește Amazon S3 pentru imagini
     user: Utilizator
     user_rule:
@@ -1314,15 +1479,16 @@ ro:
     users: Utilizatori
     validation:
       cannot_be_less_than_shipped_units: nu poate fi mai mic de numărul de unități livrate.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: depășește stocul disponibil. Vă rugăm verificați ca liniile comenzii să aibă cantități valide.
       is_too_large: este prea mare -- stocul actual nu acoperă cantitatea comandată!
       must_be_int: trebuie să fie indivizibil
       must_be_non_negative: trebuie să fie o valoare pozitivă sau nulă
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Valoare
     variant: Variantă
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Variante
     version: Versiune
     void: Void
@@ -1338,3 +1504,10 @@ ro:
     zipcode: Cod poștal
     zone: Zonă
     zones: Zone
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,4 +1,6 @@
+---
 ru:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ ru:
         state: "Область/Регион"
         zipcode: "Почтовый индекс"
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ ru:
         name: "Название"
         numcode: ISO-код
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: "Тип кредитной карты"
         month: "Месяц"
-        name:
+        name: TODO_TRANSLATE
         number: "Номер"
         verification_value: "Значение проверки"
         year: "Год"
@@ -72,6 +74,7 @@ ru:
         zipcode: "Почтовый индекс"
       spree/payment:
         amount: "Количество"
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: "Название"
       spree/product:
@@ -95,8 +98,8 @@ ru:
         starts_at: "Начинается"
         usage_limit: "Лимит использования"
       spree/promotion_category:
-        name: "Название"
         code: "Код"
+        name: "Название"
       spree/property:
         name: "Название"
         presentation: "Представление"
@@ -106,17 +109,19 @@ ru:
         amount: "Сумма"
       spree/role:
         name: "Название"
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: "Аббревиатура"
         name: "Название"
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
         mail_from_address: "Отсылать почту как"
         meta_description: Meta-описание
@@ -158,48 +163,54 @@ ru:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: "Срок действия карты истек"
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         many: "Адресов"
         one: "Адрес"
@@ -224,8 +235,8 @@ ru:
         many: "Позиций"
         one: "Позиция"
         other: "Позиции"
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         many: "Заказов"
         one: "Заказ"
@@ -262,7 +273,7 @@ ru:
         many: "Причин возврата"
         one: "Причина возврата"
         other: "Причины возврата"
-      spree/reimbursement:
+      spree/reimbursement: TODO_TRANSLATE
       spree/reimbursement_type:
         many: "Типов возврата"
         one: "Тип возврата"
@@ -276,7 +287,8 @@ ru:
         one: "Причина разрешения на возврат"
         other: "Причины разрешения на возврат"
       spree/role:
-        many: "Ролей"
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: "Роль"
         other: "Роли"
       spree/shipment:
@@ -295,12 +307,12 @@ ru:
         many: "Областей/Регионов"
         one: "Область/Регион"
         other: "Области/Региона"
-      spree/state_change:
+      spree/state_change: TODO_TRANSLATE
       spree/stock_location:
         many: "Расположений складов"
         one: "Расположение склада"
         other: "Расположения складов"
-      spree/stock_movement:
+      spree/stock_movement: TODO_TRANSLATE
       spree/stock_transfer:
         many: "Перемещений по складам"
         one: "Перемещение по складам"
@@ -337,6 +349,9 @@ ru:
         many: "Зон"
         one: "Зона"
         other: "Зоны"
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: "Ваш аккаунт успешно активирован. Теперь вы авторизованы."
@@ -375,6 +390,7 @@ ru:
     user_sessions:
       signed_in: "Вы успешно вошли."
       signed_out: "Вы успешно вышли."
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: "уже был подтвержден"
@@ -384,12 +400,30 @@ ru:
         many: "%{count} ошибок препятствуют сохранению %{resource}:"
         one: "Одна ошибка препятствует сохранению %{resource}:"
         other: "%{count} ошибки препятствуют сохранению %{resource}:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: "Аббревиатура"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "Учетная запись"
     account_updated: "Учетная запись обновлена!"
     action: "Действие"
@@ -402,7 +436,7 @@ ru:
       list: "Показать"
       listing: "Список"
       new: "Новый"
-      refund:
+      refund: TODO_TRANSLATE
       save: "Сохранить"
       update: "Изменить"
     activate: "Активировать"
@@ -424,11 +458,16 @@ ru:
     add_to_cart: "Добавить в корзину"
     add_variant: "Добавить вариант"
     additional_item: "Ставка для дополнительных наименований"
+    address: TODO_TRANSLATE
     address1: "Адрес"
     address2: "адрес (продолж.)"
     adjustable: "Корректируемое"
     adjustment: "Корректировка"
     adjustment_amount: "Количество"
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: "Корректировка была успешно закрыта!"
     adjustment_successfully_opened: "Корректировка была успешно открыта!"
     adjustment_total: "Итого (коррект.)"
@@ -453,18 +492,18 @@ ru:
         items: "Товары"
         items_purchased: "Купленные товары"
         order_history: "История заказов"
-        order_num:
+        order_num: TODO_TRANSLATE
         orders: "Заказы"
         user_information: "Информация"
     administration: "Администрирование"
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: "Согласиться с Политикой Конфиденциальности"
     agree_to_terms_of_service: "Согласиться с Уловиями обслуживания"
     all: "все"
     all_adjustments_closed: "Все корректировки успешно закрыты!"
     all_adjustments_opened: "Все корректировки успешно открыты!"
     all_departments: "Все разделы"
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: "Разрешить SSL для development и test режимов"
     allow_ssl_in_production: "Разрешить SSL для production режима"
     allow_ssl_in_staging: "Разрешить SSL для staging режима"
@@ -480,43 +519,77 @@ ru:
     analytics_desc_list_4: "Полностью бесплатный!"
     analytics_trackers: "Трекеры веб-аналитики"
     and: "и"
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: "Подтвердить"
     approved_at: "Подтверждено"
     approver: "Подтвердил(а)"
     are_you_sure: "Вы уверены"
     are_you_sure_delete: "Вы уверены, что хотите удалить эту запись?"
     associated_adjustment_closed: "Связанная корректировка закрыта, и не будет пересчитана. Хотите ли вы открыть её?"
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: "Ошибка авторизации"
-    authorized:
+    authorized: TODO_TRANSLATE
     auto_capture: "Автозахват"
     available_on: "Доступно с"
     average_order_value: "Средняя сумма заказа"
-    avs_response:
+    avs_response: TODO_TRANSLATE
     back: "Назад"
     back_end: "в администраторском интерфейсе"
-    back_to_payment:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
     back_to_resource_list: "Назад к списку"
     back_to_rma_reason_list: "Назад к списку причин разрешения на возврат"
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: "Вернуться в магазин"
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: "Назад к списку пользователей"
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: "Возможен предзаказ"
     backorderable_default: "Предзаказ по умолчанию"
     backordered: "Предзаказано"
     backorders_allowed: "Предзаказы разрешены"
     balance_due: "Дебетовое сальдо"
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: "Платёжный адрес"
     billing: "Биллинг"
     billing_address: "Платёжный адрес"
     both: "везде"
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: "Калькулятор"
     calculator_settings_warning: "При изменении типа калькулятора, вы должны сохранить это изменение, прежде, чем вы сможете изменить настройки калькулятора."
     cancel: "Отмена"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: "Нельзя создать платеж для заказа, если не настроен ни один из способов оплаты."
     cannot_create_returns: "Невозможно оформить возврат, т.к. этот заказ ещё не отправлен."
     cannot_perform_operation: "Невозможно выполнить требуемую операцию"
@@ -525,23 +598,23 @@ ru:
     capture_events: "Платежи"
     card_code: "Код карты"
     card_number: "Номер карты"
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: "Тип карты"
     cart: "Корзина"
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: "Категории"
     category: "Категория"
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: "Проверить оповещения Spree"
     checkout: "Оформление заказа"
     choose_a_customer: "Выберите клиента"
     choose_a_taxon_to_sort_products_for: "Выберите таксон для сортировки товаров"
     choose_currency: "Выбрать валюту"
     choose_dashboard_locale: "Выбрать язык отображения панели управления"
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: "Город"
     clear_cache: "Очистить кэш"
-    clear_cache_ok:
+    clear_cache_ok: TODO_TRANSLATE
     clear_cache_warning: "Внимание, данное действие приведёт к очистке кэша"
     click_and_drag_on_the_products_to_sort_them: "Перетаскивайте товары мышкой для сортировки"
     clone: "Копировать"
@@ -552,6 +625,7 @@ ru:
     complete: "Завершено"
     configuration: "Конфигурация"
     configurations: "Конфигурация"
+    configure_s3: TODO_TRANSLATE
     confirm: "Подтвердить"
     confirm_delete: "Подтверждение удаления"
     confirm_password: "Подтверждение пароля"
@@ -560,7 +634,7 @@ ru:
     cost_currency: "Валюта"
     cost_price: "Себестоимость"
     could_not_connect_to_jirafe: "Невозможно синхоринизороваться с Jirafe. Попытка будет повторена позже."
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: "Возникла проблема при сохранении перемещения запасов. Пожалуйста, попытайтесь снова."
     count_on_hand: "Наличие"
     countries: "Страны"
@@ -568,10 +642,10 @@ ru:
     country_based: "Страна"
     country_name: "Имя"
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: "Купон"
     coupon_code: "Код купона"
     coupon_code_already_applied: "Скидочный купон уже был применен к этому заказу"
@@ -581,17 +655,17 @@ ru:
     coupon_code_max_usage: "Лимит использования кода купона превышен"
     coupon_code_not_eligible: "Это скидочный купон не отвечает требованиям для этого заказа"
     coupon_code_not_found: "Скидочный купон не существует. Пожалуйста, попробуйте еще раз."
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: "Создать"
     create_a_new_account: "Создать новую учетную запись"
     create_new_order: "Создать новый заказ"
-    create_reimbursement:
+    create_reimbursement: TODO_TRANSLATE
     created_at: "Создано в"
     credit: "Кредит"
     credit_card: "Кредитная карта"
     credit_cards: "Кредитные карты"
     credit_owed: "Кредитная задолженность"
-    credits:
+    credits: TODO_TRANSLATE
     currency: "Валюта"
     currency_decimal_mark: "Десятичный знак валюты"
     currency_settings: "Настройки валюты"
@@ -602,11 +676,11 @@ ru:
     customer: "Клиент"
     customer_details: "Реквизиты клиента"
     customer_details_updated: "Данные клиента были обновлены."
-    customer_return:
+    customer_return: TODO_TRANSLATE
     customer_returns: "Возвраты покупателю"
     customer_search: "Поиск клиента"
-    cut:
-    cvv_response:
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: ID приложения
@@ -625,11 +699,15 @@ ru:
       js_format: dd.mm.yy
     date_range: "Период времени"
     default: "По умолчанию"
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: "Стандартный налог"
     default_tax_zone: "Стандартный налоговый регион"
     delete: "Удалить"
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: "Доставка"
     depth: "Глубина"
     description: "Описание"
@@ -640,26 +718,41 @@ ru:
     dismiss_banner: "Нет, спасибо! Я не заинтересован. Не показывайте мне больше это сообщение."
     display: "Показать"
     display_currency: "Показывать валюту"
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: "Редактировать"
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: "Редактирование пользователя"
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: "Электронная почта"
     empty: "пусто"
     empty_cart: "Очистить корзину"
@@ -694,29 +787,30 @@ ru:
           signup: "Новый пользователь"
     exceptions:
       count_on_hand_setter: "Невозможно установить значение count_on_hand вручную, т.к. оно устанавливается автоматически с помощью recalculate_count_on_hand callback'а. Вместо этого, используйте `update_column(:count_on_hand, value)`, пожалуйста"
-    exchange_for:
+    exchange_for: TODO_TRANSLATE
     excl: "искл."
-    existing_shipments:
-    expedited_exchanges_warning:
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: "Окончание действия"
     extension: "Расширение"
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: "Имя файла"
     fill_in_customer_info: "Заполните информацию о клиенте"
     filter: "Фильтр"
     filter_results: "Результаты фильтрации"
     finalize: "Завершить"
-    finalized:
+    finalized: TODO_TRANSLATE
     find_a_taxon: "Найти таксон"
     first_item: "Начальная ставка"
     first_name: "Имя"
     first_name_begins_with: "Имя начинается с"
     flat_percent: "Фиксированный процент"
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: "Фиксированная ставка (за заказ)"
     flexible_rate: "Гибкая ставка"
     forgot_password: "Забыли пароль?"
     free_shipping: "Бесплатная доставка"
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: "в публичном интерфейсе"
     gateway: "Платежный шлюз"
     gateway_config_unavailable: "Шлюз не доступен для данного окружения"
@@ -740,37 +834,41 @@ ru:
       only_incomplete: "Только незавершённые"
       select_locale: "Выберите локализацию"
       show_only: "Показывать только"
+      store_translations: TODO_TRANSLATE
       supported_locales: "Поддерживаемые языки"
       this_file_language: Russian
       translations: "Переводы"
     icon: "Иконка"
-    identifier:
+    identifier: TODO_TRANSLATE
     image: "Изображение"
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: "Изображения"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
     incl: "вкл."
     included_in_price: "Включено в цену"
     included_price_validation: "не может быть выбрано, если только вы настроили зону налогообложения по умолчанию"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: "Чтобы сбросить пароль, заполните форму ниже. Новый пароль будет отправлен вам по указанному email"
     insufficient_stock: "Недостаточно единиц товара, только %{on_hand} есть в наличии"
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: "Перехват писем"
     intercept_email_instructions: "Заменить email получателя на этот адрес."
     internal_name: "Внутреннее имя"
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: "Неверно указан способ оплаты"
     invalid_promotion_action: "Неверная промо-акция"
     invalid_promotion_rule: "Неверно указан принцип рекламной кампании"
     inventory: "Товарная номенклатура"
     inventory_adjustment: "Корректировки"
     inventory_error_flash_for_insufficient_quantity: "Один из товаров вашей корзины стал недоступен."
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: "не может быть применён к указанному адресу доставки"
     iso_name: "Имя согласно ISO"
     item: "Наименование"
@@ -780,12 +878,12 @@ ru:
       operators:
         gt: "больше"
         gte: "больше или равно"
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: "К сожалению мы не можем доставить ваш товар на указанный адрес. Пожалуйста введите другой адрес."
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: "Путь"
@@ -795,11 +893,17 @@ ru:
     lifetime_stats: "Статистика"
     line_item_adjustments: "Корректировки позиций"
     list: "Список"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "Загружается"
     locale_changed: "Язык изменён"
     location: "Местоположение"
     lock: Lock
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: "Пользователь"
     logged_in_succesfully: "Вы вошли в систему"
     logged_out: "Вы вышли из системы."
@@ -810,21 +914,24 @@ ru:
     logout: "Выйти"
     logs: "Журналы событий"
     look_for_similar_items: "Посмотрите похожие товары"
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: "Сделать возврат"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: "Основная цена"
     match_choices:
       all: "Всем"
       none: "Ни одному"
     max_items: "Максимальное число наименований по начальной ставке"
     member_since: "Зарегистр. с"
-    memo:
+    memo: TODO_TRANSLATE
     meta_description: "Описание"
     meta_keywords: "Ключевые слова"
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: "Метаданные"
     minimal_amount: "Минимальная сумма"
     month: "Месяц"
@@ -833,7 +940,7 @@ ru:
     my_account: "Моя учетная запись"
     my_orders: "Мои заказы"
     name: "Наименование"
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: "Наименование или артикул"
     new: "Новый"
     new_adjustment: "Новая корректировка"
@@ -851,11 +958,12 @@ ru:
     new_promotion_category: "Новая категория акций"
     new_property: "Новое свойство"
     new_prototype: "Новый прототип"
-    new_refund:
+    new_refund: TODO_TRANSLATE
     new_refund_reason: "Новая причина возврата"
     new_return_authorization: "Новое разрешение на возврат"
     new_rma_reason: "Новая причина разрешения на возврат"
-    new_shipment_at_location:
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: "Новая категория доставки"
     new_shipping_method: "Новый способ доставки"
     new_state: "Новый регион/область"
@@ -872,24 +980,30 @@ ru:
     new_zone: "Новая зона"
     next: "след."
     no_actions_added: "Нет действий"
-    no_payment_found:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: "Нет незавершённых платежей"
     no_products_found: "Не найдено ни одного товара"
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: "%{resource} не найдены"
     no_results: "Ничего не найдено"
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: "Ни одного правила не задано"
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: "Отсутствуют детали отслеживания"
     none: "Ни одного"
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: "Обычная сумма"
     not: "не"
     not_available: "Не доступен"
     not_enough_stock: "Недостаточно позиций в исходном местоположении для завершения движения"
     not_found: "%{resource} не найден"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: "Копия товара создана"
       product_deleted: "Товар успешно удалён"
@@ -912,32 +1026,37 @@ ru:
     or_over_price: "более чем %{price}"
     order: "Заказ"
     order_adjustments: "Корректировки заказа"
-    order_already_updated:
+    order_already_updated: TODO_TRANSLATE
     order_approved: "Заказ подтвержден"
-    order_canceled:
+    order_canceled: TODO_TRANSLATE
     order_details: "Реквизиты заказа"
     order_email_resent: "Письмо с описанием заказа выслано повторно"
     order_information: "Информация"
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: "Дорогой покупатель,\\n"
         instructions: "Ваш заказ был отменен. Сохраните эту информацию для истории."
         order_summary_canceled: "Детали заказа [ОТМЕНЕНО]"
         subject: "Аннулирование заказа"
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: "Дорогой покупатель,\\n"
         instructions: "Пожалуйста, проверьте детали заказа."
         order_summary: "Детали заказа"
         subject: "Подтверждение заказа"
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: "Спасибо, что выбрали нас."
-        total:
+        total: TODO_TRANSLATE
     order_not_found: "Мы не смогли найти Ваш заказ. Попробуйте еще раз."
     order_number: "Заказ %{number}"
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: "Ваш заказ был успешно обработан"
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: "Адрес"
       awaiting_return: "Ожидает возврата"
@@ -945,7 +1064,7 @@ ru:
       cart: "орзина"
       complete: "Завершение"
       confirm: "Подтверждение"
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: "Доставка"
       payment: "Оплата"
       resumed: "Возобновлён"
@@ -955,12 +1074,14 @@ ru:
     order_total: "Итого заказ"
     order_updated: "Заказ обновлен"
     orders: "Заказы"
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: "Нет в наличии"
     overview: "Обзор"
     package_from: "Фасовку в"
     pagination:
+      first: TODO_TRANSLATE
       next_page: "следующая страница »"
+      previous: TODO_TRANSLATE
       previous_page: "« предыдущая страница"
       truncate: "…"
     password: "Пароль"
@@ -968,8 +1089,8 @@ ru:
     path: "Путь"
     pay: "оплатить"
     payment: "Платеж"
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: "Информация о платеже"
     payment_method: "Способ оплаты"
     payment_method_not_supported: "Этот способ оплаты не поддерживается"
@@ -990,22 +1111,23 @@ ru:
       void: "аннулирован"
     payment_updated: "Платёж обновлён"
     payments: "Платежи"
-    pending:
+    pending: TODO_TRANSLATE
     percent: "Процент"
     percent_per_item: "Процент с каждой единицы товара"
     permalink: "Постоянная ссылка"
     phone: "Телефон"
     place_order: "Разместить заказ"
     please_define_payment_methods: "Сначала определите способ оплаты."
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: "Что-то пошло не так. Попробуйте добавить товар еще раз."
     powered_by: "Работает на"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: "Отображать как"
     previous: "пред."
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: "Цена"
     price_range: "Ценовой диапазон"
     price_sack: Price Sack
@@ -1017,10 +1139,10 @@ ru:
     product_properties: "Свойства товара"
     product_rule:
       choose_products: "Выбранные товары"
-      label:
+      label: TODO_TRANSLATE
       match_all: "все"
       match_any: "хотя бы один"
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: "Из группы товаров"
         manual: "Выбрать вручную"
@@ -1032,19 +1154,24 @@ ru:
         description: "Создаёт промо-корректировки для заказа"
         name: "Создать корректировку"
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: "Заполняет корзину указанным количеством вариантов"
         name: "Создать элемент заказа"
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: "Акции"
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: "Соответствует всем этим правилам"
         any: "Соответствует хотя бы одному правилу"
+    promotion_label: TODO_TRANSLATE
     promotion_rule: "Правило"
     promotion_rule_types:
       first_order:
@@ -1057,25 +1184,25 @@ ru:
         description: "Покупатель должен был попасть на указанную страницу"
         name: "Страница"
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: "Заказ включает указанные товары"
         name: "Товары"
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: "Доступно только для указанных пользователей"
         name: "Пользователи"
       user_logged_in:
         description: "Доступно только зарегистрированным пользователям"
         name: "Пользователь авторизовался"
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: "Промо-акции"
     propagate_all_variants: "Применить ко всем вариантам"
     properties: "Свойства"
@@ -1094,41 +1221,43 @@ ru:
     receive: "Получить"
     receive_stock: "Получить товар"
     received: "Получен"
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: "Ссылка"
+    reference_contains: TODO_TRANSLATE
     refund: "Возврат"
-    refund_amount_must_be_greater_than_zero:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
     refund_reasons: "Причины возврата"
-    refunded_amount:
-    refunds:
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: "Зарегистрироваться как новый пользователь"
     registration: "Регистрация"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
     reimbursement_types: "Типы возврата"
-    reimbursements:
-    reject:
-    rejected:
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: "Запомнить меня"
     remove: "Убрать"
     rename: "Переименовать"
-    report:
+    report: TODO_TRANSLATE
     reports: "Отчеты"
+    resellable: TODO_TRANSLATE
     resend: "Отправить повторно"
     reset_password: "Сбросить мой пароль"
     response_code: "Код ответа"
@@ -1139,25 +1268,32 @@ ru:
     return_authorization_reasons: "Причины разрешения на возврат"
     return_authorization_updated: "Разрешение на возврат обновлено"
     return_authorizations: "Разрешения на возврат"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
     return_number: "Номер возврата"
     return_quantity: "возвращенное количество"
     returned: "Возвращенные"
     returns: "Разрешения на возврат"
     review: "Проверить"
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: "Номер RMA"
     rma_value: "Сумма RMA"
+    role_id: TODO_TRANSLATE
     roles: "Роли"
     rules: "Правила"
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
     safe: "Безопасный"
     sales_total: "Итого (продажи)"
     sales_total_description: "Общий объём продаж по всем заказам"
@@ -1177,6 +1313,7 @@ ru:
     select_a_stock_location: "Выбрать адрес склада"
     select_from_prototype: "Выбрать из прототипов"
     select_stock: "Выбрать склад"
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: "Отсылать копии всех писем на"
     send_mails_as: "Отсылать почту как"
     server: "Сервер"
@@ -1187,7 +1324,8 @@ ru:
     ship_total: "Всего к доставке"
     shipment: "Отправка"
     shipment_adjustments: "Корректировки доставки"
-    shipment_details:
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: "Дорогой покупатель,\\n"
@@ -1200,13 +1338,13 @@ ru:
     shipment_state: "Статус отправки"
     shipment_states:
       backorder: "задерживается"
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: "частично"
       pending: "ожидает"
       ready: "готов"
       shipped: "отправлен"
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: "Отправки"
     shipped: "Отправлено"
     shipping: "Доставка"
@@ -1220,6 +1358,10 @@ ru:
     shipping_method: "Способ доставки"
     shipping_methods: "Способы доставки"
     shipping_price_sack: "Подсчет стоимости доставки"
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     shipping_total: "Итого (доставка):"
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: "Корзина"
@@ -1227,52 +1369,64 @@ ru:
     show_active: "Показать активные"
     show_deleted: "Показать удаленные"
     show_only_complete_orders: "Показывать только завершённые заказы"
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: "Показывать процент в названии"
     sku: "Артикул"
-    skus:
+    skus: TODO_TRANSLATE
     slug: "Ссылка"
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: "Источник"
     special_instructions: "Дополнительные инструкции"
     split: "Разделить"
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: "Возникли проблемы с Вашими реквизитами. Пожалуйста, проверьте их и попробуйте ещё раз."
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: "Начало"
+    start_date: TODO_TRANSLATE
     state: "Регион/Область"
     state_based: "Есть области"
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: "Регионы/Области"
     states_required: "Регионы обязательны"
     status: "Статус"
@@ -1280,7 +1434,7 @@ ru:
     stock_location: "Расположение склада"
     stock_location_info: "Подробности расположения склада"
     stock_locations: "Адреса складов"
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: "Управление Запасами"
     stock_management_requires_a_stock_location: "Добавьте расположение склада для управления запасами, пожалуйста."
     stock_movements: "Перемещения товаров"
@@ -1294,28 +1448,30 @@ ru:
     street_address_2: "Адрес (строка 2)"
     subtotal: "Подитог"
     subtract: "Вычет"
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} был успешно создан!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} был успешно удален!"
     successfully_signed_up_for_analytics: "Успешно авторизованы в Spree Analytics"
     successfully_updated: "%{resource} был успешно обновлен!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: "Налог"
     tax_categories: "Категории налогов"
     tax_category: "Категория налогов"
-    tax_code:
+    tax_code: TODO_TRANSLATE
     tax_included: "Вкл. налоги"
     tax_rate_amount_explanation: "Налоговые ставки вводятся как десятичные значения (напр. если налог 5%, то вводите 0.05)"
     tax_rates: "Налоговые ставки"
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: "Таксон"
     taxon_edit: "Редактировать таксон"
     taxon_placeholder: "Добавить таксон"
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: "Таксономии"
     taxonomy: "Таксономия"
     taxonomy_edit: "Редактирование таксономии"
@@ -1324,6 +1480,9 @@ ru:
     taxons: "Таксоны"
     test: "Тест"
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: "Поздравляем!"
         message: "Если Вы читаете это сообщение, значит почтовые настройки Spree верны."
@@ -1332,24 +1491,24 @@ ru:
     thank_you_for_your_order: "Спасибо за покупку!"
     there_are_no_items_for_this_order: "В этом заказе нет товаров. Добавьте товары, чтобы продолжить, пожалуйста."
     there_were_problems_with_the_following_fields: "Возникли некоторые проблемы со следующими полями"
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: "Миниатюра"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: "Время"
     to_add_variants_you_must_first_define: "Перед добавлением вариантов, вы должны определить"
     total: "Итого"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
     total_sales: "Всего продано на"
     track_inventory: "Отслеживать наличие"
     tracking: "Отслеживание"
     tracking_number: "Трекинговый номер"
     tracking_url: "Трекинговый URL"
     tracking_url_placeholder: "например, http://quickship.com/package?num=:tracking"
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: "Перевести из"
     transfer_stock: "Перевести Товар"
     transfer_to_location: "Перевести на"
@@ -1357,7 +1516,7 @@ ru:
     type: "Тип"
     type_to_search: "Начните печатать чтобы активировать поиск"
     unable_to_connect_to_gateway: "Не удалось подключиться к платёжному шлюзу."
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: "Дешевле %{price}"
     unlock: "Разблокировать"
     unrecognized_card_type: "Неизвестный тип карты"
@@ -1367,7 +1526,9 @@ ru:
     usage_limit: "Максимальное количество использований"
     use_app_default: "По умолчанию"
     use_billing_address: "Использовать платёжный адрес"
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: "Использовать новую карту"
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: "Использовать Amazon S3 для хранения изображений"
     user: "Пользователь"
     user_rule:
@@ -1375,12 +1536,13 @@ ru:
     users: "Пользователи"
     validation:
       cannot_be_less_than_shipped_units: "не может быть меньше, чем количество отгруженных единиц"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: "превышает количество на складе. Пожалуйста проверьте количество товара."
       is_too_large: "слишком много - количество на складе меньше запрошенного количества!"
       must_be_int: "должно быть целым числом"
       must_be_non_negative: "должно быть неотрицательным числом"
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: "Значение"
     variant: "Вариант"
     variant_placeholder: "Выберите вариант"
@@ -1399,3 +1561,10 @@ ru:
     zipcode: "Почтовый индекс"
     zone: "Торговая зона"
     zones: "Торговые зоны"
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,4 +1,6 @@
+---
 sk:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -6,17 +8,17 @@ sk:
         address2: Adresa (pokr.)
         city: Mesto
         country: "Štát"
-        firstname: "Krstné meno"
+        firstname: Krstné meno
         lastname: Priezvisko
         phone: Telefón
         state: Kraj
-        zipcode: "PSČ"
+        zipcode: PSČ
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,36 +26,36 @@ sk:
         name: Názov
         numcode: ISO kód štátu
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Typ
         month: Mesiac
-        name: "Meno"
+        name: Meno
         number: "Číslo"
-        verification_value: "Overovací kód"
+        verification_value: Overovací kód
         year: Rok
       spree/inventory_unit:
-        state:
+        state: TODO_TRANSLATE
       spree/line_item:
         price: Cena
-        quantity: "Množstvo"
+        quantity: Množstvo
       spree/option_type:
         name: Názov
-        presentation:
+        presentation: TODO_TRANSLATE
       spree/order:
-        checkout_complete: "Dokončiť objednávku"
-        completed_at: "Dokončené"
-        considered_risky:
-        coupon_code: "Kód kupónu"
-        created_at: "Dátum objednania"
+        checkout_complete: Dokončiť objednávku
+        completed_at: Dokončené
+        considered_risky: TODO_TRANSLATE
+        coupon_code: Kód kupónu
+        created_at: Dátum objednania
         email: Email zákazníka
         ip_address: IP adresa
-        item_total:
-        number: "Počet"
-        payment_state: "Stav platby"
-        shipment_state: "Stav doručenia"
-        special_instructions: "Zvláštne pokyny"
-        state:
-        total: "Celkom"
+        item_total: TODO_TRANSLATE
+        number: Počet
+        payment_state: Stav platby
+        shipment_state: Stav doručenia
+        special_instructions: Zvláštne pokyny
+        state: TODO_TRANSLATE
+        total: Celkom
       spree/order/bill_address:
         address1: "Účtovná adresa - Ulica a č.d."
         city: "Účtovná adresa - Mesto/Obec"
@@ -63,830 +65,961 @@ sk:
         state: "Účtovná adresa - Kraj"
         zipcode: "Účtovná adresa - PSČ"
       spree/order/ship_address:
-        address1: "Doručovacia adresa - Ulica a č.d."
-        city: "Doručovacia adresa - Mesto/Obec"
-        firstname: "Doručovacia adresa - Krstné meno"
-        lastname: "Doručovacia adresa - Priezvisko"
-        phone: "Doručovacia adresa - Telefón"
-        state: "Doručovacia adresa - Kraj"
-        zipcode: "Doručovacia adresa - PSČ"
+        address1: Doručovacia adresa - Ulica a č.d.
+        city: Doručovacia adresa - Mesto/Obec
+        firstname: Doručovacia adresa - Krstné meno
+        lastname: Doručovacia adresa - Priezvisko
+        phone: Doručovacia adresa - Telefón
+        state: Doručovacia adresa - Kraj
+        zipcode: Doručovacia adresa - PSČ
       spree/payment:
-        amount: "Suma"
+        amount: Suma
+        number: TODO_TRANSLATE
       spree/payment_method:
-        name: "Názov"
+        name: Názov
       spree/product:
-        available_on:
-        cost_currency:
-        cost_price:
-        description: "Popis"
-        master_price:
-        name: "Názov"
-        on_hand:
-        shipping_category:
-        tax_category:
+        available_on: TODO_TRANSLATE
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        description: Popis
+        master_price: TODO_TRANSLATE
+        name: Názov
+        on_hand: TODO_TRANSLATE
+        shipping_category: TODO_TRANSLATE
+        tax_category: TODO_TRANSLATE
       spree/promotion:
-        advertise:
-        code: "Kód"
-        description: "Popis"
-        event_name:
-        expires_at:
-        name: "Názov"
-        path: "Cesta"
-        starts_at:
-        usage_limit:
+        advertise: TODO_TRANSLATE
+        code: Kód
+        description: Popis
+        event_name: TODO_TRANSLATE
+        expires_at: TODO_TRANSLATE
+        name: Názov
+        path: Cesta
+        starts_at: TODO_TRANSLATE
+        usage_limit: TODO_TRANSLATE
       spree/promotion_category:
-        name: "Názov"
+        code: TODO_TRANSLATE
+        name: Názov
       spree/property:
-        name: "Názov"
-        presentation:
+        name: Názov
+        presentation: TODO_TRANSLATE
       spree/prototype:
-        name: "Názov"
+        name: Názov
       spree/return_authorization:
-        amount:
+        amount: TODO_TRANSLATE
       spree/role:
-        name: "Názov"
+        name: Názov
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
-        abbr: "Skratka"
-        name: "Názov"
+        abbr: Skratka
+        name: Názov
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type: "Typ"
-        updated: "Aktualizované"
-        user: "Používateľ"
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: Typ
+        updated: Aktualizované
+        user: Používateľ
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name: "Názov"
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: Názov
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Popis
-        name: "Názov"
+        name: Názov
       spree/tax_rate:
-        amount: "Suma"
-        included_in_price: "Zahrnutá v cene"
-        show_rate_in_label:
+        amount: Suma
+        included_in_price: Zahrnutá v cene
+        show_rate_in_label: TODO_TRANSLATE
       spree/taxon:
-        name: "Názov"
+        name: Názov
         permalink: Permalink
-        position: "Umiestnenie"
+        position: Umiestnenie
       spree/taxonomy:
-        name: "Názov"
+        name: Názov
       spree/user:
-        email: "E-mail"
+        email: E-mail
         password: Heslo
         password_confirmation: Potvrdenie hesla
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth: "Hĺbka"
-        height: "Výška"
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        depth: Hĺbka
+        height: Výška
         price: Cena
         sku: SKU
-        weight: "Hmotnosť"
+        weight: Hmotnosť
         width: "Šírka"
       spree/zone:
         description: Popis
-        name: "Názov"
+        name: Názov
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
-        one: Adresa
         few: Adresy
+        one: Adresa
         other: Adries
       spree/country:
-        one: "Štát"
         few: "Štáty"
+        one: "Štát"
         other: "Štátov"
       spree/credit_card:
-        one: "Kreditná karta"
-        few: "Kreditné karty"
-        other: "Kreditných kariet"
-      spree/customer_return:
+        few: Kreditné karty
+        one: Kreditná karta
+        other: Kreditných kariet
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
-        one: "Skladová jednotka"
-        few: "Skladové jednotky"
-        other: "Skladových jednotiek"
+        few: Skladové jednotky
+        one: Skladová jednotka
+        other: Skladových jednotiek
       spree/line_item:
-        one: "Riadková položka"
-        few: "Riadkové položky"
-        other: "Riadkových položiek"
-      spree/option_type:
-      spree/option_value:
+        few: Riadkové položky
+        one: Riadková položka
+        other: Riadkových položiek
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
-        one: "Objednávka"
-        few: "Objednávky"
-        other: "Objednávok"
+        few: Objednávky
+        one: Objednávka
+        other: Objednávok
       spree/payment:
-        one: Platba
         few: Platby
+        one: Platba
         other: Platieb
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
-        one: Produkt
         few: Produkty
+        one: Produkt
         other: Produktov
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/prototype:
-        one: Prototyp
         few: Prototypy
+        one: Prototyp
         other: Prototypov
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
-      spree/return_authorization_reason:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
-        one: Rola
         few: Roly
-        oher: "Rôl"
+        oher: Rôl
+        one: Rola
+        other: TODO_TRANSLATE
       spree/shipment:
-        one: "Doručenie"
-        few: "Doručenia"
-        other: "Doručení"
+        few: Doručenia
+        one: Doručenie
+        other: Doručení
       spree/shipping_category:
-        one: "Kategória doručenia"
-        few: "Kategórie doručenia"
-        other: "Kategórií doručenia"
+        few: Kategórie doručenia
+        one: Kategória doručenia
+        other: Kategórií doručenia
       spree/shipping_method:
-        one: "Spôsob doručenia"
-        few: "Spôsoby doručenia"
-        other: "Spôsobov doručenia"
+        few: Spôsoby doručenia
+        one: Spôsob doručenia
+        other: Spôsobov doručenia
       spree/state:
-        one: Kraj
         few: Kraje
+        one: Kraj
         other: Krajov
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/tax_rate:
-        one: "Sadzba dane"
-        few: "Sadzby dane"
-        other: "Sadzieb dane"
+        few: Sadzby dane
+        one: Sadzba dane
+        other: Sadzieb dane
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
-        one: "Taxonómia"
-        few: "Taxonómie"
-        other: "Taxonómií"
-      spree/tracker:
+        few: Taxonómie
+        one: Taxonómia
+        other: Taxonómií
+      spree/tracker: TODO_TRANSLATE
       spree/user:
-        one: "Používateľ"
-        few: "Používatelia"
-        other: "Používateľov"
+        few: Používatelia
+        one: Používateľ
+        other: Používateľov
       spree/variant:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/zone:
-        one: "Zóna"
-        few: "Zóny"
-        other: "Zón"
+        few: Zóny
+        one: Zóna
+        other: Zón
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
-      inactive:
-      invalid:
-      invalid_token:
-      locked:
-      timeout:
-      unauthenticated:
-      unconfirmed:
+      inactive: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      invalid_token: TODO_TRANSLATE
+      locked: TODO_TRANSLATE
+      timeout: TODO_TRANSLATE
+      unauthenticated: TODO_TRANSLATE
+      unconfirmed: TODO_TRANSLATE
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Skratka
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "Účet"
     account_updated: "Účet aktualizovaný"
     action: Akcia
     actions:
-      cancel: "Zrušiť"
-      continue: "Pokračovať"
-      create: "Vytvoriť"
-      destroy: "Zmazať"
-      edit: "Upraviť"
+      cancel: Zrušiť
+      continue: Pokračovať
+      create: Vytvoriť
+      destroy: Zmazať
+      edit: Upraviť
       list: Zoznam
       listing: Zoznam
       new: Nový
-      refund:
-      save: "Uložiť"
-      update: "Aktualizovať"
-    activate: "Aktivovať"
-    active: "Aktívny"
-    add: "Pridať"
-    add_action_of_type: "Pridať akciu typu"
-    add_country: "Pridať štát"
-    add_coupon_code:
-    add_new_header: "Pridať novú hlavičku"
-    add_new_style: "Pridať nový štýl"
-    add_one: "Pridať jeden"
-    add_option_value: "Pridať novú voľbu"
-    add_product: "Pridať produkt"
-    add_product_properties: "Pridať vlastnosť produktu"
-    add_rule_of_type: "Pridať pravidlo typu"
-    add_state: "Pridať okres"
-    add_stock: "Pridať sklad"
-    add_stock_management: "Pridať správu skladu"
-    add_to_cart: "Pridať do košíka"
-    add_variant: "Pridať variant"
+      refund: TODO_TRANSLATE
+      save: Uložiť
+      update: Aktualizovať
+    activate: Aktivovať
+    active: Aktívny
+    add: Pridať
+    add_action_of_type: Pridať akciu typu
+    add_country: Pridať štát
+    add_coupon_code: TODO_TRANSLATE
+    add_new_header: Pridať novú hlavičku
+    add_new_style: Pridať nový štýl
+    add_one: Pridať jeden
+    add_option_value: Pridať novú voľbu
+    add_product: Pridať produkt
+    add_product_properties: Pridať vlastnosť produktu
+    add_rule_of_type: Pridať pravidlo typu
+    add_state: Pridať okres
+    add_stock: Pridať sklad
+    add_stock_management: Pridať správu skladu
+    add_to_cart: Pridať do košíka
+    add_variant: Pridať variant
     additional_item: "Ďaľšie náklady na tovar"
+    address: TODO_TRANSLATE
     address1: Adresa
     address2: Adresa (pokr.)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: "Úprava"
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
-    adjustment_total:
-    adjustments:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
+    adjustment_total: TODO_TRANSLATE
+    adjustments: TODO_TRANSLATE
     admin:
       tab:
-        configuration: "Konfigurácia"
-        option_types: "Typy volieb"
-        orders: "Objednávky"
-        overview: "Prahľad"
-        products: "Produkty"
-        promotions: 
-        properties: "Vlastnosti"
-        prototypes: "Prototypy"
-        reports: "Výkazy"
-        taxonomies: "Taxonómie"
-        taxons:
-        users: "Používatelia"
+        configuration: Konfigurácia
+        option_types: Typy volieb
+        orders: Objednávky
+        overview: Prahľad
+        products: Produkty
+        promotions: TODO_TRANSLATE
+        properties: Vlastnosti
+        prototypes: Prototypy
+        reports: Výkazy
+        taxonomies: Taxonómie
+        taxons: TODO_TRANSLATE
+        users: Používatelia
       user:
         account: "Účet"
-        addresses: "Adresy"
-        items: "Položky"
-        items_purchased: "Zakúpené položky"
-        order_history: "História objednávok"
+        addresses: Adresy
+        items: Položky
+        items_purchased: Zakúpené položky
+        order_history: História objednávok
         order_num: "Číslo objednávky"
-        orders: "Objednávky"
-        user_information:
+        orders: Objednávky
+        user_information: TODO_TRANSLATE
     administration: Administrácia
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
     all: Všetky
-    all_adjustments_closed:
-    all_adjustments_opened:
-    all_departments: "Všetky oddelenia"
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
-    alt_text: "Alternatívny text"
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
+    all_departments: Všetky oddelenia
+    all_items_have_been_returned: TODO_TRANSLATE
+    allow_ssl_in_development_and_test: TODO_TRANSLATE
+    allow_ssl_in_production: TODO_TRANSLATE
+    allow_ssl_in_staging: TODO_TRANSLATE
+    already_signed_up_for_analytics: TODO_TRANSLATE
+    alt_text: Alternatívny text
     alternative_phone: Iný telefónny kontakt
     amount: Suma
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
-    analytics_trackers:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
+    analytics_trackers: TODO_TRANSLATE
     and: a
-    approve: "Schváliť"
-    approved_at: "Schválené"
-    approver: "Schválil"
-    are_you_sure: "Ste si istí?"
-    are_you_sure_delete: "Ste si istí, že chcete zmazať tento záznam?"
-    associated_adjustment_closed:
-    authorization_failure: "Chyba pri autorizácii"
-    authorized: 
-    auto_capture:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: Schváliť
+    approved_at: Schválené
+    approver: Schválil
+    are_you_sure: Ste si istí?
+    are_you_sure_delete: Ste si istí, že chcete zmazať tento záznam?
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
+    authorization_failure: Chyba pri autorizácii
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Prístupný dňa
-    average_order_value: "Priemerná hodnota objednávky"
-    avs_response:
-    back: "Späť"
-    back_end:
-    back_to_payment: "Späť na platbu"
-    back_to_resource_list:
-    back_to_rma_reason_list:
-    back_to_store: "Späť do obchodu"
-    back_to_users_list: "Späť na zoznam používateľov"
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
-    balance_due:
-    base_amount:
-    base_percent:
+    average_order_value: Priemerná hodnota objednávky
+    avs_response: TODO_TRANSLATE
+    back: Späť
+    back_end: TODO_TRANSLATE
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: Späť na platbu
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
+    back_to_store: Späť do obchodu
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: Späť na zoznam používateľov
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
+    balance_due: TODO_TRANSLATE
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: "Účtovanie na adresu"
-    billing:
+    billing: TODO_TRANSLATE
     billing_address: "Účtovná adresa"
-    both:
-    calculated_reimbursements:
+    both: TODO_TRANSLATE
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Kalkulačka
     calculator_settings_warning: Ak si prajete zmenu typu kalkulačky, je potrebné nastavenia najprv uložiť pred daľšími zmenami v nastaveniach kalkulačky.
     cancel: zrušiť
-    canceled_at: "Zrušené"
-    canceler: "Zrušil"
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
-    cannot_create_returns:
-    cannot_perform_operation: "Operácia sa nedá vykonať"
-    cannot_set_shipping_method_without_address:
-    capture: "zachytiť"
-    capture_events:
+    canceled_at: Zrušené
+    canceler: Zrušil
+    cannot_create_customer_returns: TODO_TRANSLATE
+    cannot_create_payment_without_payment_methods: TODO_TRANSLATE
+    cannot_create_returns: TODO_TRANSLATE
+    cannot_perform_operation: Operácia sa nedá vykonať
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
+    capture: zachytiť
+    capture_events: TODO_TRANSLATE
     card_code: Kód karty
     card_number: "Číslo karty"
-    card_type: "Typ karty"
+    card_type: Typ karty
     card_type_is: Typ karty je
     cart: Košík
-    cart_subtotal: "Medzisúčet"
+    cart_subtotal: Medzisúčet
     categories: Kategórie
     category: Kategória
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Platba
-    choose_a_customer: "Zvoliť zákazníka"
-    choose_a_taxon_to_sort_products_for:
-    choose_currency: "Zvoliť menu"
-    choose_dashboard_locale: "Zvoliť národné prostredie pre nástenku"
-    choose_location: "Zvoliť miesto"
-    city: "Mesto/Obec"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
-    clone:
-    close:
-    close_all_adjustments:
+    choose_a_customer: Zvoliť zákazníka
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: Zvoliť menu
+    choose_dashboard_locale: Zvoliť národné prostredie pre nástenku
+    choose_location: Zvoliť miesto
+    city: Mesto/Obec
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
+    clone: TODO_TRANSLATE
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
     code: Kód
-    company: "Spoločnosť"
+    company: Spoločnosť
     complete: celkom
     configuration: Nastavenie
     configurations: Nastavenia
-    confirm: "Potvrdiť"
-    confirm_delete: "Potvriť zmazanie"
+    configure_s3: TODO_TRANSLATE
+    confirm: Potvrdiť
+    confirm_delete: Potvriť zmazanie
     confirm_password: Potvrdenie hesla
-    continue: "Pokračovať"
-    continue_shopping: "Pokračovať v nákupe"
-    cost_currency: "Mena nákladov"
-    cost_price: "Suma nákladov"
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement: "Vyskytol sa problém pri ukladaní tohoto skladového pohybu. Skúste prosím znova"
-    count_on_hand:
+    continue: Pokračovať
+    continue_shopping: Pokračovať v nákupe
+    cost_currency: Mena nákladov
+    cost_price: Suma nákladov
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: Vyskytol sa problém pri ukladaní tohoto skladového pohybu. Skúste prosím znova
+    count_on_hand: TODO_TRANSLATE
     countries: "Štáty"
     country: "Štát"
     country_based: Krajina
-    country_name: "Názov"
+    country_name: Názov
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon: "Kupón"
-    coupon_code:
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
-    create: "Vytvoriť"
-    create_a_new_account: "Vytvoriť nový účet"
-    create_new_order: "Vytvoriť novú objednávku"
-    create_reimbursement:
-    created_at: "Vytvorené"
-    credit: "Kredit"
-    credit_card: "Kreditná karta"
-    credit_cards: "Kreditné karty"
-    credit_owed:
-    credits:
-    currency: "Mena"
-    currency_decimal_mark: "Znak desatinnej čiarky"
-    currency_settings: "Nastavenia meny"
-    currency_symbol_position: "Umiestniť znaku meny pred, alebo za sumu?"
-    currency_thousands_separator: "Oddeľovač tisícov"
-    current: "Aktuálny"
-    current_promotion_usage:
-    customer: "Zákazník"
-    customer_details: "Podrobnosti o zákazíkovi"
-    customer_details_updated: "Podrobnosti o zákazníkovi boli aktualizované."
-    customer_return:
-    customer_returns:
-    customer_search: "Vyhľadávanie zákazníkov"
-    cut: "Vyrezať"
-    cvv_response:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
+    coupon: Kupón
+    coupon_code: TODO_TRANSLATE
+    coupon_code_already_applied: TODO_TRANSLATE
+    coupon_code_applied: TODO_TRANSLATE
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
+    create: Vytvoriť
+    create_a_new_account: Vytvoriť nový účet
+    create_new_order: Vytvoriť novú objednávku
+    create_reimbursement: TODO_TRANSLATE
+    created_at: Vytvorené
+    credit: Kredit
+    credit_card: Kreditná karta
+    credit_cards: Kreditné karty
+    credit_owed: TODO_TRANSLATE
+    credits: TODO_TRANSLATE
+    currency: Mena
+    currency_decimal_mark: Znak desatinnej čiarky
+    currency_settings: Nastavenia meny
+    currency_symbol_position: Umiestniť znaku meny pred, alebo za sumu?
+    currency_thousands_separator: Oddeľovač tisícov
+    current: Aktuálny
+    current_promotion_usage: TODO_TRANSLATE
+    customer: Zákazník
+    customer_details: Podrobnosti o zákazíkovi
+    customer_details_updated: Podrobnosti o zákazníkovi boli aktualizované.
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
+    customer_search: Vyhľadávanie zákazníkov
+    cut: Vyrezať
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date: "Dátum"
-    date_completed:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: Dátum
+    date_completed: TODO_TRANSLATE
     date_picker:
       first_day: 1
       format: "%d.%m.%Y"
       js_format: dd.mm.rr
-    date_range: "Obdobie"
-    default:
-    default_refund_amount:
-    default_tax: 
-    default_tax_zone:
-    delete: "Zmazať"
-    deleted_variants_present:
+    date_range: Obdobie
+    default: TODO_TRANSLATE
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
+    delete: Zmazať
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Doručenie
-    depth: "Hĺbka"
+    depth: Hĺbka
     description: Popis
-    destination: "Miesto doručenia"
-    destroy: "Zrušiť"
-    details: "podrobnosti"
-    discount_amount:
-    dismiss_banner:
-    display: "Zobraziť"
-    display_currency:
-    doesnt_track_inventory:
-    edit: "Upraviť"
-    editing_resource:
-    editing_rma_reason:
+    destination: Miesto doručenia
+    destroy: Zrušiť
+    details: podrobnosti
+    discount_amount: TODO_TRANSLATE
+    dismiss_banner: TODO_TRANSLATE
+    display: Zobraziť
+    display_currency: TODO_TRANSLATE
+    doesnt_track_inventory: TODO_TRANSLATE
+    edit: Upraviť
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: "Úprava používateľa"
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: Prázdny
-    empty_cart: "Prázdny košík"
+    empty_cart: Prázdny košík
     enable_mail_delivery: Povolenie doručenie emailom
-    end:
-    ending_in:
-    environment:
+    end: TODO_TRANSLATE
+    ending_in: TODO_TRANSLATE
+    environment: TODO_TRANSLATE
     error: chyba
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available: "Pre toto prostredie nie sú nastavené žiadne spôsoby platby"
-        no_shipping_methods_available: "Pre zvolenú lokalitu nie sú dostupné žiadne spôsoby doručenia, zmeňte prosím vašu adresu"
+        could_not_create_taxon: TODO_TRANSLATE
+        no_payment_methods_available: Pre toto prostredie nie sú nastavené žiadne spôsoby platby
+        no_shipping_methods_available: Pre zvolenú lokalitu nie sú dostupné žiadne spôsoby doručenia, zmeňte prosím vašu adresu
     errors_prohibited_this_record_from_being_saved:
-      one: "1 chyba znemožnila uložiť tento záznam"
       few: "%{count} chyby znemožnily uložiť tento záznam"
-      other:  "%{count} chýb znemožnilo uložiť tento záznam"
-    event: "Udalosť"
+      one: 1 chyba znemožnila uložiť tento záznam
+      other: "%{count} chýb znemožnilo uložiť tento záznam"
+    event: Udalosť
     events:
       spree:
         cart:
-          add: "Pridať do košíka"
+          add: Pridať do košíka
         checkout:
-          coupon_code_added:
+          coupon_code_added: TODO_TRANSLATE
         content:
-          visited:
+          visited: TODO_TRANSLATE
         order:
-          contents_changed:
-        page_view:
+          contents_changed: TODO_TRANSLATE
+        page_view: TODO_TRANSLATE
         user:
-          signup: "Registrácia používateľa"
+          signup: Registrácia používateľa
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Expirácia
     extension: Rozšírenie
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Názov súboru
-    fill_in_customer_info:
-    filter_results:
-    finalize:
-    finalized:
-    find_a_taxon:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
+    filter_results: TODO_TRANSLATE
+    finalize: TODO_TRANSLATE
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Cena prvej položky
-    first_name: "Krstné meno"
-    first_name_begins_with: "Krstné meno začína na"
-    flat_percent: "Pevné percento"
-    flat_rate_per_order: "Pevná sadzba (za objednávku)"
-    flexible_rate: "Pružná sadzba"
-    forgot_password: "Zabudnuté heslo"
-    free_shipping: "Doručenie zdarma"
-    free_shipping_amount:
-    front_end:
-    gateway: "Platobná brána"
-    gateway_config_unavailable:
+    first_name: Krstné meno
+    first_name_begins_with: Krstné meno začína na
+    flat_percent: Pevné percento
+    flat_rate_per_item: TODO_TRANSLATE
+    flat_rate_per_order: Pevná sadzba (za objednávku)
+    flexible_rate: Pružná sadzba
+    forgot_password: Zabudnuté heslo
+    free_shipping: Doručenie zdarma
+    free_shipping_amount: TODO_TRANSLATE
+    front_end: TODO_TRANSLATE
+    gateway: Platobná brána
+    gateway_config_unavailable: TODO_TRANSLATE
     gateway_error: Chyba brány
     general: Všeobecné
     general_settings: Všeobecné nastavenia
-    google_analytics:
-    google_analytics_id:
-    guest_checkout:
+    google_analytics: TODO_TRANSLATE
+    google_analytics_id: TODO_TRANSLATE
+    guest_checkout: TODO_TRANSLATE
     guest_user_account: K pokladnici ako hosť
-    has_no_shipped_units:
+    has_no_shipped_units: TODO_TRANSLATE
     height: Výška
-    hide_cents: "Skryť centy"
+    hide_cents: Skryť centy
     home: Domov
     i18n:
-      available_locales: "Dostupné národné prostredia"
-      fields: "Polia"
-      language: "Jazyk"
-      localization_settings: "Nastavenia národného prostredia"
-      only_complete: "Len kompletné"
-      only_incomplete: "Len nekompletné"
-      select_locale: "Zvoliť národné prostredie"
-      show_only: "Len zobraziť"
-      supported_locales: "Podporované národné prostredia"
+      available_locales: Dostupné národné prostredia
+      fields: Polia
+      language: Jazyk
+      localization_settings: Nastavenia národného prostredia
+      only_complete: Len kompletné
+      only_incomplete: Len nekompletné
+      select_locale: Zvoliť národné prostredie
+      show_only: Len zobraziť
+      store_translations: TODO_TRANSLATE
+      supported_locales: Podporované národné prostredia
       this_file_language: Slovenčina
-      translations: "Praklady"
-    icon: "Ikona"
-    identifier:
+      translations: Praklady
+    icon: Ikona
+    identifier: TODO_TRANSLATE
     image: Obrázok
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Obrázky
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive: "Neaktívny"
-    incl:
-    included_in_price: "Zahrnuté v cene"
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
-    instructions_to_reset_password:
-    insufficient_stock:
-    insufficient_stock_lines_present:
-    intercept_email_address:
-    intercept_email_instructions:
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: Neaktívny
+    incl: TODO_TRANSLATE
+    included_in_price: Zahrnuté v cene
+    included_price_validation: TODO_TRANSLATE
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
+    instructions_to_reset_password: TODO_TRANSLATE
+    insufficient_stock: TODO_TRANSLATE
+    insufficient_stock_lines_present: TODO_TRANSLATE
+    intercept_email_address: TODO_TRANSLATE
+    intercept_email_instructions: TODO_TRANSLATE
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: Sklad
     inventory_adjustment: "Úprava skladu"
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
-    is_not_available_to_shipment_address:
-    iso_name:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
+    is_not_available_to_shipment_address: TODO_TRANSLATE
+    iso_name: TODO_TRANSLATE
     item: Položka
     item_description: Popis položky
     item_total: Položky celkom
     item_total_rule:
       operators:
-        gt: "väčšie ako"
-        gte: "väčšie ako alebo rovné"
-        lt: "menšie ako"
-        lte: "menšie ako alebo rovné"
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        gt: väčšie ako
+        gte: väčšie ako alebo rovné
+        lt: menšie ako
+        lte: menšie ako alebo rovné
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
       path: Cesta
     last_name: Priezvisko
-    last_name_begins_with: "Priezvisko začína na"
-    learn_more: "Viac informácií"
-    lifetime_stats:
-    line_item_adjustments:
+    last_name_begins_with: Priezvisko začína na
+    learn_more: Viac informácií
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Zoznam
-    loading: "Načítavanie"
-    locale_changed: "Národné prostredie zmenené"
-    location: "Umiestnenie"
-    lock: "Zamknúť"
-    log_entries:
-    logged_in_as: "Prihlásený ako"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
+    loading: Načítavanie
+    locale_changed: Národné prostredie zmenené
+    location: Umiestnenie
+    lock: Zamknúť
+    log_entries: TODO_TRANSLATE
+    logged_in_as: Prihlásený ako
     logged_in_succesfully: "Úspešné prihlásenie"
     logged_out: Odhlásili ste sa.
-    login: "Prihlásenie"
+    login: Prihlásenie
     login_as_existing: Prihláste sa ako náš zákazník
     login_failed: Nesprávne prihlasovacie údaje.
     login_name: Prihlásenie
     logout: Odhlásenie
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Hľadaj podobný tovar
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
+    make_refund: TODO_TRANSLATE
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Hlavná cena
     match_choices:
-      all:
-      none:
+      all: TODO_TRANSLATE
+      none: TODO_TRANSLATE
     max_items: Maximálny počet položiek
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta-popis
     meta_keywords: Meta-kľúčové slová
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metaúdaje
-    minimal_amount: "Minimálne množstvo"
+    minimal_amount: Minimálne množstvo
     month: Mesiac
     more: Viac
-    move_stock_between_locations:
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: Môj účet
     my_orders: Moje objednávky
     name: Meno
-    name_on_card: "Meno na karte"
-    name_or_sku: "Názov alebo SKU"
+    name_on_card: Meno na karte
+    name_or_sku: Názov alebo SKU
     new: Nové
-    new_adjustment:
-    new_country:
+    new_adjustment: TODO_TRANSLATE
+    new_country: TODO_TRANSLATE
     new_customer: Nový zákazník
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Nový obrázok
     new_option_type: Nový typ volieb
     new_order: Nová objednávka
-    new_order_completed:
-    new_payment: "Nová platba"
-    new_payment_method: "Nový spôsob platby"
+    new_order_completed: TODO_TRANSLATE
+    new_payment: Nová platba
+    new_payment_method: Nový spôsob platby
     new_product: Nový produkt
     new_promotion: New Promotion
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Nová vlastnosť
     new_prototype: Nový prototyp
-    new_refund:
-    new_refund_reason:
-    new_return_authorization:
-    new_rma_reason:
-    new_shipment_at_location:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
+    new_return_authorization: TODO_TRANSLATE
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Nová kategória doručenia
-    new_shipping_method: "Nový spôsob doručenia"
-    new_state: "Nový okres"
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_shipping_method: Nový spôsob doručenia
+    new_state: Nový okres
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: Nová kategória dane
     new_tax_rate: Nová sadzba dane
     new_taxon: Nový taxón
     new_taxonomy: Nová taxonómia
-    new_tracker:
+    new_tracker: TODO_TRANSLATE
     new_user: Nový používateľ
     new_variant: Nový variant
     new_zone: Nová zóna
     next: "Ďaľšie"
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Nenašli sme žiadny produkt
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: "Žiadne výsledky"
-    no_returns_found:
-    no_rules_added:
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_returns_found: TODO_TRANSLATE
+    no_rules_added: TODO_TRANSLATE
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: "Žiadny"
-    none_selected:
-    normal_amount:
+    none_selected: TODO_TRANSLATE
+    normal_amount: TODO_TRANSLATE
     not: nie
     not_available: N/A
-    not_enough_stock:
-    not_found:
-    note:
+    not_enough_stock: TODO_TRANSLATE
+    not_found: TODO_TRANSLATE
+    note: TODO_TRANSLATE
     notice_messages:
-      product_cloned:
-      product_deleted:
-      product_not_cloned:
-      product_not_deleted:
-      variant_deleted:
-      variant_not_deleted:
-    num_orders:
+      product_cloned: TODO_TRANSLATE
+      product_deleted: TODO_TRANSLATE
+      product_not_cloned: TODO_TRANSLATE
+      product_not_deleted: TODO_TRANSLATE
+      variant_deleted: TODO_TRANSLATE
+      variant_not_deleted: TODO_TRANSLATE
+    num_orders: TODO_TRANSLATE
     on_hand: Na sklade
-    open:
-    open_all_adjustments:
-    option_type:
-    option_type_placeholder:
-    option_types: "Typy volieb"
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
+    option_type: TODO_TRANSLATE
+    option_type_placeholder: TODO_TRANSLATE
+    option_types: Typy volieb
     option_value: Option Value
     option_values: Hodnoty opcií
-    optional: "Voliteľný"
-    options: "Voľby"
+    optional: Voliteľný
+    options: Voľby
     or: alebo
     or_over_price: "%{price} alebo viac"
     order: Objednávka
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Detaily objednávky
     order_email_resent: Email objednávky bol opäť poslaný
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Vaša objednávka bola spracovaná úspešne
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: adresa
       awaiting_return: "čaká na vrátenie"
@@ -894,238 +1027,256 @@ sk:
       cart: košík
       complete: zhrnutie
       confirm: potvrdenie
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: doručenie
       payment: platba
       resumed: obnovené
       returned: vrátené
     order_summary: Sumár objednávky
-    order_sure_want_to:
+    order_sure_want_to: TODO_TRANSLATE
     order_total: Objednávka celkom
     order_updated: Objednávka zmenená
     orders: Objednávky
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Nie je na sklade
     overview: Prehľad
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
-      next_page:
-      previous_page:
-      truncate:
+      first: TODO_TRANSLATE
+      next_page: TODO_TRANSLATE
+      previous: TODO_TRANSLATE
+      previous_page: TODO_TRANSLATE
+      truncate: TODO_TRANSLATE
     password: Heslo
     paste: Paste
     path: Cesta
     pay: platba
     payment: Platba
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Informácia o platení
-    payment_method:
-    payment_method_not_supported:
-    payment_methods:
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
-    payment_state:
+    payment_method: TODO_TRANSLATE
+    payment_method_not_supported: TODO_TRANSLATE
+    payment_methods: TODO_TRANSLATE
+    payment_processing_failed: TODO_TRANSLATE
+    payment_processor_choose_banner_text: TODO_TRANSLATE
+    payment_processor_choose_link: TODO_TRANSLATE
+    payment_state: TODO_TRANSLATE
     payment_states:
-      balance_due:
-      checkout:
-      completed:
-      credit_owed:
-      failed:
-      paid:
-      pending:
-      processing:
-      void:
-    payment_updated:
+      balance_due: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      credit_owed: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      paid: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      void: TODO_TRANSLATE
+    payment_updated: TODO_TRANSLATE
     payments: Platba
-    pending:
-    percent:
-    percent_per_item:
-    permalink:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
+    percent_per_item: TODO_TRANSLATE
+    permalink: TODO_TRANSLATE
     phone: Telefón
     place_order: Objednávka
-    please_define_payment_methods:
-    populate_get_error:
+    please_define_payment_methods: TODO_TRANSLATE
+    please_enter_reasonable_quantity: TODO_TRANSLATE
+    populate_get_error: TODO_TRANSLATE
     powered_by: používame
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Prezentácia
     previous: Predchádzajúci
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Cena
     price_range: Cenové rozpätie
-    price_sack:
+    price_sack: TODO_TRANSLATE
     process: Spracuj
-    product:
+    product: TODO_TRANSLATE
     product_details: Detaily o produkte
     product_has_no_description: Produkt nemá popis
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Vlastnosti produktu
     product_rule:
-      choose_products:
-      label:
-      match_all:
-      match_any:
-      match_none:
+      choose_products: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
+      match_none: TODO_TRANSLATE
       product_source:
-        group:
-        manual:
-    products:
-    promotion:
-    promotion_action:
+        group: TODO_TRANSLATE
+        manual: TODO_TRANSLATE
+    products: TODO_TRANSLATE
+    promotion: TODO_TRANSLATE
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: TODO_TRANSLATE
+        any: TODO_TRANSLATE
+    promotion_label: TODO_TRANSLATE
+    promotion_rule: TODO_TRANSLATE
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       item_total:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       landing_page:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
-    promotions:
-    propagate_all_variants:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
+    promotions: TODO_TRANSLATE
+    propagate_all_variants: TODO_TRANSLATE
     properties: Vlastnosti
     property: Vlastnosť
     prototype: Prototyp
     prototypes: Prototypy
-    provider:
-    provider_settings_warning:
+    provider: TODO_TRANSLATE
+    provider_settings_warning: TODO_TRANSLATE
     qty: Množstvo
-    quantity:
-    quantity_returned:
-    quantity_shipped:
-    quick_search:
+    quantity: TODO_TRANSLATE
+    quantity_returned: TODO_TRANSLATE
+    quantity_shipped: TODO_TRANSLATE
+    quick_search: TODO_TRANSLATE
     rate: Sadzba
-    reason:
-    receive:
-    receive_stock:
-    received:
-    reception_status:
-    reference:
-    refund:
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    reason: TODO_TRANSLATE
+    receive: TODO_TRANSLATE
+    receive_stock: TODO_TRANSLATE
+    received: TODO_TRANSLATE
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
+    refund: TODO_TRANSLATE
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registruj sa ako nový používateľ
     registration: Registrácia
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Zapamätaj si ma
     remove: Odstráň
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: Reporty
+    resellable: TODO_TRANSLATE
     resend: Pošli opäť
     reset_password: Vygeneruj heslo
     response_code: Kód odpovede
     resume: pokračovať
     resumed: Obnovený
     return: vrátiť sa
-    return_authorization:
-    return_authorization_reasons:
-    return_authorization_updated:
-    return_authorizations:
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
-    return_quantity:
+    return_authorization: TODO_TRANSLATE
+    return_authorization_reasons: TODO_TRANSLATE
+    return_authorization_updated: TODO_TRANSLATE
+    return_authorizations: TODO_TRANSLATE
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
+    return_quantity: TODO_TRANSLATE
     returned: Vrátené
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
+    role_id: TODO_TRANSLATE
     roles: Roly
-    rules:
-    safe:
+    rules: TODO_TRANSLATE
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Tržby spolu
     sales_total_description: Sales Total For All Orders
-    sales_totals:
+    sales_totals: TODO_TRANSLATE
     save_and_continue: Ulož a pokračuj
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: TODO_TRANSLATE
+    say_no: TODO_TRANSLATE
+    say_yes: TODO_TRANSLATE
     scope: Scope
     search: Hľadaj
-    search_results:
+    search_results: TODO_TRANSLATE
     searching: Searching
     secure_connection_type: Bezpečná konekcia
     security_settings: Security Settings
     select: Vyber
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Vyber z prototypov
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Pošli kópiu všetkých emailov na
     send_mails_as: Pošli email ako
     server: Server
@@ -1133,206 +1284,231 @@ sk:
     settings: Nastavenia
     ship: zašli
     ship_address: Adresa zásielky
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: Zásielka
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
-        dear_customer:
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
-        track_link:
-    shipment_state:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        shipment_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        track_information: TODO_TRANSLATE
+        track_link: TODO_TRANSLATE
+    shipment_state: TODO_TRANSLATE
     shipment_states:
-      backorder:
-      canceled:
-      partial:
-      pending:
-      ready:
-      shipped:
-    shipment_transfer_error:
-    shipment_transfer_success:
-    shipments:
+      backorder: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      partial: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
+    shipments: TODO_TRANSLATE
     shipped: Zaslané
     shipping: Doručenie
     shipping_address: Adresa doručenia
     shipping_categories: Kategórie doručenia
     shipping_category: Kategórie doručenia
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: Inštrukcie doručenia
     shipping_method: Metóda doručenia
     shipping_methods: Metódy doručenia
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: Nákupný košík
-    show:
-    show_active:
+    show: TODO_TRANSLATE
+    show_active: TODO_TRANSLATE
     show_deleted: Zobraz vymazané
     show_only_complete_orders: Zobraz iba úplné objednávky
-    show_only_considered_risky:
-    show_rate_in_label:
-    sku:
-    skus:
-    slug:
-    source:
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
+    sku: TODO_TRANSLATE
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
+    special_instructions: TODO_TRANSLATE
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
+    spree_gateway_error_flash_for_checkout: TODO_TRANSLATE
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: "Štart"
+    start_date: TODO_TRANSLATE
     state: "Štát"
     state_based: "Štát"
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: "Štáty/Provincie"
-    states_required:
+    states_required: TODO_TRANSLATE
     status: Stavy
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
-    stop:
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
+    stop: TODO_TRANSLATE
     store: Obchod
     street_address: Ulica
     street_address_2: Ulica (pokr.)
     subtotal: Medzisúčet
     subtract: Odrátaj
-    success:
-    successfully_created:
-    successfully_refunded:
-    successfully_removed:
-    successfully_signed_up_for_analytics:
-    successfully_updated:
-    summary:
+    success: TODO_TRANSLATE
+    successfully_created: TODO_TRANSLATE
+    successfully_refunded: TODO_TRANSLATE
+    successfully_removed: TODO_TRANSLATE
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
+    successfully_updated: TODO_TRANSLATE
+    summary: TODO_TRANSLATE
     tax: Daň
     tax_categories: Kategórie daní
     tax_category: Kategória daní
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Sadzby daní
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxón
-    taxon_edit:
-    taxon_placeholder:
+    taxon_edit: TODO_TRANSLATE
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonómie
     taxonomy: Taxonomy
     taxonomy_edit: Zmeň taxonómiu
     taxonomy_tree_error: Požadovaná zmena nebola akceptovaná a strom bol zmenený do predchádzajúceho stavu, prosím skúste znova.
     taxonomy_tree_instruction: "* Pravým klikom na potomok v strome pristúpite k menu na pridávanie, mazanie a triedenie potomkov."
     taxons: Taxóny
-    test:
+    test: TODO_TRANSLATE
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
-        greeting:
-        message:
-        subject:
-    test_mode:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+    test_mode: TODO_TRANSLATE
     thank_you_for_your_order: "Ďakujeme za Vašu objednávku.  Prosím vytlačte kópiu toto potvrdenie pre Vaše položky objednávky."
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields:
-    this_order_has_already_received_a_refund:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
+    there_were_problems_with_the_following_fields: TODO_TRANSLATE
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Miniatúra
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: K pridaniu variánt, najprv musíte určiť
     total: Celkom
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Sledovanie
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Strom
     type: Typ
-    type_to_search:
-    unable_to_connect_to_gateway:
-    unable_to_create_reimbursements:
+    type_to_search: TODO_TRANSLATE
+    unable_to_connect_to_gateway: TODO_TRANSLATE
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Menej ako %{price}
-    unlock:
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: Neznámy typ kreditnej karty
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: Zmeň
     updating: Obnovuje sa
     usage_limit: Limit použitia
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Použi ako adresu platby
-    use_new_cc:
-    use_s3:
+    use_existing_cc: TODO_TRANSLATE
+    use_new_cc: TODO_TRANSLATE
+    use_new_cc_or_payment_method: TODO_TRANSLATE
+    use_s3: TODO_TRANSLATE
     user: Používateľ
     user_rule:
-      choose_users:
+      choose_users: TODO_TRANSLATE
     users: Používatelia
     validation:
-      cannot_be_less_than_shipped_units:
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
-      is_too_large:
-      must_be_int:
-      must_be_non_negative:
-      unpaid_amount_not_zero:
+      cannot_be_less_than_shipped_units: TODO_TRANSLATE
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
+      is_too_large: TODO_TRANSLATE
+      must_be_int: TODO_TRANSLATE
+      must_be_non_negative: TODO_TRANSLATE
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Hodnota
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Varianty
     version: Verzia
     void: Void
@@ -1341,10 +1517,17 @@ sk:
     what_is_this: "Čo to je?"
     width: "Šírka"
     year: Rok
-    you_have_no_orders_yet:
+    you_have_no_orders_yet: TODO_TRANSLATE
     your_cart_is_empty: Váš košík je prázdny
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: PSČ
-    zipcode:
+    zipcode: TODO_TRANSLATE
     zone: Zóna
     zones: Zóny
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/sl-SI.yml
+++ b/config/locales/sl-SI.yml
@@ -1,614 +1,759 @@
+---
 sl-SI:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
-        address1:
-        address2:
-        city:
-        country:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        address2: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        country: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
-        iso:
-        iso3:
-        iso_name:
-        name:
-        numcode:
+        iso: TODO_TRANSLATE
+        iso3: TODO_TRANSLATE
+        iso_name: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        numcode: TODO_TRANSLATE
       spree/credit_card:
-        base:
-        cc_type:
-        month:
-        name:
-        number:
-        verification_value:
-        year:
+        base: TODO_TRANSLATE
+        cc_type: TODO_TRANSLATE
+        month: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        number: TODO_TRANSLATE
+        verification_value: TODO_TRANSLATE
+        year: TODO_TRANSLATE
       spree/inventory_unit:
-        state:
+        state: TODO_TRANSLATE
       spree/line_item:
-        price:
-        quantity:
+        price: TODO_TRANSLATE
+        quantity: TODO_TRANSLATE
       spree/option_type:
-        name:
-        presentation:
+        name: TODO_TRANSLATE
+        presentation: TODO_TRANSLATE
       spree/order:
-        checkout_complete:
-        completed_at:
-        considered_risky:
-        coupon_code:
-        created_at:
-        email:
-        ip_address:
-        item_total:
-        number:
-        payment_state:
-        shipment_state:
-        special_instructions:
-        state:
-        total:
+        checkout_complete: TODO_TRANSLATE
+        completed_at: TODO_TRANSLATE
+        considered_risky: TODO_TRANSLATE
+        coupon_code: TODO_TRANSLATE
+        created_at: TODO_TRANSLATE
+        email: TODO_TRANSLATE
+        ip_address: TODO_TRANSLATE
+        item_total: TODO_TRANSLATE
+        number: TODO_TRANSLATE
+        payment_state: TODO_TRANSLATE
+        shipment_state: TODO_TRANSLATE
+        special_instructions: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       spree/order/bill_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/order/ship_address:
-        address1:
-        city:
-        firstname:
-        lastname:
-        phone:
-        state:
-        zipcode:
+        address1: TODO_TRANSLATE
+        city: TODO_TRANSLATE
+        firstname: TODO_TRANSLATE
+        lastname: TODO_TRANSLATE
+        phone: TODO_TRANSLATE
+        state: TODO_TRANSLATE
+        zipcode: TODO_TRANSLATE
       spree/payment:
-        amount:
+        amount: TODO_TRANSLATE
+        number: TODO_TRANSLATE
       spree/payment_method:
-        name:
+        name: TODO_TRANSLATE
       spree/product:
-        available_on:
-        cost_currency:
-        cost_price:
-        description:
-        master_price:
-        name:
-        on_hand:
-        shipping_category:
-        tax_category:
+        available_on: TODO_TRANSLATE
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        description: TODO_TRANSLATE
+        master_price: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        on_hand: TODO_TRANSLATE
+        shipping_category: TODO_TRANSLATE
+        tax_category: TODO_TRANSLATE
       spree/promotion:
-        advertise:
-        code:
-        description:
-        event_name:
-        expires_at:
-        name:
-        path:
-        starts_at:
-        usage_limit:
+        advertise: TODO_TRANSLATE
+        code: TODO_TRANSLATE
+        description: TODO_TRANSLATE
+        event_name: TODO_TRANSLATE
+        expires_at: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        path: TODO_TRANSLATE
+        starts_at: TODO_TRANSLATE
+        usage_limit: TODO_TRANSLATE
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
-        name:
-        presentation:
+        name: TODO_TRANSLATE
+        presentation: TODO_TRANSLATE
       spree/prototype:
-        name:
+        name: TODO_TRANSLATE
       spree/return_authorization:
-        amount:
+        amount: TODO_TRANSLATE
       spree/role:
-        name:
+        name: TODO_TRANSLATE
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
-        abbr:
-        name:
+        abbr: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/tax_rate:
-        amount:
-        included_in_price:
-        show_rate_in_label:
+        amount: TODO_TRANSLATE
+        included_in_price: TODO_TRANSLATE
+        show_rate_in_label: TODO_TRANSLATE
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: TODO_TRANSLATE
+        permalink: TODO_TRANSLATE
+        position: TODO_TRANSLATE
       spree/taxonomy:
-        name:
+        name: TODO_TRANSLATE
       spree/user:
-        email:
-        password:
-        password_confirmation:
+        email: TODO_TRANSLATE
+        password: TODO_TRANSLATE
+        password_confirmation: TODO_TRANSLATE
       spree/variant:
-        cost_currency:
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_currency: TODO_TRANSLATE
+        cost_price: TODO_TRANSLATE
+        depth: TODO_TRANSLATE
+        height: TODO_TRANSLATE
+        price: TODO_TRANSLATE
+        sku: TODO_TRANSLATE
+        weight: TODO_TRANSLATE
+        width: TODO_TRANSLATE
       spree/zone:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/country:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/credit_card:
-      spree/customer_return:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/line_item:
-      spree/option_type:
-      spree/option_value:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/payment:
-      spree/payment_method:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
-      spree/promotion:
-      spree/promotion_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/prototype:
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
-      spree/return_authorization_reason:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipment:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipping_category:
-      spree/shipping_method:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/tax_rate:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
-      spree/tracker:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/tracker: TODO_TRANSLATE
       spree/user:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/variant:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/zone:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
-      confirmed:
-      send_instructions:
+      confirmed: TODO_TRANSLATE
+      send_instructions: TODO_TRANSLATE
     failure:
-      inactive:
-      invalid:
-      invalid_token:
-      locked:
-      timeout:
-      unauthenticated:
-      unconfirmed:
+      inactive: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      invalid_token: TODO_TRANSLATE
+      locked: TODO_TRANSLATE
+      timeout: TODO_TRANSLATE
+      unauthenticated: TODO_TRANSLATE
+      unconfirmed: TODO_TRANSLATE
     mailer:
       confirmation_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       reset_password_instructions:
-        subject:
+        subject: TODO_TRANSLATE
       unlock_instructions:
-        subject:
+        subject: TODO_TRANSLATE
     oauth_callbacks:
-      failure:
-      success:
+      failure: TODO_TRANSLATE
+      success: TODO_TRANSLATE
     unlocks:
-      send_instructions:
-      unlocked:
+      send_instructions: TODO_TRANSLATE
+      unlocked: TODO_TRANSLATE
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
-      destroyed:
-      inactive_signed_up:
-      signed_up:
-      updated:
+      destroyed: TODO_TRANSLATE
+      inactive_signed_up: TODO_TRANSLATE
+      signed_up: TODO_TRANSLATE
+      updated: TODO_TRANSLATE
     user_sessions:
-      signed_in:
-      signed_out:
+      signed_in: TODO_TRANSLATE
+      signed_out: TODO_TRANSLATE
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
-      already_confirmed:
-      not_found:
-      not_locked:
+      already_confirmed: TODO_TRANSLATE
+      not_found: TODO_TRANSLATE
+      not_locked: TODO_TRANSLATE
       not_saved:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Okrajšava
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Uporabniški račun
     account_updated: Uporabniški račun osvežen!
     action: Možnosti
     actions:
       cancel: Prekini
-      continue:
+      continue: TODO_TRANSLATE
       create: Ustvari
       destroy: Izbriši
-      edit:
+      edit: TODO_TRANSLATE
       list: Prikaz
       listing: Prikazujem
       new: Dodaj
-      refund:
-      save:
+      refund: TODO_TRANSLATE
+      save: TODO_TRANSLATE
       update: Posodobi
     activate: Activate
     active: Objavljeno
     add: Dodaj
     add_action_of_type: Add action of type
     add_country: Dodaj Državo
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Add New Header
     add_new_style: Add New Style
-    add_one:
+    add_one: TODO_TRANSLATE
     add_option_value: Dodaj izbiro
     add_product: Dodaj izdelek
     add_product_properties: Dodaj lastnosti izdelka
     add_rule_of_type: Dodaj tip pravila
     add_state: Dodaj pokraijno
-    add_stock:
-    add_stock_management:
+    add_stock: TODO_TRANSLATE
+    add_stock_management: TODO_TRANSLATE
     add_to_cart: Dodaj v košarico
-    add_variant:
+    add_variant: TODO_TRANSLATE
     additional_item: Additional Item Cost
-    address1:
-    address2:
-    adjustable:
+    address: TODO_TRANSLATE
+    address1: TODO_TRANSLATE
+    address2: TODO_TRANSLATE
+    adjustable: TODO_TRANSLATE
     adjustment: Prilagoditev
-    adjustment_amount:
-    adjustment_successfully_closed:
-    adjustment_successfully_opened:
+    adjustment_amount: TODO_TRANSLATE
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    adjustment_successfully_closed: TODO_TRANSLATE
+    adjustment_successfully_opened: TODO_TRANSLATE
     adjustment_total: Prilagoditev Skupaj
     adjustments: Prilagoditve
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Administracija
-    advertise:
-    agree_to_privacy_policy:
-    agree_to_terms_of_service:
+    advertise: TODO_TRANSLATE
+    agree_to_privacy_policy: TODO_TRANSLATE
+    agree_to_terms_of_service: TODO_TRANSLATE
     all: Vse
-    all_adjustments_closed:
-    all_adjustments_opened:
+    all_adjustments_closed: TODO_TRANSLATE
+    all_adjustments_opened: TODO_TRANSLATE
     all_departments: Vsi oddelki
-    all_items_have_been_returned:
-    allow_ssl_in_development_and_test:
-    allow_ssl_in_production:
-    allow_ssl_in_staging:
-    already_signed_up_for_analytics:
+    all_items_have_been_returned: TODO_TRANSLATE
+    allow_ssl_in_development_and_test: TODO_TRANSLATE
+    allow_ssl_in_production: TODO_TRANSLATE
+    allow_ssl_in_staging: TODO_TRANSLATE
+    already_signed_up_for_analytics: TODO_TRANSLATE
     alt_text: Alternativni tekst
     alternative_phone: Drugi telefon
     amount: Znesek
-    analytics_desc_header_1:
-    analytics_desc_header_2:
-    analytics_desc_list_1:
-    analytics_desc_list_2:
-    analytics_desc_list_3:
-    analytics_desc_list_4:
+    analytics_desc_header_1: TODO_TRANSLATE
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
+    analytics_desc_list_2: TODO_TRANSLATE
+    analytics_desc_list_3: TODO_TRANSLATE
+    analytics_desc_list_4: TODO_TRANSLATE
     analytics_trackers: Statistike
-    and:
-    approve:
-    approved_at:
-    approver:
+    and: TODO_TRANSLATE
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Ste prepričani?
     are_you_sure_delete: Ste prepričani, da želite izbrisati ta vnos?
-    associated_adjustment_closed:
+    associated_adjustment_closed: TODO_TRANSLATE
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Napaka pri avtorizaciji
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Na voljo
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Nazaj
     back_end: Nazaj na Konec
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Nazaj v trgovino
-    back_to_users_list:
-    backorderable:
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
+    back_to_users_list: TODO_TRANSLATE
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
+    backorderable: TODO_TRANSLATE
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Balance Due
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Naslov za Račun
     billing: Račun
     billing_address: Naslov za Račun
     both: Oboje
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Kalkulator
     calculator_settings_warning: "Če spreminjate tip kalkulatorja, morate pred urejanjem nastavitev najprej shraniti."
     cancel: prekini
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Ne morem generirati vračil, ker naročilo še ni bilo poslano.
     cannot_perform_operation: Ni mogoče izvesti zahtevane operacije
-    cannot_set_shipping_method_without_address:
+    cannot_set_shipping_method_without_address: TODO_TRANSLATE
     capture: zajemi
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Koda Kartice
     card_number: "Številka Kartice"
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Tip kartice je
     cart: Košarica
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategorije
     category: Kategorija
-    charged:
-    check_for_spree_alerts:
+    charged: TODO_TRANSLATE
+    check_for_spree_alerts: TODO_TRANSLATE
     checkout: Naročilo
-    choose_a_customer:
-    choose_a_taxon_to_sort_products_for:
-    choose_currency:
-    choose_dashboard_locale:
-    choose_location:
+    choose_a_customer: TODO_TRANSLATE
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
+    choose_currency: TODO_TRANSLATE
+    choose_dashboard_locale: TODO_TRANSLATE
+    choose_location: TODO_TRANSLATE
     city: Mesto
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Kloniraj
-    close:
-    close_all_adjustments:
+    close: TODO_TRANSLATE
+    close_all_adjustments: TODO_TRANSLATE
     code: Koda
-    company:
+    company: TODO_TRANSLATE
     complete: complete
     configuration: Nastavitev
     configurations: Nastavitve
+    configure_s3: TODO_TRANSLATE
     confirm: Potrdi
     confirm_delete: Potrdi izbris?
     confirm_password: Potrditev gesla
     continue: Nadaljuj
     continue_shopping: Nadaljuj z nakupovanjem
-    cost_currency:
+    cost_currency: TODO_TRANSLATE
     cost_price: Nabavna Cena
-    could_not_connect_to_jirafe:
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
-    count_on_hand:
-    countries:
+    could_not_connect_to_jirafe: TODO_TRANSLATE
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
+    count_on_hand: TODO_TRANSLATE
+    countries: TODO_TRANSLATE
     country: Država
     country_based: Glede na Države
-    country_name:
+    country_name: TODO_TRANSLATE
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Kupon
     coupon_code: Koda kupona
-    coupon_code_already_applied:
-    coupon_code_applied:
-    coupon_code_better_exists:
-    coupon_code_expired:
-    coupon_code_max_usage:
-    coupon_code_not_eligible:
-    coupon_code_not_found:
-    coupon_code_unknown_error:
+    coupon_code_already_applied: TODO_TRANSLATE
+    coupon_code_applied: TODO_TRANSLATE
+    coupon_code_better_exists: TODO_TRANSLATE
+    coupon_code_expired: TODO_TRANSLATE
+    coupon_code_max_usage: TODO_TRANSLATE
+    coupon_code_not_eligible: TODO_TRANSLATE
+    coupon_code_not_found: TODO_TRANSLATE
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Ustvari
     create_a_new_account: Ustvari nov račun
-    create_new_order:
-    create_reimbursement:
-    created_at:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
+    created_at: TODO_TRANSLATE
     credit: Kredit
     credit_card: Kreditna kartica
-    credit_cards:
-    credit_owed:
-    credits:
-    currency:
-    currency_decimal_mark:
-    currency_settings:
-    currency_symbol_position:
-    currency_thousands_separator:
+    credit_cards: TODO_TRANSLATE
+    credit_owed: TODO_TRANSLATE
+    credits: TODO_TRANSLATE
+    currency: TODO_TRANSLATE
+    currency_decimal_mark: TODO_TRANSLATE
+    currency_settings: TODO_TRANSLATE
+    currency_symbol_position: TODO_TRANSLATE
+    currency_thousands_separator: TODO_TRANSLATE
     current: Trenutno
-    current_promotion_usage:
+    current_promotion_usage: TODO_TRANSLATE
     customer: Stranka
     customer_details: Podrobnosti stranke
-    customer_details_updated:
-    customer_return:
-    customer_returns:
+    customer_details_updated: TODO_TRANSLATE
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Iskanje strank
-    cut:
-    cvv_response:
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
-        explanation:
-        header:
-        site_id:
-        token:
-      jirafe_settings_updated:
-    date:
-    date_completed:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
+      jirafe_settings_updated: TODO_TRANSLATE
+    date: TODO_TRANSLATE
+    date_completed: TODO_TRANSLATE
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: TODO_TRANSLATE
+      format: TODO_TRANSLATE
+      js_format: TODO_TRANSLATE
     date_range: Obdobje
     default: Privzeto
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
     delete: Izbriši
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Delivery
     depth: Globina
     description: Opis
-    destination:
+    destination: TODO_TRANSLATE
     destroy: Izbriši
-    details:
+    details: TODO_TRANSLATE
     discount_amount: Znesek popusta
-    dismiss_banner:
+    dismiss_banner: TODO_TRANSLATE
     display: Prikaži
     display_currency: Display currency
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Uredi
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Urejanje uporabnika
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
+    email: TODO_TRANSLATE
     empty: Izprazni
     empty_cart: Izprazni košarico
     enable_mail_delivery: Vklopi pošiljanje emailov
-    end:
-    ending_in:
+    end: TODO_TRANSLATE
+    ending_in: TODO_TRANSLATE
     environment: Okolje
     error: napaka
     errors:
       messages:
-        could_not_create_taxon:
-        no_payment_methods_available:
-        no_shipping_methods_available:
+        could_not_create_taxon: TODO_TRANSLATE
+        no_payment_methods_available: TODO_TRANSLATE
+        no_shipping_methods_available: TODO_TRANSLATE
     errors_prohibited_this_record_from_being_saved:
+      one: TODO_TRANSLATE
+      other: TODO_TRANSLATE
     event: Dogodek
     events:
       spree:
         cart:
-          add:
+          add: TODO_TRANSLATE
         checkout:
-          coupon_code_added:
+          coupon_code_added: TODO_TRANSLATE
         content:
-          visited:
+          visited: TODO_TRANSLATE
         order:
-          contents_changed:
-        page_view:
+          contents_changed: TODO_TRANSLATE
+        page_view: TODO_TRANSLATE
         user:
-          signup:
+          signup: TODO_TRANSLATE
     exceptions:
-      count_on_hand_setter:
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+      count_on_hand_setter: TODO_TRANSLATE
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Velja do
     extension: Razširitev
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Datoteka
-    fill_in_customer_info:
-    filter_results:
+    fill_in_customer_info: TODO_TRANSLATE
+    filter: TODO_TRANSLATE
+    filter_results: TODO_TRANSLATE
     finalize: Zaključi
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Strošek prvega izdelka
     first_name: Ime
     first_name_begins_with: Ime se začne z
     flat_percent: Fiksni odstotek
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Fiksna cena (na naročilo)
     flexible_rate: Fleksibilna cena
     forgot_password: Ne spomnim se gesla
     free_shipping: Brezplačna dostava
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Ponudnik
     gateway_config_unavailable: Gateway unavailable for environment
@@ -621,50 +766,54 @@ sl-SI:
     guest_user_account: Naroči kot gost
     has_no_shipped_units: nima prodajnih enot
     height: Višina
-    hide_cents:
+    hide_cents: TODO_TRANSLATE
     home: Domov
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: Slovenščina (SL)
-      translations:
+      translations: TODO_TRANSLATE
     icon: Ikona
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Slika
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Slike
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
-    included_in_price:
-    included_price_validation:
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
+    included_in_price: TODO_TRANSLATE
+    included_price_validation: TODO_TRANSLATE
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: 'Izpolnite spodnji obrazec in navodila za ponastavitev gesla vam bomo poslali na email:'
-    insufficient_stock:
-    insufficient_stock_lines_present:
+    insufficient_stock: TODO_TRANSLATE
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Prestrezi Email naslov
     intercept_email_instructions: Zamenjaj prejemnika email sporočila s tem naslovom
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
-    invalid_payment_provider:
-    invalid_promotion_action:
-    invalid_promotion_rule:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
+    invalid_payment_provider: TODO_TRANSLATE
+    invalid_promotion_action: TODO_TRANSLATE
+    invalid_promotion_rule: TODO_TRANSLATE
     inventory: Inventar
     inventory_adjustment: Prilagoditev inventarja
-    inventory_error_flash_for_insufficient_quantity:
-    inventory_state:
+    inventory_error_flash_for_insufficient_quantity: TODO_TRANSLATE
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: ni na voljo za ta naslov pošiljanja
-    iso_name:
+    iso_name: TODO_TRANSLATE
     item: Izdelek
     item_description: Opis izdelka
     item_total: Izdelki skupaj
@@ -672,26 +821,32 @@ sl-SI:
       operators:
         gt: večje
         gte: večje ali enako
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
-    jirafe:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
+    jirafe: TODO_TRANSLATE
     landing_page_rule:
-      path:
+      path: TODO_TRANSLATE
     last_name: Priimek
     last_name_begins_with: Priimek se začne z
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Seznam
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Nalagam
     locale_changed: Locale Changed
-    location:
-    lock:
-    log_entries:
+    location: TODO_TRANSLATE
+    lock: TODO_TRANSLATE
+    log_entries: TODO_TRANSLATE
     logged_in_as: Prijavljeni ste kot
     logged_in_succesfully: Prijava uspešna
     logged_out: Uspešno ste se odjavili.
@@ -700,38 +855,41 @@ sl-SI:
     login_failed: Prijava ni uspela.
     login_name: Uporabniško ime
     logout: Odjava
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Poišči podobne izdelke
-    make_refund:
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
+    make_refund: TODO_TRANSLATE
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Osnovna cena
     match_choices:
       all: All
       none: None
     max_items: Max Izdelkov
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta opis
     meta_keywords: Meta ključne besede
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Minimalni znesek
     month: Mesec
     more: More
-    move_stock_between_locations:
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: Moj račun
     my_orders: Moja naročila
     name: Ime
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Ime ali šifra
     new: Novo
     new_adjustment: Nova prilagoditev
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Nova stranka
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Dodaj sliko
     new_option_type: Nova možnost izbire
     new_order: Novo naročilo
@@ -740,20 +898,21 @@ sl-SI:
     new_payment_method: Nov način plačila
     new_product: Dodaj Izdelek
     new_promotion: Dodaj promocijo
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Dodaj lastnost
     new_prototype: Dodaj prototip
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Nova avtorizacija vračila
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Dodaj kategorijo poštnine
     new_shipping_method: Dodaj tip dostave
     new_state: Nova Zvezna Država
-    new_stock_location:
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_location: TODO_TRANSLATE
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: Dodaj davčno stopnjo
     new_tax_rate: Dodaj davčno stopnjo
     new_taxon: Dodaj takson
@@ -763,25 +922,31 @@ sl-SI:
     new_variant: Dodaj varianto
     new_zone: Dodaj območje
     next: Naprej
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Ni izdelkov
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Ni zadetkov
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Ni dodanih pravil
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: Noben
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normalna količina
     not: ne
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: Izdelek je bil podvojen
       product_deleted: Izdelek je bil izbrisan
@@ -789,47 +954,52 @@ sl-SI:
       product_not_deleted: Izdelka ni mogoče izbrisati
       variant_deleted: Varianta je bila izbrisana
       variant_not_deleted: Variante ni mogoče izbrisati
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Na zalogi
-    open:
-    open_all_adjustments:
+    open: TODO_TRANSLATE
+    open_all_adjustments: TODO_TRANSLATE
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Možnosti izbire
     option_value: Option Value
     option_values: Izbire
-    optional:
+    optional: TODO_TRANSLATE
     options: Možnosti
     or: ali
     or_over_price: "%{price} or over"
     order: Naročilo
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_adjustments: TODO_TRANSLATE
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Podrobnosti naročila
     order_email_resent: Email z naročilom je bil ponovno poslan.
-    order_information:
+    order_information: TODO_TRANSLATE
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
-        dear_customer:
-        instructions:
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary_canceled: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
-        dear_customer:
-        instructions:
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
-    order_not_found:
-    order_number:
+        dear_customer: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        order_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
+    order_not_found: TODO_TRANSLATE
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Vaše naročilo je bilo uspešno obdelano
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: naslov
       awaiting_return: "čakajo na vrnitev"
@@ -837,7 +1007,7 @@ sl-SI:
       cart: košarica
       complete: končaj
       confirm: potrdi
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: dostava
       payment: plačilo
       resumed: resumed
@@ -847,96 +1017,104 @@ sl-SI:
     order_total: Naročilo skupaj
     order_updated: Naročilo osveženo
     orders: Naročila
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Ni na zalogi
     overview: Pregled
-    package_from:
+    package_from: TODO_TRANSLATE
     pagination:
-      next_page:
-      previous_page:
+      first: TODO_TRANSLATE
+      next_page: TODO_TRANSLATE
+      previous: TODO_TRANSLATE
+      previous_page: TODO_TRANSLATE
       truncate: "…"
     password: Geslo
     paste: Paste
     path: Pot
     pay: plačaj
     payment: Plačilo
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Podatki o plačilu
     payment_method: Način plačila
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Načini plačila
     payment_processing_failed: Plačila ni možno izvesti, prosimo preverite vnešene podatke
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
+    payment_processor_choose_banner_text: TODO_TRANSLATE
+    payment_processor_choose_link: TODO_TRANSLATE
     payment_state: Stanje plačila
     payment_states:
-      balance_due:
-      checkout:
-      completed:
-      credit_owed:
-      failed:
+      balance_due: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      credit_owed: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
       paid: plačano
-      pending:
-      processing:
-      void:
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     payment_updated: Plačilo osveženo
     payments: Plačila
-    pending:
-    percent:
-    percent_per_item:
+    pending: TODO_TRANSLATE
+    percent: TODO_TRANSLATE
+    percent_per_item: TODO_TRANSLATE
     permalink: Povezava
     phone: Telefon
     place_order: Oddaj naročilo
-    please_define_payment_methods:
-    populate_get_error:
+    please_define_payment_methods: TODO_TRANSLATE
+    please_enter_reasonable_quantity: TODO_TRANSLATE
+    populate_get_error: TODO_TRANSLATE
     powered_by: Poganja
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Prikazano ime
     previous: Nazaj
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Cena
-    price_range:
-    price_sack:
+    price_range: TODO_TRANSLATE
+    price_sack: TODO_TRANSLATE
     process: Procesiraj
     product: Izdelek
     product_details: Podrobnosti izdelka
     product_has_no_description: Izdelek nima opisa
-    product_not_available_in_this_currency:
+    product_not_available_in_this_currency: TODO_TRANSLATE
     product_properties: Lastnosti izdelka
     product_rule:
       choose_products: Izberite izdelke
-      label:
+      label: TODO_TRANSLATE
       match_all: vse
       match_any: vsaj en
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: Iz skupine izdelkov
         manual: Ročno izberi
     products: Izdelki
-    promotion:
-    promotion_action:
+    promotion: TODO_TRANSLATE
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Ujemaj se s katerim koli izmed teh pravil
         any: Ujemaj se z vsemi temi pravili
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promotion Rule
     promotion_rule_types:
       first_order:
@@ -949,27 +1127,27 @@ sl-SI:
         description: Customer must have visited the specified page
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Naročilo vsebuje določene izdelke
         name: Izdelek(i)
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Na vojo samo za določene uporabnike
         name: Uporabnik
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promocije
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Lastnosti
     property: Lastnost
     prototype: Prototip
@@ -977,50 +1155,52 @@ sl-SI:
     provider: Ponudnik
     provider_settings_warning: "Če spreminjate tip ponudnika, morate najprej shraniti predno lahko urejate nastavitve ponudnika"
     qty: Količina
-    quantity:
+    quantity: TODO_TRANSLATE
     quantity_returned: Quantity Returned
     quantity_shipped: Poslana količina
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Stopnja
     reason: Razlog
     receive: prejmi
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: Prejeto
-    reception_status:
-    reference:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
     refund: Povračilo
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Registriraj se kot nov uporabnik
     registration: Registracija
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Zapomni si me
     remove: Odstrani
-    rename:
-    report:
+    rename: TODO_TRANSLATE
+    report: TODO_TRANSLATE
     reports: Poročila
+    resellable: TODO_TRANSLATE
     resend: Pošlji ponovno
     reset_password: Ponastavi moje geslo
     response_code: Odzivna koda
@@ -1028,36 +1208,43 @@ sl-SI:
     resumed: Nadaljevana
     return: vračilo
     return_authorization: Avtorizacija vračila
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Avtorizacija vračila spremenjena
     return_authorizations: Avtorizacije vračil
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Količina za vračilo
     returned: Vrnjeno
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
+    returns: TODO_TRANSLATE
+    review: TODO_TRANSLATE
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA kredit
     rma_number: RMA šifra
     rma_value: RMA vrednost
+    role_id: TODO_TRANSLATE
     roles: Vloge
-    rules:
-    safe:
+    rules: TODO_TRANSLATE
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Skupaj
     sales_total_description: Sales Total For All Orders
-    sales_totals:
+    sales_totals: TODO_TRANSLATE
     save_and_continue: Shrani in nadaljuj
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: TODO_TRANSLATE
+    say_no: TODO_TRANSLATE
+    say_yes: TODO_TRANSLATE
     scope: Pravilo
     search: Najdi
     search_results: Iskalni razultati za '%{keywords}'
@@ -1065,10 +1252,11 @@ sl-SI:
     secure_connection_type: Tip varne povezave
     security_settings: Security Settings
     select: Izberi
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Izberi iz prototipa
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Pošlji kopijo vseh emailov na
     send_mails_as: Pošiljatelj izhodnih emailov
     server: Strežnik
@@ -1076,10 +1264,11 @@ sl-SI:
     settings: Nastavitve
     ship: pošlji
     ship_address: Naslov za dostavo
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: Pošiljka
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Dear Customer,\n
@@ -1088,126 +1277,144 @@ sl-SI:
         subject: Shipment Notification
         thanks: Thank you for your business.
         track_information: 'Tracking Information: %{tracking}'
-        track_link:
+        track_link: TODO_TRANSLATE
     shipment_state: Stanje pošiljke
     shipment_states:
       backorder: backorder
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: delno
       pending: v teku
       ready: pripravljeno
       shipped: poslano
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Pošiljke
     shipped: Poslano
     shipping: Poštnina
     shipping_address: Naslov za dostavo
     shipping_categories: Kategorije poštnine
     shipping_category: Kategorija poštnine
-    shipping_flat_rate_per_item:
-    shipping_flat_rate_per_order:
-    shipping_flexible_rate:
+    shipping_flat_rate_per_item: TODO_TRANSLATE
+    shipping_flat_rate_per_order: TODO_TRANSLATE
+    shipping_flexible_rate: TODO_TRANSLATE
     shipping_instructions: Navodila za dostavo
     shipping_method: Način dostave
     shipping_methods: Načini dostave
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Preglej %{taxonomy}
     shopping_cart: Nakupovalna košarica
     show: Prikaži
     show_active: Prikaži objavljene
     show_deleted: Prikaži izbrisane
     show_only_complete_orders: Prikaži le dokončana naročila
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
     sku: "šifra"
-    skus:
-    slug:
-    source:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
+    source: TODO_TRANSLATE
     special_instructions: Special Instructions
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Od
+    start_date: TODO_TRANSLATE
     state: Pokrajina
     state_based: Na osnovi pokrajin
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Pokrajine
-    states_required:
+    states_required: TODO_TRANSLATE
     status: Status
-    stock:
-    stock_location:
-    stock_location_info:
-    stock_locations:
-    stock_locations_need_a_default_country:
-    stock_management:
-    stock_management_requires_a_stock_location:
-    stock_movements:
-    stock_movements_for_stock_location:
-    stock_successfully_transferred:
-    stock_transfer:
-    stock_transfers:
+    stock: TODO_TRANSLATE
+    stock_location: TODO_TRANSLATE
+    stock_location_info: TODO_TRANSLATE
+    stock_locations: TODO_TRANSLATE
+    stock_locations_need_a_default_country: TODO_TRANSLATE
+    stock_management: TODO_TRANSLATE
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
+    stock_movements: TODO_TRANSLATE
+    stock_movements_for_stock_location: TODO_TRANSLATE
+    stock_successfully_transferred: TODO_TRANSLATE
+    stock_transfer: TODO_TRANSLATE
+    stock_transfers: TODO_TRANSLATE
     stop: Do
     store: Trgovina
     street_address: Ulica in hišna številka
     street_address_2: Ulica dodatno
     subtotal: Skupaj
     subtract: Odštej
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} has been successfully removed!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: DDV
     tax_categories: Davčne kategorije
     tax_category: Davčna kategorija
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: Davčne stopnje
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Takson
     taxon_edit: Uredi takson
-    taxon_placeholder:
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taksonomije
     taxonomy: Taxonomy
     taxonomy_edit: Uredi taksonomijo
@@ -1216,50 +1423,55 @@ sl-SI:
     taxons: Taksoni
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Congratulations!
         message: If you have received this email, then your email settings are correct.
         subject: Testmail
     test_mode: Testni način
     thank_you_for_your_order: Hvala za zaupanje. Prosimo natisnite si kopijo te potrditvene strani za lastno referenco.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: There were problems with the following fields
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Mala slika
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
-    time:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
+    time: TODO_TRANSLATE
     to_add_variants_you_must_first_define: Za dodajanje variant, morate najprej definirati
     total: Skupaj
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Sledenje
-    tracking_number:
-    tracking_url:
-    tracking_url_placeholder:
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: Drevo
     type: Tip
     type_to_search: Vrsta iskanja
     unable_to_connect_to_gateway: Povezava do ponudnika plačilnih storitev ni uspela
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
-    unlock:
+    unlock: TODO_TRANSLATE
     unrecognized_card_type: Neznan tip kartice
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: Spremeni
     updating: Osvežujem
     usage_limit: Omejitev uporabe
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Uporabi naslov za račun
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Uporabi drugo kreditno karico
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Use Amazon S3 For Images
     user: Uporabnik
     user_rule:
@@ -1267,15 +1479,16 @@ sl-SI:
     users: Uporabniki
     validation:
       cannot_be_less_than_shipped_units: ne more biti manjše od števila prodanih enot.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
-      exceeds_available_stock:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      exceeds_available_stock: TODO_TRANSLATE
       is_too_large: je prevelika -- na zalogi ni dovolj naročenih izdelkov!
       must_be_int: mora biti celo število
       must_be_non_negative: mora biti pozitivna vrednost
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Vrednost
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Variante
     version: Verzija
     void: Neveljaven
@@ -1286,8 +1499,15 @@ sl-SI:
     year: Leto
     you_have_no_orders_yet: You have no orders yet.
     your_cart_is_empty: Vaša nakupovalna košarica je prazna
-    your_order_is_empty_add_product:
+    your_order_is_empty_add_product: TODO_TRANSLATE
     zip: Poštna številka
-    zipcode:
+    zipcode: TODO_TRANSLATE
     zone: Območje
     zones: Območja
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,4 +1,6 @@
+---
 sv:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -24,7 +26,7 @@ sv:
         name: Namn
         numcode: ISO-kod
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Typ
         month: Månad
         name: Namn
@@ -72,6 +74,7 @@ sv:
         zipcode: Fraktadress, postnr.
       spree/payment:
         amount: Belopp
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Namn
       spree/product:
@@ -95,6 +98,7 @@ sv:
         starts_at: Startar
         usage_limit: Utnyttjargräns
       spree/promotion_category:
+        code: TODO_TRANSLATE
         name: Namn
       spree/property:
         name: Namn
@@ -105,6 +109,8 @@ sv:
         amount: Belopp
       spree/role:
         name: Namn
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Förkortning
         name: Namn
@@ -199,6 +205,12 @@ sv:
             base:
               cannot_destroy_default_store: Kan inte radera den primära shoppen.
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: Adress
         other: Adresser
@@ -263,6 +275,8 @@ sv:
         one: Retur auktorisation skäl
         other: Retur auktorisations skäl
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: Uppgift
         other: Uppgifter
       spree/shipment:
@@ -283,7 +297,7 @@ sv:
       spree/stock_location:
         one: Leverans plats
         other: Leverans platser
-      spree/stock_movement:
+      spree/stock_movement: TODO_TRANSLATE
       spree/stock_transfer:
         one: Lageröverföring
         other: Lageröverföringar
@@ -311,6 +325,9 @@ sv:
       spree/zone:
         one: Zone
         other: Zoner
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Ditt konto är bekräftat. Du kan nu logga in.
@@ -349,6 +366,7 @@ sv:
     user_sessions:
       signed_in: Inloggningen lyckades.
       signed_out: Utloggningen lyckades.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: var redan bekräftad
@@ -357,6 +375,24 @@ sv:
       not_saved:
         one: '1 fel hindrade detta %{resource} från att sparas:'
         other: "%{count} fel hindrade detta %{resource} från att sparas:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Förkortning
     accept: Accept
@@ -397,11 +433,16 @@ sv:
     add_to_cart: Lägg i varukorgen
     add_variant: Lägg till variant
     additional_item: Ytterligare artikelkostnad
+    address: TODO_TRANSLATE
     address1: Adress
     address2: Adress (forts.)
     adjustable: Justerbar
     adjustment: Justering
     adjustment_amount: Belopp
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: "Ändring är framgångsrikt stängd!"
     adjustment_successfully_opened: "Ändring är framgångsrikt öppnad!"
     adjustment_total: Summa justeringar
@@ -453,12 +494,24 @@ sv:
     analytics_desc_list_4: Det är helt gratis!
     analytics_trackers: Statistikspårare
     and: och
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: godkänn
     approved_at: Datum godkänt
     approver: Attestant
     are_you_sure: "Är du säker?"
     are_you_sure_delete: "Är du säker på att du vill ta bort denna post?"
     associated_adjustment_closed: Den tillhörande justeringen är stängd, och blir inte omräknad. Vill du öppna den?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Auktorisationen misslyckades
     authorized: Auktoriserad
     auto_capture: Auto-capture
@@ -467,14 +520,36 @@ sv:
     avs_response: AVS svar
     back: Tillbaka
     back_end: Administrationsgränssnitt
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
     back_to_payment: Tillbaka till betalningen
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
     back_to_resource_list: Tillbaka till %{resource} listan
     back_to_rma_reason_list: Tillbaka till RMA skäls listan
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Tillbaka till butiken
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Tillbaka till användarlistan
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Möjligt att förhandsbeställa
-    backorderable_default:
-    backordered:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
     backorders_allowed: förhandsbeställning tillåtet
     balance_due: Summa att betala
     base_amount: Basbelopp
@@ -495,7 +570,7 @@ sv:
     cannot_perform_operation: Kan inte utföra efterfrågad aktivitet
     cannot_set_shipping_method_without_address: Kan inte använda fraktmetod förrän kunddetaljerna är angivna
     capture: Fånga
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Säkerhetskod
     card_number: Kortnummer
     card_type: Varumärke
@@ -527,6 +602,7 @@ sv:
     complete: komplett
     configuration: Konfiguration
     configurations: Konfigurationer
+    configure_s3: TODO_TRANSLATE
     confirm: Bekräfta
     confirm_delete: Bekräfta borttagning
     confirm_password: Bekräfta lösenord
@@ -600,10 +676,14 @@ sv:
       js_format: yy/mm/dd
     date_range: Datumintervall
     default: Förvald
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Förvald moms
     default_tax_zone: Förvald moms-zon
     delete: Ta bort
+    delete_from_taxon: TODO_TRANSLATE
     deleted_variants_present: Vissa poster i denna beställning har produkter som inte längre finns.
     delivery: Leverera
     depth: Djup
@@ -617,9 +697,24 @@ sv:
     display_currency: Visa valuta
     doesnt_track_inventory: Det spårar inte inventeringen
     edit: Redigera
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
     editing_resource: Redigerar %{resource}
     editing_rma_reason: Redigerar RMA skäl
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Redigerar användare
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
         has_excluded_product: Din varukorg innehåller en produkt som förhindrar detta kupongkod från att tillämpas.
@@ -667,15 +762,16 @@ sv:
           signup: Användarregistrering
     exceptions:
       count_on_hand_setter: Kan inte sätta tillgängligt manuellt eftersom det ställs in automatisk av recalculate_count_on_hand callback. Använd istället 'update_column(:count_on_hand, value)'
-    exchange_for:
+    exchange_for: TODO_TRANSLATE
     excl: exkl.
     existing_shipments: Existerande leveranser
-    expedited_exchanges_warning:
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Upphörande
     extension: Utökning
     failed_payment_attempts: Misslyckade betalningsförsök
     filename: Filnamn
     fill_in_customer_info: Fyll i kundens information
+    filter: TODO_TRANSLATE
     filter_results: Filtrera resultaten
     finalize: Slutför
     finalized: Slutförd
@@ -684,6 +780,7 @@ sv:
     first_name: Förnamn
     first_name_begins_with: Förnamn börjar med
     flat_percent: Fast procentsats
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Fast pris (per order)
     flexible_rate: Flexibelt sats
     forgot_password: Glömt Lösenord?
@@ -712,12 +809,16 @@ sv:
       only_incomplete: Endast ofullständiga
       select_locale: Välj språk
       show_only: Visa endast
+      store_translations: TODO_TRANSLATE
       supported_locales: Tillgängliga språk
       this_file_language: Svenska (SE)
       translations: "Översättningar"
     icon: Ikon
     identifier: Identifierare
     image: Bild
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Bilder
     implement_eligible_for_return: Måste genomföra
     implement_requires_manual_intervention: Måste genomföra
@@ -759,9 +860,9 @@ sv:
         lt: mindre än
         lte: mindre än eller lika med
     items_cannot_be_shipped: Vi kan inte skicka till den angivna adressen. Var vänlig välj en annan adress.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Sökväg
@@ -769,8 +870,14 @@ sv:
     last_name_begins_with: Efternamn börjar med
     learn_more: Mer info
     lifetime_stats: Livstids statistik
-    line_item_adjustments:
+    line_item_adjustments: TODO_TRANSLATE
     list: Lista
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Laddar
     locale_changed: Språket har ändrats
     location: Lager
@@ -786,11 +893,14 @@ sv:
     logout: Logga ut
     logs: Loggar
     look_for_similar_items: Visa liknande artiklar
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Gör återbetalning
-    make_sure_the_above_reimbursement_amount_is_correct:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
     manage_promotion_categories: Hantera kampanjkategorier
     manage_variants: Hantera varianter
-    manual_intervention_required:
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Grundpris
     match_choices:
       all: Alla
@@ -831,6 +941,7 @@ sv:
     new_refund_reason: Nytt återbetalning skäl
     new_return_authorization: Ny returauktorisation
     new_rma_reason: Nytt RMA skäl
+    new_role: TODO_TRANSLATE
     new_shipment_at_location: Ny leverans på plats
     new_shipping_category: Ny fraktkategori
     new_shipping_method: Ny fraktmetod
@@ -848,15 +959,21 @@ sv:
     new_zone: Ny zon
     next: Nästa
     no_actions_added: Inga handlingar tillagda
+    no_orders_found: TODO_TRANSLATE
     no_payment_found: Ingen betalning hittades
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: Inga förestående betalningar
     no_products_found: Inga produkter hittades
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: ingen %{resource} hittades
     no_results: Inga resultat
     no_returns_found: Inga returer hittades
     no_rules_added: Inga regler tillagda
     no_shipping_method_selected: Ingen leveransmetod vald.
+    no_shipping_methods_found: TODO_TRANSLATE
     no_state_changes: Inga status förändringar ännu.
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Inga spårningsdetaljer tillgodosedda
     none: Ingen
     none_selected: Ingen vald
@@ -894,6 +1011,7 @@ sv:
     order_details: Orderdetaljer
     order_email_resent: Order epost har skickats igen
     order_information: Orderinformation
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Bäste kund,\n
@@ -912,6 +1030,10 @@ sv:
         total: 'Totalsumma:'
     order_not_found: Vi kunde inte hitta din order. Gör ett nytt försök.
     order_number: Beställning %{number}
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Din order har tagits emot.
     order_resumed: Beställningen återupptogs
     order_state:
@@ -936,7 +1058,9 @@ sv:
     overview: "Översikt"
     package_from: paket från
     pagination:
+      first: TODO_TRANSLATE
       next_page: nästa sida »
+      previous: TODO_TRANSLATE
       previous_page: "« föregående sida"
       truncate: "…"
     password: Lösenord
@@ -973,15 +1097,16 @@ sv:
     phone: Telefon
     place_order: Placera order
     please_define_payment_methods: Definiera först någon betalningsmetod
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Något gick fel. Försök att lägga till artikeln igen.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
     preferred_reimbursement_type: "Önskad ersättningstyp"
     presentation: Presentation
     previous: Föregående
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Pris
     price_range: Prisintervall
     price_sack: Prisgräns
@@ -1008,19 +1133,24 @@ sv:
         description: Skapa en justerad kampanjkredit på ordern
         name: Skapa ändring
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Fyll varukorgen med det angivna antalet av variant
         name: Skapa radartiklar
       free_shipping:
         description: Gör alla leveranser för beställningen kostnadsfria
         name: Fri leverans
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Actions
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Matcha alla dessa regler
         any: Matcha någon av dessa regler
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Kampanjregel
     promotion_rule_types:
       first_order:
@@ -1050,10 +1180,10 @@ sv:
       user_logged_in:
         description: Tillgänglig endast för inloggade användare
         name: Användare inloggad
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Kampanjer
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: Egenskaper
     property: Egenskap
     prototype: Prototyp
@@ -1070,32 +1200,33 @@ sv:
     receive: ta emot
     receive_stock: Motta lager
     received: Mottaget
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Referens
+    reference_contains: TODO_TRANSLATE
     refund: "Återbetala"
-    refund_amount_must_be_greater_than_zero:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
     refund_reasons: "Återbetalning anledning"
     refunded_amount: "Återbetalningsbelopp"
     refunds: "Återbetalning"
     register: Registrera dig
     registration: Registrering
     reimburse: Ersätta
-    reimbursed:
+    reimbursed: TODO_TRANSLATE
     reimbursement: Ersättning
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
+        days_to_send: TODO_TRANSLATE
         dear_customer: Kära kund,\n
-        exchange_summary:
+        exchange_summary: TODO_TRANSLATE
         for: för
         instructions: Din ersättning har behandlats.
         refund_summary: "Återbetalnings sammanfattning"
         subject: Ersättnings notifiering
-        total_refunded:
-    reimbursement_perform_failed:
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
     reimbursement_status: Ersättningsstatus
     reimbursement_type: Ersättningstyp
-    reimbursement_type_override:
+    reimbursement_type_override: TODO_TRANSLATE
     reimbursement_types: Ersättningstyper
     reimbursements: Ersättningar
     reject: Avvisa
@@ -1105,6 +1236,7 @@ sv:
     rename: Byt namn
     report: Rapport
     reports: Rapporter
+    resellable: TODO_TRANSLATE
     resend: Skicka igen
     reset_password: "Återställ mitt lösenord"
     response_code: Svarskod
@@ -1112,15 +1244,16 @@ sv:
     resumed: "Återupptagen"
     return: returera
     return_authorization: Returauktorisation
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: Returauktorisation uppdaterad
     return_authorizations: Returauktorisation
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
     return_items: Retur artklar
-    return_items_cannot_be_associated_with_multiple_orders:
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
     return_number: Returnummer
     return_quantity: Returantal
     returned: Returnerad
@@ -1132,8 +1265,14 @@ sv:
     rma_credit: RMA-kredit
     rma_number: RMA-nummer
     rma_value: RMA-värde
+    role_id: TODO_TRANSLATE
     roles: Uppgifter
     rules: Regler
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
     safe: Säker
     sales_total: Total försäljning
     sales_total_description: Total försäljning på alla ordrar
@@ -1149,10 +1288,11 @@ sv:
     secure_connection_type: Säker anslutningstyp
     security_settings: Säkerhetsinställningar
     select: Välj
-    select_a_return_authorization_reason:
+    select_a_return_authorization_reason: TODO_TRANSLATE
     select_a_stock_location: Välj lager pats
     select_from_prototype: Välj från prototyp
     select_stock: Välj lager
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Skicka kopia av alla mail till
     send_mails_as: Skicka e-post som
     server: Server
@@ -1164,6 +1304,7 @@ sv:
     shipment: Leverans
     shipment_adjustments: Leveransjusteringar
     shipment_details: Från %{stock_location} via %{shipping_method}
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Bäste kund,\n
@@ -1196,6 +1337,10 @@ sv:
     shipping_method: Leveransmetod
     shipping_methods: Leveransmetoder
     shipping_price_sack: Prisgräns
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     shipping_total: Frakt totalt
     shop_by_taxonomy: Köp via %{taxonomy}
     shopping_cart: Varukorg
@@ -1208,13 +1353,25 @@ sv:
     sku: SKU
     skus: SKU's
     slug: Permalänk
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Källa
     special_instructions: Särskilda instruktioner
     split: Dela
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: Det var ett problem med din betalningsinformation. Kontrollera din information och försök igen.
     ssl:
       change_protocol: Vänligen ändra till HTTP (snarare än HTTPS) och försök igen.
     start: Starta
+    start_date: TODO_TRANSLATE
     state: Län
     state_based: Län-baserad
     state_machine_states:
@@ -1223,7 +1380,7 @@ sv:
       authorized: Auktoriserad
       awaiting: Inväntar
       awaiting_return: Inväntar retur
-      backordered:
+      backordered: TODO_TRANSLATE
       canceled: Avbruten
       cart: Kundvagn
       checkout: Kassan
@@ -1234,9 +1391,9 @@ sv:
       delivery: Leverans
       errored: Fel uppstod
       failed: Misslyckades
-      given_to_customer:
+      given_to_customer: TODO_TRANSLATE
       invalid: Ogiltigt
-      manual_intervention_required:
+      manual_intervention_required: TODO_TRANSLATE
       on_hand: I lager
       open: "Öppen"
       order: Beställning
@@ -1284,12 +1441,14 @@ sv:
     tax_included: Moms (inkl.)
     tax_rate_amount_explanation: Momssatsen anges som decimalsiffor (t.ex. om momssatsen är 25%, skriv 25.0)
     tax_rates: Momssatser
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Klass
     taxon_edit: Redigera klass
     taxon_placeholder: Lägg till klass
     taxon_rule:
       choose_taxons: Välj grupp
-      label:
+      label: TODO_TRANSLATE
       match_all: alla
       match_any: minst en
     taxonomies: Klassificeringar
@@ -1300,6 +1459,9 @@ sv:
     taxons: Klasser
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Gratulerar!
         message: Om du har fått detta e-post, är inställningarna för e-post rätt.
@@ -1308,16 +1470,16 @@ sv:
     thank_you_for_your_order: Tack för ditt köp. Var god skriv ut denna sida för framtida korrespondens.
     there_are_no_items_for_this_order: Det finns inga produkter för denna order. Lägg till en produkt för att fortsätta.
     there_were_problems_with_the_following_fields: Det var problem med följande fält
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Tumnagelbild
-    tiered_flat_rate:
-    tiered_percent:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
     tiers: Nivåer
     time: Tid
     to_add_variants_you_must_first_define: För att lägga till varianter måste du först definiera
     total: Totalt
     total_per_item: Totalt per artikel
-    total_pre_tax_refund:
+    total_pre_tax_refund: TODO_TRANSLATE
     total_price: Total pris
     total_sales: Total försäljning
     track_inventory: Spåra inventering
@@ -1343,7 +1505,9 @@ sv:
     usage_limit: Användargräns
     use_app_default: Använd standard applikation
     use_billing_address: Använd faktureringsadress
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Använd ett nytt kort
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Använd Amazon S3 för bilder
     user: Användare
     user_rule:
@@ -1351,7 +1515,8 @@ sv:
     users: Användare
     validation:
       cannot_be_less_than_shipped_units: får inte vara mindre än antalet levererade enheter.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: "Överstiger tillgängligt lager. Var säker på att radartikeln har ett giltigt antal."
       is_too_large: "är för stor – vi har inte så mycket i lager!"
       must_be_int: måste vara ett heltal
@@ -1375,3 +1540,10 @@ sv:
     zipcode: Postnummer
     zone: Zon
     zones: Zoner
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1,4 +1,6 @@
+---
 th:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ th:
         state: "จังหวัด"
         zipcode: "รหัสไปรษณีย์"
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ th:
         name: "ชื่อประเทศ"
         numcode: ISO Code
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: "ประเภท"
         month: "เดือน"
-        name:
+        name: TODO_TRANSLATE
         number: "เลขที่บัตร"
         verification_value: "เลขยืนยัน"
         year: "ปี"
@@ -42,7 +44,7 @@ th:
       spree/order:
         checkout_complete: "เช็คเอ้าท์เรียบร้อย"
         completed_at: "รายการสมบูรณ์เมื่อ"
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: "เลขคูปอง"
         created_at: "วันที่สั่งสินค้า"
         email: "อีเมลของลูกค้า"
@@ -72,6 +74,7 @@ th:
         zipcode: "รหัสไปรษณีย์ผู้รับ"
       spree/payment:
         amount: "จำนวน"
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: "ชื่อ"
       spree/product:
@@ -95,7 +98,8 @@ th:
         starts_at: "เริ่มเมื่อ"
         usage_limit: "จำกัดจำนวน"
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: "ชื่อ"
         presentation: "การแสดงผล"
@@ -105,24 +109,26 @@ th:
         amount: "จำนวน"
       spree/role:
         name: "ชื่อ"
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: "ตัวย่อ"
         name: "ชื่อ"
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: "รายละเอียด"
         name: "ชื่อ"
@@ -157,48 +163,54 @@ th:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: "ที่อยู่"
         other: "ที่อยู่"
@@ -208,41 +220,43 @@ th:
       spree/credit_card:
         one: "บัตรเครดิต"
         other: "บัตรเครดิต"
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: "จำนวนในคลัง"
         other: "จำนวนในคลัง"
       spree/line_item:
         one: Line Item
         other: Line Items
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: "สั่งซื้อ"
         other: "สั่งซื้อ"
       spree/payment:
         one: "ชำระ"
         other: "ชำระ"
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: "สินค้า"
         other: "สินค้า"
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: "คุณสมบัติ"
         other: "คุณสมบัติ"
       spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: "รายการคืน"
         other: "รายการคืน"
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: "หน้าที่"
         other: "หน้าที่"
       spree/shipment:
@@ -251,14 +265,14 @@ th:
       spree/shipping_category:
         one: "ประเภทการจัดส่ง"
         other: "ประเภทการจัดส่ง"
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: "จังหวัด"
         other: "จังหวัด"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: "ประเภทภาษี"
         other: "ประเภทภาษี"
@@ -266,8 +280,12 @@ th:
         one: "อัตราภาษีTax Rate"
         other: "อัตราภาษี"
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
-      spree/tracker:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: "ผู้ใช้งาน"
         other: "ผู้ใช้งาน"
@@ -277,6 +295,9 @@ th:
       spree/zone:
         one: "เขต"
         other: "เขต"
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: "บัญชีของคุณได้ถูกยืนยันแล้ว ขณะนี้คุณได้เข้าระบบเรียบร้อย"
@@ -315,18 +336,37 @@ th:
     user_sessions:
       signed_in: "เข้าสู่ระบบเรียบร้อย"
       signed_out: "ออกจากระบบเรียบร้อย"
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: "ได้ทำการยืนยันแล้ว"
       not_found: "ไม่พบ"
       not_locked: "ไม่ได้ล๊อก"
       not_saved: "พบ %{count} ข้อผิดพลาดที่ทำให้ %{resource} ไม่สามารถบันทึกได้"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: "คำย่อ"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "บัญชีผู้ใช้"
     account_updated: "ปรับปรุงบัญชีผู้ใช้แล้ว"
     action: "ทำการ"
@@ -339,7 +379,7 @@ th:
       list: "แสดงรายการ"
       listing: "รายการ"
       new: "สร้าง"
-      refund:
+      refund: TODO_TRANSLATE
       save: "บันทึก"
       update: "ปรับปรุง"
     activate: "เริ่มใช้งาน"
@@ -347,7 +387,7 @@ th:
     add: "เพิ่ม"
     add_action_of_type: "เพิ่มประเภท"
     add_country: "เพิ่มประเทศ"
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: "เพิ่ม Header"
     add_new_style: "เพิ่ม Style"
     add_one: "เพิ่ม"
@@ -361,11 +401,16 @@ th:
     add_to_cart: "เพิ่มลงตะกร้า"
     add_variant: "เพิ่มตัวแปร"
     additional_item: "ราคาเพิ่มเติม"
+    address: TODO_TRANSLATE
     address1: "ที่อยู่"
     address2: "ที่อยู่ (เพิ่มเติม)"
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: "แก้ไขรายการ"
     adjustment_amount: "จำนวน"
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: "รายการแก้ไขได้ทำการปิดเป็นที่เรียบร้อย"
     adjustment_successfully_opened: "รายการแก้ไขได้ทำการเปิดเป็นที่เรียบร้อย"
     adjustment_total: "ยอดรวมรายการที่แก้ไข"
@@ -373,35 +418,35 @@ th:
     admin:
       tab:
         configuration: "ตั้งค่า"
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: "สั่งซื้อ"
         overview: "ภาพรวม"
         products: "สินค้า"
         promotions: "โปรโมชั่น"
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: "รายงาน"
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: "ผู้ใช้"
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: "การจัดการ"
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: "ตกลงในนโยบายความเป็นส่วนตัว"
     agree_to_terms_of_service: "ตกลงในข้อตกลงบริการ"
     all: "ทั้งหมด"
     all_adjustments_closed: "ทุกรายการแก้ไขนั้นได้ปิดลงแล้ว!"
     all_adjustments_opened: "ทุกรายการแก้ไขนั้้นได้เปิดแล้ว!"
     all_departments: "ทุกแผนก"
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: "อนุญาตให้ใช้ SSL เมื่ออยู่ในโหมดของการพัฒนาและทดสอบ"
     allow_ssl_in_production: "อนุญาต SSL ให้ทำงานบน Production"
     allow_ssl_in_staging: "อนุณาต SSL ให้ทำงานบน Stagging"
@@ -417,70 +462,104 @@ th:
     analytics_desc_list_4: "มันฟรีจริงๆนะ!"
     analytics_trackers: Analytics Trackers
     and: "และ"
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: "แน่ใจหรือไม่"
     are_you_sure_delete: "คุณแน่ใจที่จะลบข้อมูลนี้หรือไม่?"
     associated_adjustment_closed: "รายการที่เกี่ยวข้อกับรายการปรับปรุงนั้นได้ปิดแล้ว และจะไม่นำมาคำนวนใหม่ คุณต้องการที่จะเปิดหรือไม่?"
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: "การขออนุญาต ไม่สำเร็จ"
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: "พร้อมเมื่อ"
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: "กลับ"
     back_end: Back End
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: "กลับไปหน้าร้าน"
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: "กลับไปยังรายการลูกค้า"
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: "สามารถสั่งซื้อล่วงหน้าได้"
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: "ยอดที่ต้องชำระ"
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: "ที่อยู่บนใบเสร็จรับเงิน"
     billing: "ใบเสร็จรับเงิน"
     billing_address: "ที่อยู่บนใบเสร็จรับเงิน"
     both: "ทั้งสอง"
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: "เครื่องคิดเลข"
     calculator_settings_warning: "หากคุณต้องการเปลี่ยนวิธีการคำนวน คุณต้องบันทึกก่อนถึงจะสามารถแก้ไขการคำนวนได้"
     cancel: "ยกเลิก"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: "คุณไม่สามารถชำระรายการสั่งซื้อได้เนื่องจากไม่ได้กำหนดวิธีชำระสินค้า"
     cannot_create_returns: "ไม่สามารถทำรายการคืนสินาได้เนื่องจากยังไม่ได้ส่งสินค้าดังกล่าว"
     cannot_perform_operation: "ไม่สามารถทำรายการที่ต้องการได้"
     cannot_set_shipping_method_without_address: "ไม่สามารถตั้งค่าประเภทการจัดส่งได้จนกว่าจะได้รับรายละเอียดของลูกค้า"
     capture: capture
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: "รหัสบัตร"
     card_number: "หมายเลขบัตร"
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: "ชนิดของบัตร"
     cart: "ตะกร้าสินค้า"
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: "หมวดหมู่"
     category: "ชนิด"
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: "ตรวจสอบการแจ้งเตือน Spree"
     checkout: "สั่งซื้อ"
     choose_a_customer: "เลือกลูกค้า"
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: "เลือกสกุลเงิน"
     choose_dashboard_locale: "เลือกภาษาของ Dashboard"
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: "เขต หรือ อำเภอ"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Clone
     close: "ปิด"
     close_all_adjustments: "ปิดรายการปรับปรุงทั้งหมด"
@@ -489,6 +568,7 @@ th:
     complete: "เสร็จสิ้น"
     configuration: "จัดการระบบ"
     configurations: "รายการจัดการ"
+    configure_s3: TODO_TRANSLATE
     confirm: "ยืนยันรหัสผ่าน"
     confirm_delete: "ยืนยันการลบ"
     confirm_password: "ยืนยันรหัสผ่าน"
@@ -497,7 +577,7 @@ th:
     cost_currency: "ราคาสกุลเงิน"
     cost_price: Cost Price
     could_not_connect_to_jirafe: "ไม่สามารถเชื่อมต่อกับ Jirafe เพื่อรับข้อมูลได้ ระบบจะทดลองเชื่อมต่อใหม่อีกครั้ง"
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: "เกิดปัญหาขึ้นระหว่างทำการเคลื่อนย้ายสินค้า กรุณาลองใหม่อีกครั้ง"
     count_on_hand: "จำนวนในมือ"
     countries: "ประเทศ"
@@ -505,10 +585,10 @@ th:
     country_based: "ยีดประเทศเป็นหลัก"
     country_name: "ชื่อ"
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: "คูปอง"
     coupon_code: "หมายเลขคูปอง"
     coupon_code_already_applied: "คูปองใบนี้ได้ถูกใช้ในรายการสั่งซื้อนี้แล้ว"
@@ -518,17 +598,17 @@ th:
     coupon_code_max_usage: "คูปองได้ถูกใช้เกินกำหนดแล้ว"
     coupon_code_not_eligible: "คูปองนี้ไม่สามารถใช้กับรายการสั่งซื้อดังกล่าวได้"
     coupon_code_not_found: "ไม่พบหมายเลขคูปองนี้ กรุณาลองใหม่อีกครั้ง"
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: "สร้าง"
     create_a_new_account: "สร้างบัญชีผู้ใช้ใหม่"
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: "สร้างเมื่อ"
     credit: "เครดิต"
     credit_card: "บัตรเครดิต"
     credit_cards: "บัตรเครดิต"
     credit_owed: "ค้างเครดิตอยู่"
-    credits:
+    credits: TODO_TRANSLATE
     currency: "สกุลเงิน"
     currency_decimal_mark: "จุดทศนิยมของสกุลเงิน"
     currency_settings: "ตั้งค่าสกุลเงิน"
@@ -539,11 +619,11 @@ th:
     customer: "ลูกค้า"
     customer_details: "รายละเอียดลูกค้า"
     customer_details_updated: "ได้ทำการปรับปรุงรายละเอียดของลูกค้าแล้ว"
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: "ค้นหาลูกค้า"
     cut: Cut
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: App ID
@@ -557,46 +637,65 @@ th:
     date: "วันที่"
     date_completed: "วันที่เสร็จสิ้น"
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
     date_range: "ช่วงวันที่"
     default: "ค่าเริ่มต้น"
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: "ค่าภาษีเริ่มต้น"
     default_tax_zone: "ค่าโซนภาษีเริ่มต้น"
     delete: "ลบ"
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: "จัดส่ง"
     depth: "ลึก"
     description: "รายละเอียด"
     destination: "จุดหมาย"
     destroy: "ทำลาย"
-    details:
+    details: TODO_TRANSLATE
     discount_amount: "จำนวนส่วนลด"
     dismiss_banner: "ไม่ ขอบคุณ! ฉันไม่สนใจ และไม่ต้องแสดงข้อความดังกล่าวอีก"
     display: "แสดง"
     display_currency: "แสดงสกุลเงิน"
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: "แก้ไข"
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: "แก้ไขข้อมูลผู้ใช้"
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: "อีเมล"
     empty: "ว่างเปล่า"
     empty_cart: "ล้างตะกร้า"
@@ -629,28 +728,30 @@ th:
           signup: "สมัครสมาชิก"
     exceptions:
       count_on_hand_setter: "ไม่สามารถตั้งค่า count_on_hand ได้ด้วยตัวเอง เนื่องจากระบบได้ตั้งค่า recalculate_count_on_hand โดยอัตโนมัติ กรุณาใช้ `update_column(:count_on_hand, value)` แทน"
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: "หมดอายุ"
     extension: "ส่วนขยาย"
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: "ชื่อไฟล์"
     fill_in_customer_info: "กรุณากรอกข้อมูลลูกค้า"
+    filter: TODO_TRANSLATE
     filter_results: "กรอกผลลัพท์"
     finalize: Finalize
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: "ราคาสินค้าชิ้นแรก"
     first_name: "ชื่อจริง"
     first_name_begins_with: "ชื่อจริงเริ่มต้นด้วย"
     flat_percent: Flat Percent
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Flat Rate (ต่อรายการสั่งซื้อ)
     flexible_rate: Flexible Rate
     forgot_password: "ลืมรหัสผ่าน"
     free_shipping: Free Shipping
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: "หน้าขายสินค้า"
     gateway: "ช่องทางการชำระเงิน"
     gateway_config_unavailable: Gateway unavailable for environment
@@ -674,37 +775,41 @@ th:
       only_incomplete: "เฉพาะที่ไม่สมบูรณ์"
       select_locale: "เลือกภาษา"
       show_only: "แสดงเฉพาะ"
+      store_translations: TODO_TRANSLATE
       supported_locales: "ภาษาที่รองรับ"
       this_file_language: "ภาษาไทย (TH)"
       translations: "แปล"
     icon: "ไอค่อน"
-    identifier:
+    identifier: TODO_TRANSLATE
     image: "รูปภาพ"
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: "รูปภาพ"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: "รวมในราคา"
     included_price_validation: "ไม่สามารถเลือกได้หากคุณยังไม่ได้ตั้งค่าเริ่มต้นของโซนภาษี"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: "กรุณากรอกอีเมลของคุณในฟอร์มด้านล่าง"
     insufficient_stock: "สินค้าในคลังไม่เพียงพอ เรามีแค่ %{on_hand} อยู่ในขณะนี้"
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: "ยับยั้งอีเมล"
     intercept_email_instructions: "แก้ไขอีเมลผู้รับและแทนที่ด้วยอีเมลนี้"
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: "ผู้ให้บริการชำระเงินไม่ถูกต้อง"
     invalid_promotion_action: "การตั้งค่าโปรโมชั่นไม่ถูกต้อง"
     invalid_promotion_rule: "กฏของโปรโมชั่นไม่ถูกต้อง"
     inventory: "คลัง"
     inventory_adjustment: "ปรับแต่งคลังสินค้า"
     inventory_error_flash_for_insufficient_quantity: "สินค้าในตะกร้าของคุณนั้นหมดเสียแล้ว"
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: "นั้นไม่พร้อมที่ส่งไปยังที่อยู่ดังกล่าว"
     iso_name: "ชื่อ ISO"
     item: "สินค้า"
@@ -714,26 +819,32 @@ th:
       operators:
         gt: "มากกว่า"
         gte: "มากกว่าหรือเท่ากับ"
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: "เราไม่สามารถส่งสินค้าดังกล่าวไปยังสถานที่ของคุณได้ กรุณาเลือกสถานที่จัดส่งอื่น"
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: "นามสกุล"
     last_name_begins_with: "นามสกุลเริ่มต้นด้วย"
     learn_more: "เพิ่มเติม"
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: "รายการ"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "กำลังโหลด"
     locale_changed: "เปลี่ยนภาษา"
     location: "สถานที่"
     lock: "ล๊อก"
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: "เข้าสู่ระบบเป็น"
     logged_in_succesfully: "เข้าสู่ระบบสำเร็จ"
     logged_out: "คุณได้ออกจากระบบแล้ว"
@@ -742,23 +853,26 @@ th:
     login_failed: "ไม่สามารถเข้าสู่ระบบได้"
     login_name: "เข้าสู่ระบบ"
     logout: "ออกจากระบบ"
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: "มองหาสินค้าที่คล้ายกัน"
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: "ทำเรื่องขอคืนสินค้า"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: "ราคาหลัก"
     match_choices:
       all: "ทั้งหมด"
       none: "ไม่มี"
     max_items: "มากสุด"
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta Description
     meta_keywords: Meta Keywords
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: "จำนวนต่ำสุด"
     month: "เดือน"
@@ -767,13 +881,13 @@ th:
     my_account: "บัญชีของท่าน"
     my_orders: "รายการสั่งซื้อ"
     name: "ชื่อ"
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: "ชื่อหรือ SKU (กรุณาใส่ตัวอักษรอย่างน้อย 4 ตัวขึ้นไปของชื่อสินค้า)"
     new: "ใหม่"
     new_adjustment: New Adjustment
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: "สมัครสมาชิก"
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: "เพิ่มภาพ"
     new_option_type: "เพิ่มรายการให้เลือก"
     new_order: "สั่งซื้อสินค้า"
@@ -782,14 +896,15 @@ th:
     new_payment_method: "เลือกวิธีการชำระใหม่"
     new_product: "เพิ่มสินค้า"
     new_promotion: "โปรโมชั่นใหม่"
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: "เพิ่มคุณลักษณะ"
     new_prototype: "เพิ่มต้นแบบ"
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: "รายการคืนสินค้าใหม่"
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: "เพิ่มกลุ่มวิธีการจัดส่ง"
     new_shipping_method: "เพิ่มวิธีจัดส่ง"
     new_state: "เพิ่มรัฐหรือจังหวัด"
@@ -806,24 +921,30 @@ th:
     new_zone: "เพิ่มเขตใหม่"
     next: "ถัดไป"
     no_actions_added: "ไม่พบการสั่งการ"
-    no_payment_found:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: "ไม่พบรายการรอชำระ"
     no_products_found: "ไม่พบสินค้า"
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: "ไม่พบผลลัพท์"
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: "ไม่พบ rules"
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: "ไม่พบรายละเอียดของ Tracker"
     none: "ว่าง"
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: "ราคาปรกติ"
     not: "ไม่"
     not_available: "ไม่มี"
     not_enough_stock: "จำนวนรายการสินค้าไม่พอในคลังสินค้าดังกล่าว"
     not_found: "%{resource} นั้นไม่พบ"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: "สินค้าได้ถูกทำสำเนา"
       product_deleted: "สินค้าได้ถูกลบแล้ว"
@@ -831,7 +952,7 @@ th:
       product_not_deleted: "สินค้าไม่สามารถถูกลบได้"
       variant_deleted: Variant has been deleted
       variant_not_deleted: "ตัวแปรไม่สามารถถูกลบได้"
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: "สินค้าในคลัง"
     open: "เปิด"
     open_all_adjustments: "เปิดรายการปรับปรุงทั้งหมด"
@@ -846,32 +967,37 @@ th:
     or_over_price: "%{price} หรือมากกว่า"
     order: "รายการ"
     order_adjustments: Order adjustments
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: "รายละเอียดการสั่งซื้อ"
     order_email_resent: "ส่งอีเมลการสั่งซื้อใหม่"
     order_information: "ข้อมูลการสั่งซื้อ"
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: "ถึงคุณลูกค้า,\\n"
         instructions: "สินค้าของคุณได้ถูกยกเลิกแล้ว กรุณาเก็บหลักฐานอีเมลฉบับนี้เอาไว้ เพื่อใช้ในการอ้างอิงในอนาคต"
         order_summary_canceled: "รายการที่สั่งซื้อ [ยกเลิก]"
         subject: "การยกเลิกการสั่งซื้อ"
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: "ถึงคุณลูกค้า,\\n"
         instructions: "กรุณาตรวจสอบและเก็บรายละเอียดการสั่งซื้อนี้เอาไว้"
         order_summary: "รายการที่สั่งซื้อ"
         subject: "ยืนยันการสั่งซื้อ"
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: "ขอขอบคุณที่ได้รับใช้คุณ"
-        total:
+        total: TODO_TRANSLATE
     order_not_found: "เราไม่พบรายการสั่งซื้อของคุณ กรุณาลองใหม่อีกครั้ง"
     order_number: "รหัสสั่งซื้อ %{number}"
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: "รายการสั่งซื้อของคุณถูกดำเนินการเรียบร้อยแล้ว"
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: "ที่อยู่"
       awaiting_return: "อยู่ในระหว่างการคืน"
@@ -879,7 +1005,7 @@ th:
       cart: "ตะกร้า"
       complete: "เสร็จสิ้น"
       confirm: "ยืนยัน"
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: "ส่งสินค้า"
       payment: "ชำระเงิน"
       resumed: "ต่อไป"
@@ -889,12 +1015,14 @@ th:
     order_total: "ราคารวม"
     order_updated: "รายการสั่งซื้อได้ถูกปรับปรุงแล้ว"
     orders: "รายการสั่งซื้อ"
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: "สินค้าหมด"
     overview: "ภาพรวม"
     package_from: "สินค้าจาก"
     pagination:
+      first: TODO_TRANSLATE
       next_page: "หน้าต่อไป »"
+      previous: TODO_TRANSLATE
       previous_page: "« ก่อนก่อนนี้"
       truncate: "…"
     password: "รหัสผ่าน"
@@ -902,11 +1030,11 @@ th:
     path: Path
     pay: "ชำระ"
     payment: "ชำระ"
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: "ข้อมูลการชำระเงิน"
     payment_method: "วิธีชำระเงิน"
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: "วิธีชำระเงิน"
     payment_processing_failed: "ไม่สามารถชำระเงินได้ กรุณาตรวจสอบข้อมูลที่คุณได้กรอกใหม่"
     payment_processor_choose_banner_text: "หากคุณต้องการความช่วยเหลือในการตัดเงิน กรุณาไปยัง"
@@ -924,22 +1052,23 @@ th:
       void: void
     payment_updated: "ได้ปรับปรุงการชำระเงินแล้ว"
     payments: "รายการชำระเงิน"
-    pending:
+    pending: TODO_TRANSLATE
     percent: "เปอร์เซ็น"
     percent_per_item: "เปอร์เซ็นต่อชิ้น"
     permalink: Permalink
     phone: "เบอร์โทรศัพท์"
     place_order: "สั่งซื้อ"
     please_define_payment_methods: "กรุณาเลือกวิธีการชำระก่อน"
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: "เกิดข้อผิดพลาด กรุณาเพิ่มสินค้าใหม่อีกครั้ง"
     powered_by: "สนับสนุนโดย"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: "แสดง"
     previous: "ก่อนหน้า"
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: "ราคา"
     price_range: "ราคาระหว่าง"
     price_sack: Price Sack
@@ -951,10 +1080,10 @@ th:
     product_properties: "สรรพคุณของสินค้า"
     product_rule:
       choose_products: "เลือกสินค้า"
-      label:
+      label: TODO_TRANSLATE
       match_all: "ทั้งหมด"
       match_any: "อย่างน้อยหนึ่ง"
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: "จากกลุ่มของสินค้า"
         manual: "เลือกเอง"
@@ -966,19 +1095,24 @@ th:
         description: Creates a promotion credit adjustment on the order
         name: "สร้างการปรับเปลี่ยน"
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: "สร้างตะกร้าสินค้าด้วยจำนวนที่กำหนดจากตัวแปร"
         name: "สร้าง line items"
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: "ดำเนินการ"
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: "จับคู่ทั้งหมด"
         any: "จับคู่อย่างใดอย่างหนึ่ง"
+    promotion_label: TODO_TRANSLATE
     promotion_rule: "กฏของโปรโมชั่น"
     promotion_rule_types:
       first_order:
@@ -991,27 +1125,27 @@ th:
         description: "ลูกค้าต้องไปยังหน้าที่กำหนด"
         name: Landing Page
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: "รายการนั้นรวมสินค้าที่กำหนด"
         name: "สินค้า"
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: "เฉพาะลูกค้าที่กำหนด"
         name: "ผู้ใช้"
       user_logged_in:
         description: "เฉพาะลูกค้าที่เข้าระบบ"
         name: "ผู้ใช้ในระบบ"
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: "โปรโมชั่น"
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: "คุณสมบัติ"
     property: "คุณสมบัติ"
     prototype: Prototype
@@ -1022,47 +1156,49 @@ th:
     quantity: "จำนวน"
     quantity_returned: "จำนวนที่คืน"
     quantity_shipped: "จำนวนที่ส่ง"
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: "อัตรา"
     reason: "เหตุผล"
     receive: "ได้รับ"
     receive_stock: "ได้รับสินค้า"
     received: "ได้รับแล้ว"
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: "อ้างอิง"
+    reference_contains: TODO_TRANSLATE
     refund: "คืนเงิน"
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: "ลงทะเบียน"
     registration: "ลงทะเบียน"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: "จำฉัน"
     remove: "ลบ"
     rename: "เปลี่ยนชื่อ"
-    report:
+    report: TODO_TRANSLATE
     reports: "รายงาน"
+    resellable: TODO_TRANSLATE
     resend: "ส่งใหม่"
     reset_password: "ตั้งรหัสผ่านใหม่"
     response_code: "รหัสที่ได้รับ"
@@ -1070,34 +1206,41 @@ th:
     resumed: "ทำต่อ"
     return: "กลับ"
     return_authorization: "รายการคืนสินค้า"
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: "รายการคืนสินค้าได้ปรับปรุงแล้ว"
     return_authorizations: "รายการคืนสินค้า"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: "จำนวนที่คืน"
     returned: "คืน"
-    returns:
+    returns: TODO_TRANSLATE
     review: "ตรวจสอบ"
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: RMA Number
     rma_value: RMA Value
+    role_id: TODO_TRANSLATE
     roles: "หน้าที่"
     rules: "กฏ"
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: "ยอดขายรวม"
     sales_total_description: "ยอดขายรวมสำหรับรายการที่สั่งซื้อทั้งหมด"
     sales_totals: "ยอดขายรวม"
     save_and_continue: "บันทึกและดำเนินการต่อ"
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: "ไม่"
     say_yes: "ถูกต้อง"
     scope: Scope
@@ -1107,10 +1250,11 @@ th:
     secure_connection_type: Secure Connection Type
     security_settings: "ตั้งค่าความปลอดภัย"
     select: "เลือก"
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: "เลือกจาก Prototype"
     select_stock: "เลือกจากคลัง"
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: "ส่งสำเนาไปยัง"
     send_mails_as: "ส่งเมลด้วย"
     server: "เซิร์ฟเวอร์"
@@ -1120,8 +1264,9 @@ th:
     ship_address: "ที่อยู่���่งของ"
     ship_total: "ค่าจัดส่ง"
     shipment: "การส่ง"
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: "ถึงคุณลูกค้า,\\n"
@@ -1134,13 +1279,13 @@ th:
     shipment_state: "สถานะการจัดส่ง"
     shipment_states:
       backorder: "พร้อมจัดส่ง"
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: "บางส่วน"
       pending: "รอ"
       ready: "พร้อม"
       shipped: "ส่งแล้ว"
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: "การจัดส่ง"
     shipped: "ส่งแล้ว"
     shipping: "ส่ง"
@@ -1154,67 +1299,83 @@ th:
     shipping_method: "วิธีการจัดส่ง"
     shipping_methods: "วิธีการจัดส่ง"
     shipping_price_sack: Price sack
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "ซื้อโดย %{taxonomy}"
     shopping_cart: "ตะกร้าสินค้า"
     show: "แสดง"
     show_active: "แสดงที่ใช้งานอยู่"
     show_deleted: "แสดงที่ลบ"
     show_only_complete_orders: "แสดงรายการสั่งซื้อที่สมบูรณ์"
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: "แสดงอัตรา"
-    sku:
-    skus:
-    slug:
+    sku: TODO_TRANSLATE
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: "จาก"
     special_instructions: "วิธี"
     split: "แยก"
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: "เกิดปัญหาขึ้นกับข้อมูลการชำระเงินของคุณ กรุณาตรวจสอบข้อมูลการชำระเงินของคุณแล้วลองใหม่"
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: "เริ่ม"
+    start_date: TODO_TRANSLATE
     state: "จังหวัด"
     state_based: "จังหวัดที่ตั้ง"
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: "จังหวัด"
     states_required: "จังหวัดที่ต้องการ"
     status: "สถานะ"
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: "สถานที่ของคลังสินค้า"
     stock_location_info: "ข้อมูลของคลังสินค้า"
     stock_locations: "สถานที่ของคลังสินค้า"
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: "การจัดการคลังสินค้า"
     stock_management_requires_a_stock_location: "กรุณาสร้างคลังสินค้าเพื่อที่จะสามารถบริหารคลังได้"
     stock_movements: "สินค้าเคลื่อนไหว"
@@ -1228,28 +1389,30 @@ th:
     street_address_2: "ที่อยู่ (ต่อ)"
     subtotal: "ยอด"
     subtract: "หักออก"
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} นั้นได้สร้างเรียบร้อยแล้ว"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} นั้นได้ถูกลบเรียบร้อยแล้ว"
     successfully_signed_up_for_analytics: "ได้สมัคร Spree Analytics เป็นที่เรียบร้อย"
     successfully_updated: "%{resource} นั้นได้ปรับปรุงเรียบร้อยแล้ว"
-    summary:
+    summary: TODO_TRANSLATE
     tax: "ภาษี"
     tax_categories: "ประเภทภาษี"
     tax_category: "ประเภทภาษี"
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: "อัตราภาษีนั้นเป็นทศนิยมเพื่อง่ายในการคำนวน (ตัวอย่าง, หากภาษีคือ 7% ให้ใส่ 0.07)"
     tax_rates: "อัตราภาษี"
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Taxon
     taxon_edit: "แก้ไข Taxon"
     taxon_placeholder: "เพิ่ม Taxon"
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: "แก้ไข taxonomy"
@@ -1258,6 +1421,9 @@ th:
     taxons: Taxons
     test: "ทดสอบ"
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: "ยินดีด้วย!"
         message: "หากคุณได้รับอีเมลฉบับนี้ แสดงว่าการตั้งค่าอีเมลของคุณนั้นถูกต้อง"
@@ -1266,24 +1432,24 @@ th:
     thank_you_for_your_order: "ขอบคุณสำหรับการสั่งซื้อของคุณ กรุณาเก็บหน้านี้เอาไว้"
     there_are_no_items_for_this_order: "ไม่พบรายการสินค้าในการสั่งซื้อนี้ กรุณาเพิ่มรายการสินค้าเพื่อทำการต่อ"
     there_were_problems_with_the_following_fields: "เกิดปัญหากับ Field ดังกล่าว"
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: "รูป Thumnail"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: "เวลา"
     to_add_variants_you_must_first_define: "หากเพิ่มตัวแปร คุณต้องกำหนด"
     total: "จำนวน"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL
     tracking_url_placeholder: "ตัวอย่าง http://quickship.com/package?num=:tracking"
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: "ย้ายจาก"
     transfer_stock: "ย้ายสินค้า"
     transfer_to_location: "ย้ายไป"
@@ -1291,7 +1457,7 @@ th:
     type: "ประเภท"
     type_to_search: "พิมพ์เพื่อค้นหา"
     unable_to_connect_to_gateway: "ไม่สามารถติดต่อกับ Gateway"
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: "ไม่เกิน %{price}"
     unlock: "ปลดล๊อก"
     unrecognized_card_type: "ไม่รู้จักบัตรประเภทนี้"
@@ -1299,9 +1465,11 @@ th:
     update: "แก้ไข"
     updating: "กำลังแก้ไข"
     usage_limit: "ลิมิตการใช้"
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: "ใช้ที่อยู่ที่ออกใบเสร็จ"
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: "ใช้บัตรใบใหม่"
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: "ใช้ Amazon S3 สำหรับรูปภาพ"
     user: "ผู้ใช้"
     user_rule:
@@ -1309,12 +1477,13 @@ th:
     users: "ผู้ใช้"
     validation:
       cannot_be_less_than_shipped_units: "ไม่สามารถน้อยกว่าจำนวนในการจัดส่ง"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: exceeds available stock. Please ensure line items have a valid quantity.
       is_too_large: "นั้นใหญ่เกินไป -- สินค้าในมือไม่สามารถรองรับจำนวนที่ต้องการได้"
       must_be_int: "ต้องเป็นเลขจำนวนเต็ม"
       must_be_non_negative: "ต้องเป็นค่าที่ไม่ติดลบ"
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: "ค่า"
     variant: "ตัวแปร"
     variant_placeholder: "เลือกตัวแปร"
@@ -1333,3 +1502,10 @@ th:
     zipcode: "รหัสไปรษณีย์"
     zone: "โซน"
     zones: "โซน"
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,4 +1,6 @@
+---
 tr:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ tr:
         state: Eyalet
         zipcode: Posta Kodu
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ tr:
         name: Ad
         numcode: ISO Kodu
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Tür
         month: Ay
-        name:
+        name: TODO_TRANSLATE
         number: Numara
         verification_value: Doğrulama Kodu
         year: Yıl
@@ -42,7 +44,7 @@ tr:
       spree/order:
         checkout_complete: "Ödeme Tamamlandı"
         completed_at: Tamamlanma zamanı
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: Kupon Kodu
         created_at: Sipariş Tarihi
         email: Müşteri E-posta
@@ -72,6 +74,7 @@ tr:
         zipcode: Kargo adresi, posta kodu
       spree/payment:
         amount: Miktar
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: Ad
       spree/product:
@@ -95,7 +98,8 @@ tr:
         starts_at: Başlama Tarihi
         usage_limit: Kullanım Limiti
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Ad
         presentation: Tanıtım
@@ -105,24 +109,26 @@ tr:
         amount: Miktar
       spree/role:
         name: Ad
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Kısaltma
         name: Ad
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Açıklama
         name: Ad
@@ -157,86 +163,99 @@ tr:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: Kart süresi doldu
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address: Adresler
       spree/country: "Ülkeler"
       spree/credit_card: Kredi Kartları
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit: Stok Birimi
       spree/line_item: Kalem
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order: Siparişler
       spree/payment: "Ödemeler"
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product: "Ürünler"
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property: "Özellikler"
       spree/prototype: Prototipler
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization: Geri İade Yetkileri
-      spree/return_authorization_reason:
-      spree/role: Roller
+      spree/return_authorization_reason: TODO_TRANSLATE
+      spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipment: Kargolar
       spree/shipping_category: Kargo Kategorileri
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state: Bölgeler
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category: Vergi Sınıfları
       spree/tax_rate: Vergi Oranları
       spree/taxon: Gruplar
       spree/taxonomy: Gruplandırmalar
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user: Kullanıcılar
       spree/variant: "Çeşitler"
       spree/zone: Bölgeler
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Hesabınız başarıyla etkinleştirildi. Şu anda giriş yaptınız.
@@ -275,18 +294,37 @@ tr:
     user_sessions:
       signed_in: Başarıyla giriş yapıldı.
       signed_out: Oturum Başarıyla kapatıldı.
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: zaten onaylanmış
       not_found: bulunamadı
       not_locked: kilitli değil
       not_saved: "%{resource} kaydedilirken %{count} hata tespit edildi."
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Kısaltma
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Hesap
     account_updated: Hesap güncellendi
     action: Hareket
@@ -299,7 +337,7 @@ tr:
       list: Liste
       listing: Listeleme
       new: Yeni
-      refund:
+      refund: TODO_TRANSLATE
       save: Kaydet
       update: Güncelle
     activate: Etkinleştirme
@@ -307,7 +345,7 @@ tr:
     add: Ekle
     add_action_of_type: Hareket tipi ekle
     add_country: "Ülke ekle"
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Yeni başlık ekle
     add_new_style: Yeni biçim ekle
     add_one: Yeni ekle
@@ -321,11 +359,16 @@ tr:
     add_to_cart: Sepete Ekle
     add_variant: Değişken ekle
     additional_item: Ek parça maliyeti
+    address: TODO_TRANSLATE
     address1: Adres
     address2: Adres(Devamı)
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: Kredi
     adjustment_amount: Miktar
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: Kredi başarıyla kapatıldı!
     adjustment_successfully_opened: Kredi başarıyla açıldı!
     adjustment_total: Kredi Toplamı
@@ -341,27 +384,27 @@ tr:
         properties: "Özellikler"
         prototypes: Prototipler
         reports: Raporlar
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: Kullanıcılar
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Yönetim
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: Gizlilik Politikasını kabul ediyorum
     agree_to_terms_of_service: Hizmet Sözleşmesini kabul ediyorum
     all: Tümü
     all_adjustments_closed: Tüm krediler başarıyla kapatıldı!
     all_adjustments_opened: Tüm Krediler başarıyla açıldı!
     all_departments: Tüm Birimler
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Geliştirme ve deneme aşamalarında SSL kullanımına izin ver
     allow_ssl_in_production: Gerçek satış aşamasında SSL kullanımına izin ver
     allow_ssl_in_staging: Devreye alma aşamasında SSL kullanımına izin ver
@@ -377,70 +420,104 @@ tr:
     analytics_desc_list_4: Tamamen ücretsiz!
     analytics_trackers: Analiz İzleyicileri
     and: ve
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Emin misiniz?
     are_you_sure_delete: Bu kaydı silmek istediğnizden emin misiniz?
     associated_adjustment_closed: Bağlı kredi kapatıldı ve tekrar hesaplanmayacak. Tekrar açmak ister misiniz?
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Yetkilendirme Hatası
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Geliş Tarihi
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Geri
     back_end: Arkaplan
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Mağazaya Geri Dön
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Kullanıcı Listesine Geri Dön
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: "İade Edilebilir"
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Kalan Bakiye
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: Fatura Adresi
     billing: Fatura
     billing_address: Fatura Adresi
     both: Her ikisi
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Hesap Makinesi
     calculator_settings_warning: Hesaplayıcı tipini değiştirirseniz, Hesap makinesi ayarlarını düzenleyebilmek için önce yaptığınız değişiklikleri kaydetmelisiniz.
     cancel: iptal
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: "Ödeme yöntemi tanımlanmadan bir ödeme oluşturamazsınız."
     cannot_create_returns: 'Bu sipariş kargolanmış bir ürün içermediğinden geri dönderilemez. '
     cannot_perform_operation: Bu işlem gerçekleştirilemez.
     cannot_set_shipping_method_without_address: Müşteri detayları belirtilmedikçe kargo yöntemi seçilemez.
     capture: Yakala
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Kart Kodu
     card_number: Kart Numarası
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Kart Tipi
     cart: Sepet
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Kategoriler
     category: Kategori
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Spree uyarılarını denetle
     checkout: "Ödeme"
     choose_a_customer: Bir müşteri seç
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Kur Seç
     choose_dashboard_locale: Kontrol Paneli Dili Seç
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: "Şehir"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: "Çoğalt"
     close: Kapat
     close_all_adjustments: Tüm kredileri kapat
@@ -449,6 +526,7 @@ tr:
     complete: tamamı
     configuration: Ayarlama
     configurations: Ayarlamalar
+    configure_s3: TODO_TRANSLATE
     confirm: Onay
     confirm_delete: Silme İşlemini Onayla
     confirm_password: "Şifre Onayı"
@@ -457,7 +535,7 @@ tr:
     cost_currency: Maliyet Kuru
     cost_price: Maliyet Fiyatı
     could_not_connect_to_jirafe: Jirafe eşleme verilerine ulaşılamıyor. Daha sonra otomatik olarak tekrar denenecek.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Stok hareketi kaydedilirken bir sorun oluştu. Lütfen daha sonra tekrar deneyiniz.
     count_on_hand: Elde olan miktar
     countries: "Ülkeler"
@@ -465,10 +543,10 @@ tr:
     country_based: "Ülke Tabanlı"
     country_name: Ad
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: Kupon
     coupon_code: Kupon kodu
     coupon_code_already_applied: Girdiğiniz kupon kodu bu siparişe önceden uygulandı
@@ -478,17 +556,17 @@ tr:
     coupon_code_max_usage: Kupon kodu kullanma limitine ulaşıldı
     coupon_code_not_eligible: Kupon kodu bu siparişe uygulanabilir değil
     coupon_code_not_found: Girdiğiniz kupon kodu bulunamadı. Lütfen tekrar deneyiniz.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Oluştur
     create_a_new_account: Yeni hesap oluştur
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Oluşturulma zamanı
     credit: Kredi
     credit_card: Kredi Kartı
     credit_cards: Kredi Kartları
     credit_owed: Kredi Borcu
-    credits:
+    credits: TODO_TRANSLATE
     currency: Kur
     currency_decimal_mark: Ondalık ayırıcı işareti
     currency_settings: Kur Ayarları
@@ -499,16 +577,16 @@ tr:
     customer: Müşteri
     customer_details: Müşteri Ayrıntıları
     customer_details_updated: Müşteri Ayrıntıları Güncellendi
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Müşteri Arama
     cut: Kes
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: Uygulama ID
         app_token: Uygulama Belirteci
-        currently_unavailable:
+        currently_unavailable: TODO_TRANSLATE
         explanation: Eğer yönetim panelinden Jirafe ile kayıt ol seçeneğini seçtiyseniz, aşağıdaki alanlar otomatik doldurulmuş olabilir.
         header: Jirafe Analizleri Ayarları
         site_id: Site ID
@@ -517,16 +595,20 @@ tr:
     date: Tarih
     date_completed: Tarih Tamamlandı
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%d.%m%Y"
       js_format: dd.mm.yyyy
     date_range: Tarih Aralığı
     default: Varsayılan
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: Varsayılan Vergi
     default_tax_zone: Varsayılan Vergi Bölgesi
     delete: Sil
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Ulaştırma
     depth: Derinlik
     description: Açıklama
@@ -537,26 +619,41 @@ tr:
     dismiss_banner: Hayır. Teşekkürler! İlgilenmiyorum, bu mesajı tekrar gösterme.
     display: Göster
     display_currency: Kurları göster
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Düzenle
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Kullanıcı Düzenleme
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: E-posta
     empty: Boş
     empty_cart: Sepeti Boşalt
@@ -587,28 +684,30 @@ tr:
           signup: Kullanıcı girişi
     exceptions:
       count_on_hand_setter: recalculate_count_on_hand geri çağrım işlevi tarafından otomatik olarak ayarlandığından, count_on_hand değeri elle değiştirilemez. Bunun yerine update_column(:count_on_hand, value) işlevini kullanın.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Geçerlilik
     extension: Eklenti
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Dosya adı
     fill_in_customer_info: Lütfen müşteri bilgilerini giriniz.
+    filter: TODO_TRANSLATE
     filter_results: Süzgeç Sonuçları
     finalize: Sonlandır
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: "İlk Parça Maliyeti"
     first_name: "İsim"
     first_name_begins_with: "İsmi Şununla Başlayan"
     flat_percent: Sabit Yüzde
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Sabit Oran (sipariş bazlı)
     flexible_rate: Esnek Oran
     forgot_password: "Şifrenizi mi Unuttunuz?"
     free_shipping: "Ücretsiz Kargo"
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: "Ön Yüz"
     gateway: Yöntem
     gateway_config_unavailable: Bu ortam için yöntem geçerli değil
@@ -632,37 +731,41 @@ tr:
       only_incomplete: Sadece tamamlanmayanlar
       select_locale: Dil Seç
       show_only: Sadece Şunları Göster
+      store_translations: TODO_TRANSLATE
       supported_locales: Desteklenen Diller
       this_file_language: Türkçe (TR)
       translations: "Çeviriler"
     icon: Simge
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Resim
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Resimler
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Fiyata eklenmiş
     included_price_validation: Varsayılan Vergi Bölgesi ayarlanmadan seçilemez
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: Lütfen aşağıdaki forma e-posta adresinizi giriniz.
     insufficient_stock: Bu üründen istenilen miktarda bulunmuyor, sadece %{on_hand} adet elde bulunmaktadır.
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: E-posta Adresini Engelle
     intercept_email_instructions: E-posta adresini yoksay ve bu adresle değiştir.
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Geçersiz ödeme sağlayıcı.
     invalid_promotion_action: Geçersiz promosyon hareketi.
     invalid_promotion_rule: Geçersiz promosyon kuralı.
     inventory: Stok
     inventory_adjustment: Stok Kredisi
     inventory_error_flash_for_insufficient_quantity: Sepetinizde bulunan bir ürün artık temin edilemiyor.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: belirtilen adrese gönderilememektedir
     iso_name: Iso Adı
     item: "Ürün"
@@ -672,26 +775,32 @@ tr:
       operators:
         gt: büyüktür
         gte: büyük ya da eşittir
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: Seçtiğiniz ülkeye gönderim yapılamamaktadır
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Yol
     last_name: Soyisim
     last_name_begins_with: Soyismi Şununla Başlayan
     learn_more: Daha Fazla
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Liste
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: Yükleniyor
     locale_changed: Dil Değiştirildi
     location: Konum
     lock: Kilitle
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: 'Açılan Oturum: '
     logged_in_succesfully: Giriş Başarılı
     logged_out: "Çıkış Yaptınız."
@@ -700,23 +809,26 @@ tr:
     login_failed: Giriş başarısız.
     login_name: Giriş
     logout: "Çıkış"
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Benzer ürünlere bak
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Geri ödeme Yap
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Ana Fiyat
     match_choices:
       all: Tümü
       none: Hiçbiri
     max_items: En fazla Ürün
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta Açıklaması
     meta_keywords: Meta Kelimeleri
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Meta verisi
     minimal_amount: En düşük Miktar
     month: Ay
@@ -725,13 +837,13 @@ tr:
     my_account: Hesabım
     my_orders: Siparişlerim
     name: "İsim"
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: "İsim ya da SKU (en az 4 karakter giriniz)"
     new: Yeni
     new_adjustment: Yeni Kredi
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Yeni Müşteri
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Yeni Resim
     new_option_type: Yeni Seçenek Tipi
     new_order: Yeni Sipariş
@@ -740,14 +852,15 @@ tr:
     new_payment_method: Yeni Ödeme Yöntemi
     new_product: Yeni Ürün
     new_promotion: Yeni Promosyon
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: Yeni Özellik
     new_prototype: Yeni Prototip
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: Yeni İade İzni
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Yeni Kargo Kategorisi
     new_shipping_method: Yeni Kargo Yöntemi
     new_state: Yeni Bölge
@@ -764,24 +877,30 @@ tr:
     new_zone: Yeni Bölge
     next: Sonraki
     no_actions_added: Hiçbir eylem eklenmemiş
-    no_payment_found:
-    no_pending_payments:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Hiçbir Ürün Bulunamadı
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: Sonuç yok
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: Hiçbir kural eklenmedi
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Hiçbir izleyici ayrıntısı belirtilmedi.
     none: Hiçbiri
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normal Miktar
     not: değil
     not_available: mevcut değil
     not_enough_stock: Belirtilen bölgede bu siparişi tamamlayabilecek kadar stok bulunmuyor.
     not_found: "%{resource} bulunamadı"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: "Ürün çoğaltıldı"
       product_deleted: "Ürün silindi"
@@ -789,7 +908,7 @@ tr:
       product_not_deleted: "Ürün silinemedi"
       variant_deleted: Değişken silindi
       variant_not_deleted: Değişken silinemedi
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Elde
     open: Açık
     open_all_adjustments: Tüm Kredileri Aç
@@ -804,12 +923,13 @@ tr:
     or_over_price: "%{price} veya daha fazlası"
     order: Sipariş
     order_adjustments: Sipariş kredileri
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Sipariş Ayrıntıları
     order_email_resent: Sipariş E-postasını Tekrar Gönder
     order_information: Sipariş Bilgisi
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: |
@@ -817,21 +937,25 @@ tr:
         instructions: Siparişiniz iptal edilmiştir. Kayıtlarınız için lütfen iptal etme işleminin bilgilerini saklayınız.
         order_summary_canceled: Sipariş Özeti[İPTAL]
         subject: Sipariş İptal Etme
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: |
           Değerli Müşterimiz,
         instructions: Lütfen aşağıdaki sipariş bilgilerini gözden geçiriniz ve kayıtlarınız için saklayınız.
         order_summary: Sipariş Özeti
         subject: Sipariş Onayı
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: Alışverişiniz için teşekkürler
-        total:
+        total: TODO_TRANSLATE
     order_not_found: Siparişinizi bulamadık. Lütfen tekrar deneyiniz.
-    order_number:
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: Siparişiniz başarıyla işlenmiştir.
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: adreste
       awaiting_return: dönüş bekleniyor
@@ -839,7 +963,7 @@ tr:
       cart: sepette
       complete: tamamlandı
       confirm: onay bekliyor
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: taşımada
       payment: "ödeme bekliyor"
       resumed: devam ediyor
@@ -849,12 +973,14 @@ tr:
     order_total: Sipariş Toplamı
     order_updated: Sipariş Güncellendi
     orders: Siparişler
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Stokta Yok
     overview: Gözden Geçirme
     package_from: kimden
     pagination:
+      first: TODO_TRANSLATE
       next_page: sonraki sayfa »
+      previous: TODO_TRANSLATE
       previous_page: "« önceki sayfa"
       truncate: "…"
     password: "Şifre"
@@ -862,11 +988,11 @@ tr:
     path: Yol
     pay: "öde"
     payment: "Ödeme"
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: "Ödeme Bilgisi"
     payment_method: "Ödeme Yöntemi"
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: "Ödeme Yöntemleri"
     payment_processing_failed: "Ödeme gerçekleştirilemedi, lütfen girmiş olduğunuz bilgileri kontrol ediniz"
     payment_processor_choose_banner_text: "Ödeme işlemi seçmekte zorlanıyorsanız, lütfen takip eden bağlantıya tıklayınız"
@@ -884,22 +1010,23 @@ tr:
       void: geçersiz
     payment_updated: "Ödeme Güncellendi"
     payments: "Ödemeler"
-    pending:
+    pending: TODO_TRANSLATE
     percent: Yüzde
     percent_per_item: "Ürün Başına Yüzde"
     permalink: Kalıcı Bağlantı
     phone: Telefon
     place_order: Sipariş Ver
     please_define_payment_methods: Lütfen önce bir ödeme yöntemi tanımlayın.
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: Bir hata oluştu. Lütfen ürün ekleme işlemini tekrar deneyin.
     powered_by: Geliştiren
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Tanıtım
     previous: "Önceki"
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Fiyat
     price_range: Fiyat Aralığı
     price_sack: Fiyat Torbası
@@ -911,10 +1038,10 @@ tr:
     product_properties: "Ürün Özellikleri"
     product_rule:
       choose_products: "Ürün seçin"
-      label:
+      label: TODO_TRANSLATE
       match_all: tümü
       match_any: en az bir
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: "Ürün grubundan"
         manual: Elle seçim
@@ -926,19 +1053,24 @@ tr:
         description: Sipariş için bir promosyon kredisi oluşturur
         name: Kredi oluştur
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
         description: Sepeti tanımlanmış değişkenlerle doldurur
         name: Sıralı ürünler oluştur
       free_shipping:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: Hareketler
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: Bu kuralların tümünü eşleştir
         any: Bu kuralların herhangi birini eşleştir
+    promotion_label: TODO_TRANSLATE
     promotion_rule: Promosyon Kuralı
     promotion_rule_types:
       first_order:
@@ -951,27 +1083,27 @@ tr:
         description: Müşteri tanımlanmış olan bir sayfayı ziyaret etmelidir
         name: Açılış Sayfası
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: Sipariş sadece tanımlanmış ürünleri içerir
         name: "Ürün(ler)"
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
         description: Sadece belirli kullanıcılar için kullanılabilir
         name: Kullanıcı
       user_logged_in:
         description: Sadece giriş yapmış kullanıcılar için kullanılabilir
         name: Kullanıcı Giriş yaptı
-    promotion_uses:
-    promotionable:
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
     promotions: Promosyonlar
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: "Özellikler"
     property: "Özellik"
     prototype: Prototip
@@ -988,41 +1120,43 @@ tr:
     receive: alınan
     receive_stock: Gelen Stok
     received: Gelen
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Referans
+    reference_contains: TODO_TRANSLATE
     refund: Geri Ödeme
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: Kayıt ol
     registration: Kayıt
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Beni hatırla
     remove: Kaldır
     rename: Yeniden adlandır
-    report:
+    report: TODO_TRANSLATE
     reports: Raporlar
+    resellable: TODO_TRANSLATE
     resend: Tekrar Gönder
     reset_password: "Şifremi Sıfırla"
     response_code: Yanıt Kodu
@@ -1030,34 +1164,41 @@ tr:
     resumed: Devam Eden
     return: iade
     return_authorization: "İade Yönetimi"
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: "İade yönetimi güncellendi"
     return_authorizations: "İade Yönetimleri"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: "İade Miktarı"
     returned: "İade Edilmiş"
-    returns:
+    returns: TODO_TRANSLATE
     review: Gözden Geçir
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: "İade(RMA) Kredisi"
     rma_number: "İade(RMA) Numarası"
     rma_value: "İade(RMA) Değeri"
+    role_id: TODO_TRANSLATE
     roles: Roller
     rules: Kurallar
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Satış Toplamı
     sales_total_description: Tüm Siparişlerin Satış Toplamı
     sales_totals: Satış Toplamı
     save_and_continue: Kaydet ve İlerle
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: Hayır
     say_yes: Evet
     scope: Kapsam
@@ -1067,10 +1208,11 @@ tr:
     secure_connection_type: Güvenli Bağlantı Tipi
     security_settings: Güvenlik Ayarları
     select: Seç
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Prototipten Seç
     select_stock: Stok Seç
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Tüm e-postaların bir kopyasını şuraya gönder
     send_mails_as: Postaları Gönderim Şekli
     server: Sunucu
@@ -1080,8 +1222,9 @@ tr:
     ship_address: Kargo Adresi
     ship_total: Kargo Toplamı
     shipment: Kargolama
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: |
@@ -1095,13 +1238,13 @@ tr:
     shipment_state: Kargo Durumu
     shipment_states:
       backorder: hazırlanıyor
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: kısmen
       pending: bekliyor
       ready: hazır
       shipped: kargoya verildi
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Kargolamalar
     shipped: Kargolanan
     shipping: Kargolama
@@ -1115,59 +1258,75 @@ tr:
     shipping_method: 'Kargo Yöntemi '
     shipping_methods: Kargo Yöntemleri
     shipping_price_sack: Fiyat pakedi
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "%{taxonomy} ile Alışveriş"
     shopping_cart: Alışveriş Sepeti
     show: Göster
     show_active: Aktifleri Göster
     show_deleted: Silinmişleri Göster
     show_only_complete_orders: Sadece tamamlanmış siparişleri göster
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Etikette oranı göster
     sku: SKU
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Kaynak
     special_instructions: "Özel Açıklamalar"
-    split:
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: "Ödeme bilgilerinizle alakalı bir sorun oluştu. Lütfen bilgilerinizi kontrol ederek tekrar deneyiniz."
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Başlangıç
+    start_date: TODO_TRANSLATE
     state: Bölge
     state_based: Bölge Tabanlı
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Bölgeler
     states_required: Zorunlu Bölgeler
     status: Durum
@@ -1175,9 +1334,9 @@ tr:
     stock_location: Stok Bölgesi
     stock_location_info: Stok bölge bilgisi
     stock_locations: Stok Bölgeleri
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Stok Yönetimi
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
     stock_movements: Stok Hareketleri
     stock_movements_for_stock_location: "%{stock_location_name} bölgesi için stok hareketleri"
     stock_successfully_transferred: Stok bölgeler arasında başarıyla aktarıldı.
@@ -1189,28 +1348,30 @@ tr:
     street_address_2: Sürekli Adres (Devamı)
     subtotal: Alt toplam
     subtract: "Çıkart"
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} başarıyla oluşturuldu!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} başarıyla kaldırıldı!"
     successfully_signed_up_for_analytics: Spree Analizleri için kayıt başarıyla tamamlandı
     successfully_updated: "%{resource} başarıyla güncellendi!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Vergi
     tax_categories: Vergi Sınıfları
     tax_category: Vergi Sınıfı
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Vergi oranları hesaplamalarda ondalık olarak kullanılır.(örneğin vergi oranı %18 ise 0.18 girin)
     tax_rates: Vergi Oranları
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: Grup
     taxon_edit: Grup Düzenle
     taxon_placeholder: Grup Ekle
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Gruplandırmalar
     taxonomy: Gruplandırma
     taxonomy_edit: Gruplandırma düzenle
@@ -1219,32 +1380,35 @@ tr:
     taxons: Gruplar
     test: Deneme
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Tebrikler!
         message: Eğer bu postayı okuyorsanız, e-posta ayarlarınız doğru yapılandırılmış demektir.
         subject: Deneme Postası
     test_mode: Deneme Modu
     thank_you_for_your_order: Alışverişiniz için teşekkürler. Lütfen kayıtlarınızda tutmak için bu bilgi sayfasının bir kopyasını saklayınız.
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: Aşağıdaki alanlarla ilgili sorunlar var
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: "Önizleme"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Zaman
     to_add_variants_you_must_first_define: Değişken eklemeden önce değişkeni tanımlamanız gerekmektedir
     total: Toplam
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Takip
     tracking_number: Takip Numarası
     tracking_url: Takip URL'si
     tracking_url_placeholder: "örnek: http://kargocum.com/paket_takip?takip_no=:takipno"
-    transaction_id:
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Buradan Aktar
     transfer_stock: Stok Aktar
     transfer_to_location: Buraya Aktar
@@ -1252,7 +1416,7 @@ tr:
     type: Tip
     type_to_search: Aranacak tip
     unable_to_connect_to_gateway: "Ödeme sağlayıcıya bağlanılamıyor."
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: "%{price} Altı"
     unlock: Kilit Çöz
     unrecognized_card_type: Tanımlanamayan kart tipi
@@ -1260,9 +1424,11 @@ tr:
     update: Güncelle
     updating: Güncelleme
     usage_limit: Kullanım Limiti
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Fatura Adresini Kullan
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Yeni bir kart kullan
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Resimler için Amazon S3 kullan
     user: Kullanıcı
     user_rule:
@@ -1270,12 +1436,13 @@ tr:
     users: Kullanıcılar
     validation:
       cannot_be_less_than_shipped_units: kargolanmış ürün sayısından daha az olamaz.
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: elde olan stok aşıldı. İstenilen ürün miktarının geçerli miktarda olduğundan emin olun.
       is_too_large: "çok fazla -- eldeki stok istenilen miktarı karşılayacak kadar yeterli değil!"
       must_be_int: bir sayı olmak zorundadır
       must_be_non_negative: negatif olmayan bir değer olmalıdır
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Değer
     variant: Değişken
     variant_placeholder: Bir varyant seçin
@@ -1294,3 +1461,10 @@ tr:
     zipcode: Posta Kodu
     zone: Bölge
     zones: Bölgeler
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,4 +1,6 @@
+---
 uk:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -24,7 +26,7 @@ uk:
         name: "Назва"
         numcode: "Код ISO"
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: "Тип"
         month: "Місяць"
         name: "Назва"
@@ -72,6 +74,7 @@ uk:
         zipcode: "Адреса доставки. Індекс"
       spree/payment:
         amount: "Сума"
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: "Назва"
       spree/product:
@@ -95,6 +98,7 @@ uk:
         starts_at: "Дата початку промо-акції"
         usage_limit: "Максимальна кількість використань"
       spree/promotion_category:
+        code: TODO_TRANSLATE
         name: "Назва"
       spree/property:
         name: "Назва"
@@ -105,17 +109,19 @@ uk:
         amount: "Сума"
       spree/role:
         name: "Назва"
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: "Абревіатура"
         name: "Назва"
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
         mail_from_address: e-mail в полі Від
         meta_description: Meta Description
@@ -197,8 +203,14 @@ uk:
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         few: "Адреси"
         many: "Адрес"
@@ -306,7 +318,7 @@ uk:
         other: "Підстав дозволу на повернення"
       spree/role:
         few: "Ролі"
-        many: "Ролей"
+        oher: TODO_TRANSLATE
         one: "Роль"
         other: "Ролей"
       spree/shipment:
@@ -329,7 +341,7 @@ uk:
         many: "Ре��іонів/Областей"
         one: "Регіон/Область"
         other: "Регіонів/Областей"
-      spree/state_change:
+      spree/state_change: TODO_TRANSLATE
       spree/stock_location:
         few: "Склади"
         many: "Складів"
@@ -385,6 +397,9 @@ uk:
         many: "Зон"
         one: "Зона"
         other: "Зон"
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: "Ваш обліковий запис був успішно підтверджений. Зараз ви в системі."
@@ -412,9 +427,9 @@ uk:
       unlocked: "Ваш акаунт розблоковано. Тепер ви успішно увійшли в систему."
     user_passwords:
       user:
-        cannot_be_blank:
-        send_instructions:
-        updated:
+        cannot_be_blank: TODO_TRANSLATE
+        send_instructions: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
     user_registrations:
       destroyed: "До побачення! Ваш акаунт знищено, але ми сподіваємося побачити вас знову найближчим часом."
       inactive_signed_up: "Ви успішно зареєструвались, проте ви не змогли увійти в систему тому що ваш обліковий запис %{reason}."
@@ -423,6 +438,7 @@ uk:
     user_sessions:
       signed_in: "Ви успішно увійшли до системи."
       signed_out: "Ви вийшли з системи."
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: "вже було підтверджено"
@@ -431,6 +447,24 @@ uk:
       not_saved:
         one: '1 помилка перешкоджає збереженню %{resource}:'
         other: "%{count} помилок перешкоджають збереженню %{resource}:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: "Абревіатура"
     accept: "Прийняти"
@@ -471,11 +505,16 @@ uk:
     add_to_cart: "Додати в кошик"
     add_variant: "Додати варіант"
     additional_item: "Ставка для додаткових найменувань"
+    address: TODO_TRANSLATE
     address1: "Адреса"
     address2: "Адреса (продовження)"
     adjustable: "Коригований елемент"
     adjustment: "Коригування"
     adjustment_amount: "Загалом"
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: "Коригування було успішно закрите!"
     adjustment_successfully_opened: "Коригування було успішно відкрите!"
     adjustment_total: "Разом (коригування)"
@@ -504,7 +543,7 @@ uk:
         orders: "Замовлення"
         user_information: "Інформація користувача"
     administration: "Адміністрування"
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: "Погоджуюсь з політикою конфіденційності"
     agree_to_terms_of_service: "Погоджуюсь з умовами обслуговування"
     all: "всі"
@@ -527,12 +566,24 @@ uk:
     analytics_desc_list_4: "Повністю безкоштовний!"
     analytics_trackers: "Трекери веб-аналітики"
     and: "і"
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: "підтвердити"
     approved_at: "Дата підтвердження"
     approver: "Підтверджено"
     are_you_sure: "Ви впевнені"
     are_you_sure_delete: "Ви впевнені, що хочете видалити цей запис?"
     associated_adjustment_closed: "Пов’язане коригування закрито, і не буде перераховано. Чи бажаєте відкрити її?"
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: "Помилка авторизації"
     authorized: "Авторизовано"
     auto_capture: "Автозахоплення"
@@ -541,13 +592,35 @@ uk:
     avs_response: "Відповідь AVS"
     back: "Назад"
     back_end: "в адміністративному інтерфейсі"
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
     back_to_payment: "Назад до оплати"
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: "Повернутися до магазину"
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: "Назад до списку користувачів"
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: "Можливий продаж під замовлення"
-    backorderable_default:
+    backorderable_default: TODO_TRANSLATE
     backordered: "Під замовлення"
     backorders_allowed: "Продаж під замовлення дозволено"
     balance_due: "Дебетове сальдо"
@@ -561,8 +634,8 @@ uk:
     calculator: "Калькулятор"
     calculator_settings_warning: "При зміні типу калькулятора, ви повинні зберегти зміни, перш ніж ви зможете змінювати його налаштування."
     cancel: "Скасувати"
-    canceled_at:
-    canceler:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
     cannot_create_customer_returns: "Неможливо створити повернення покупця, оскільки це замовлення не має відправлених одиниць."
     cannot_create_payment_without_payment_methods: "Неможливо створити оплату без визначення методів оплати."
     cannot_create_returns: "Неможливо оформити повернення, тому що це замовлення ще не відправлено."
@@ -587,11 +660,11 @@ uk:
     choose_a_taxon_to_sort_products_for: "Виберіть таксон для сортування товарів"
     choose_currency: "Виберіть валюту"
     choose_dashboard_locale: "Вибрати мову панелі управління"
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: "Місто"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
     click_and_drag_on_the_products_to_sort_them: "Перетягуйте товари, щоб відсортувати."
     clone: "Клонувати"
     close: "Закрити"
@@ -601,6 +674,7 @@ uk:
     complete: "Завершено"
     configuration: "Конфігурація"
     configurations: "Конфігурація"
+    configure_s3: TODO_TRANSLATE
     confirm: "Підтвердити"
     confirm_delete: "Підтвердження видалення"
     confirm_password: "Підтвердження пароля"
@@ -674,26 +748,45 @@ uk:
       js_format: dd/mm/yy
     date_range: "Період часу"
     default: "За замовчуванням"
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
     default_refund_amount: "Сума повернення за замовчуванням"
+    default_seo_title: TODO_TRANSLATE
     default_tax: "Податок за замовчуванням"
     default_tax_zone: "Податковий регіон за замовчуванням"
     delete: "Видалити"
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: "Доставка"
     depth: "Глибина"
     description: "Опис"
     destination: "Призначення"
     destroy: "Видалити"
-    details:
+    details: TODO_TRANSLATE
     discount_amount: "Сума знижки"
     dismiss_banner: "Ні, дякую! Більше не показувати це повідомлення"
     display: "Показати"
     display_currency: "Показувати валюту"
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: "Редагувати"
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: "Редагування користувача"
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
         has_excluded_product: "В кошику є товар, який не дозволяє застосувати код купону."
@@ -752,6 +845,7 @@ uk:
     failed_payment_attempts: "Невдалих спроб проведення платежу"
     filename: "Ім’я файлу"
     fill_in_customer_info: "Заповніть інформацію про клієнта"
+    filter: TODO_TRANSLATE
     filter_results: "Фільтрувати"
     finalize: "Завершити"
     finalized: "Завершено"
@@ -760,12 +854,13 @@ uk:
     first_name: "Ім’я"
     first_name_begins_with: "Ім’я починається з"
     flat_percent: "Фіксований відсоток"
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: "Фіксована ставка (за замовлення)"
     flexible_rate: "Гнучка ставка"
     forgot_password: "Забули пароль?"
     free_shipping: "Безкоштовна доставка"
     free_shipping_amount:
-    -
+    - 
     front_end: "в публічному інтерфейсі"
     gateway: "Платіжний шлюз"
     gateway_config_unavailable: "Шлюз не доступний для даного оточення"
@@ -789,15 +884,19 @@ uk:
       only_incomplete: "Тільки не завершені"
       select_locale: "Виберіть мову"
       show_only: "Відображати тільки"
+      store_translations: TODO_TRANSLATE
       supported_locales: "Мови, що підтримуються"
       this_file_language: Ukrainian
       translations: "Переклади"
     icon: "Іконка"
     identifier: "Ідентифікатор"
     image: "Зображення"
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: "Зображення"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
     inactive: "Неактивний"
     incl: "вкл."
     included_in_price: "Включено в ціну"
@@ -814,7 +913,7 @@ uk:
     intercept_email_instructions: "Замінити email одержувача на цю адресу."
     internal_name: "Внутрішнє ім’я"
     invalid_credit_card: "Невірна кредитна карта."
-    invalid_exchange_variant:
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: "Невірно вказано спосіб оплати"
     invalid_promotion_action: "Невірна промо-акція"
     invalid_promotion_rule: "Невірно вказано принцип рекламної кампанії"
@@ -846,6 +945,12 @@ uk:
     lifetime_stats: "Статистика"
     line_item_adjustments: "Коригування позиції"
     list: "Список"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "Завантажується"
     locale_changed: "Мова змінена"
     location: "Локація"
@@ -861,6 +966,9 @@ uk:
     logout: "Вийти"
     logs: "Журнали"
     look_for_similar_items: "Подивіться схожі товари"
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: "Зробити повернення"
     make_sure_the_above_reimbursement_amount_is_correct: "Переконайтесь, що сума відшкодування правильна"
     manage_promotion_categories: "Керувати категоріями промо-акцій"
@@ -906,6 +1014,7 @@ uk:
     new_refund_reason: "Нова причина повернення"
     new_return_authorization: "Новий дозвіл на повернення"
     new_rma_reason: "Нова підстава дозволу на повернення"
+    new_role: TODO_TRANSLATE
     new_shipment_at_location: "Нове відправлення на склад"
     new_shipping_category: "Нова категорія доставки"
     new_shipping_method: "Новий спосіб доставки"
@@ -923,15 +1032,21 @@ uk:
     new_zone: "Нова зона"
     next: "наст."
     no_actions_added: "Немає дій"
+    no_orders_found: TODO_TRANSLATE
     no_payment_found: "Не знайдено платежів"
+    no_payment_methods_found: TODO_TRANSLATE
     no_pending_payments: "Немає незавершених платежів"
     no_products_found: "Не знайдено жодного товару"
+    no_promotions_found: TODO_TRANSLATE
     no_resource_found: "%{resource} не знайдено"
     no_results: "Нічого не знайдено"
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: "Жодного правила не задано"
     no_shipping_method_selected: "Не вибраний спосіб доставки."
-    no_state_changes:
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: "Відсутні деталі відслідковування"
     none: "Жодного"
     none_selected: "Не вибрано"
@@ -963,30 +1078,35 @@ uk:
     or_over_price: "дорожче %{price}"
     order: "Замовлення"
     order_adjustments: "Коригування замовлення"
-    order_already_updated:
+    order_already_updated: TODO_TRANSLATE
     order_approved: "Замовлення прийняте"
     order_canceled: "Замовлення скасоване"
     order_details: "Деталі замовлення"
     order_email_resent: "Лист з описом замовлення надіслано повторно"
     order_information: "Інформація стосовно замовлення"
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: "Шановний покупцю,\\n"
         instructions: "Ваше замовлення СКАСОВАНО. Збережіть цю інформацію в історії."
         order_summary_canceled: "Стан замовленн [СКАСОВАНО]"
         subject: "Скасування замовлення"
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: "Шановний покупцю,\\n"
         instructions: "Перегляньте інформацію про ваше замовлення."
         order_summary: "Всього"
         subject: "Підтвердження замовлення"
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: "Дякуємо за замовлення."
-        total:
+        total: TODO_TRANSLATE
     order_not_found: "Ми не змогли знайти Ваше замовлення. Спробуйте ще раз."
     order_number: "Замовлення %{number}"
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: "Ваше замовлення було успішно опрацьоване"
     order_resumed: "Замовлення продовжене"
     order_state:
@@ -1011,7 +1131,9 @@ uk:
     overview: "Огляд"
     package_from: "Пакунок з"
     pagination:
+      first: TODO_TRANSLATE
       next_page: "наступна сторінка »"
+      previous: TODO_TRANSLATE
       previous_page: "« попередня сторінка"
       truncate: "…"
     password: "Пароль"
@@ -1048,6 +1170,7 @@ uk:
     phone: "Телефон"
     place_order: "Розмістити замовлення"
     please_define_payment_methods: "Визначіть спочатку метод оплати."
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: "Щось трапилось. Спробуйте додати товар пізніше."
     powered_by: "Працює на"
     pre_tax_amount: "Сума без податків"
@@ -1056,7 +1179,7 @@ uk:
     preferred_reimbursement_type: "Зручніший тип відшкодування"
     presentation: "Відображати як"
     previous: "поперед."
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: "Ціна"
     price_range: "Ціновий діапазон"
     price_sack: "Ціновий мішок"
@@ -1068,7 +1191,7 @@ uk:
     product_properties: "Властивості товару"
     product_rule:
       choose_products: "Вибрані товари"
-      label:
+      label: TODO_TRANSLATE
       match_all: "все"
       match_any: "хоча б один"
       match_none: "жодного"
@@ -1091,11 +1214,16 @@ uk:
       free_shipping:
         description: "Робить доставку замовлення безкоштовною"
         name: "Безкоштовна доставка"
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: "Дії"
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: "Відповідає всім цим правилам"
         any: "Відповідає хоча б одному правилу"
+    promotion_label: TODO_TRANSLATE
     promotion_rule: "Правило"
     promotion_rule_types:
       first_order:
@@ -1111,8 +1239,8 @@ uk:
         description: "Тільки одна на користувача"
         name: "Одна на користувача"
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: "Замовлення включає зазначені товари"
         name: "Товари"
@@ -1128,7 +1256,7 @@ uk:
     promotion_uses: "Застосування промо-акцій"
     promotionable: "Акційний товар"
     promotions: "Промо-акції"
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: "Властивості"
     property: "Властивість"
     prototype: "Прототип"
@@ -1139,7 +1267,7 @@ uk:
     quantity: "Кількість"
     quantity_returned: "Кількість повернення"
     quantity_shipped: "Кількість доставлених"
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: "Ставка"
     reason: "Причина"
     receive: "Отримати"
@@ -1147,6 +1275,7 @@ uk:
     received: "Отримано"
     reception_status: "Стан одержання"
     reference: "Посилання"
+    reference_contains: TODO_TRANSLATE
     refund: "Повернення"
     refund_amount_must_be_greater_than_zero: "Сума повернення має бути більшою нуля"
     refund_reasons: "Причини повернення"
@@ -1178,8 +1307,9 @@ uk:
     remember_me: "Запам’ятати мене"
     remove: "Видалити"
     rename: "Переіменувати"
-    report:
+    report: TODO_TRANSLATE
     reports: "��віти"
+    resellable: TODO_TRANSLATE
     resend: "Відправити повторно"
     reset_password: "Скинути мій пароль"
     response_code: "Код відповіді"
@@ -1190,8 +1320,9 @@ uk:
     return_authorization_reasons: "Підстава для дозволу на повернення"
     return_authorization_updated: "Дозвіл на повернення оновлено"
     return_authorizations: "Дозволи на повернення"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
     return_item_rma_ineligible: "Повернення вимагає дозволу продавця"
     return_item_time_period_ineligible: "Термін повернення товару збіг"
     return_items: "Повернені товари"
@@ -1199,7 +1330,7 @@ uk:
     return_number: "Номер повернення"
     return_quantity: "повернена кількість"
     returned: "Повернуті"
-    returns:
+    returns: TODO_TRANSLATE
     review: "Огляд"
     risk: "Ризик"
     risk_analysis: "Аналіз ризиків"
@@ -1207,9 +1338,15 @@ uk:
     rma_credit: RMA Кредит
     rma_number: "Номер RMA"
     rma_value: "Сума RMA"
+    role_id: TODO_TRANSLATE
     roles: "Ролі"
     rules: "Правила"
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: "Разом (продаж)"
     sales_total_description: "Загальний обсяг продажів за всіма замовленнями"
     sales_totals: "Продажі загалом"
@@ -1228,6 +1365,7 @@ uk:
     select_a_stock_location: "Вибрати розташування складу"
     select_from_prototype: "Вибрати з прототипів"
     select_stock: "Вибрати склад"
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: "Надсилати копії всіх листів на"
     send_mails_as: "Надсилати пошту як"
     server: "Сервер"
@@ -1239,6 +1377,7 @@ uk:
     shipment: "Відправки"
     shipment_adjustments: "Коригування доставки"
     shipment_details: "Від %{stock_location} через %{shipping_method}"
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: "Шановний покупцю,\\n"
@@ -1271,6 +1410,10 @@ uk:
     shipping_method: "Спосіб"
     shipping_methods: "Способи доставки"
     shipping_price_sack: "Підрахунок вартості доставки"
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     shipping_total: "Усього за доставку"
     shop_by_taxonomy: "%{taxonomy}"
     shopping_cart: "Кошик"
@@ -1283,51 +1426,63 @@ uk:
     sku: "Артикул"
     skus: "Артикули"
     slug: "Заголовок в URL"
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: "Джерело"
     special_instructions: "Додаткові інструкції"
     split: "Розділити"
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: "Виникли проблеми з Вашими реквізитами. Будь ласка, перевірте їх та спробуйте ще раз."
     ssl:
       change_protocol: "Змініть протокол на HTTP (замість HTTPS) та повторіть запит."
     start: "Початок"
+    start_date: TODO_TRANSLATE
     state: "Регіон/Область"
     state_based: "Є області"
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: "Регіони/Області"
     states_required: "Регіони/Області обов’язкові"
     status: "Статус"
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: "Розташування складу"
     stock_location_info: "Подробиці про розташування складу"
     stock_locations: "Склади"
@@ -1351,20 +1506,22 @@ uk:
     successfully_removed: "%{resource} був успішно знищений!"
     successfully_signed_up_for_analytics: "Авторизація в Spree Analytics пройшла успішно"
     successfully_updated: "%{resource} було успішно оновлено!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: "Податок"
     tax_categories: "Категорії податків"
     tax_category: "Категорія податків"
-    tax_code:
+    tax_code: TODO_TRANSLATE
     tax_included: "Податок (вкл.)"
     tax_rate_amount_explanation: "Податкові ставки вводяться як десяткові значення (наприклад якщо податок 5%, то вводьте 0.05)"
     tax_rates: "Податкові ставки"
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: "Таксон"
     taxon_edit: "Редагувати таксон"
     taxon_placeholder: "Додати таксон"
     taxon_rule:
       choose_taxons: "Виберіть таксони"
-      label:
+      label: TODO_TRANSLATE
       match_all: "всі"
       match_any: "щонайменше один"
     taxonomies: "Таксономії"
@@ -1375,6 +1532,9 @@ uk:
     taxons: "Таксони"
     test: Test
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: "Наші вітання!"
         message: "Якщо ви отримали це повідомлення тоді ваші поштові налаштування коректні."
@@ -1418,7 +1578,9 @@ uk:
     usage_limit: "Максимальна кількість використань"
     use_app_default: "Взяти значення за замовчуванням"
     use_billing_address: "Використовувати платіжну адресу"
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: "Використовувати нову карту"
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: "Використоувати S3 для зображень"
     user: "Користувач"
     user_rule:
@@ -1426,7 +1588,8 @@ uk:
     users: "Користувачі"
     validation:
       cannot_be_less_than_shipped_units: "не може бути менше, ніж кількість відвантажених одиниць"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: "перевищує кількість на складі. Будь ласка перевірте кількість товару."
       is_too_large: "занадто багато - кількість на складі менше запитаної кількості!"
       must_be_int: "має бути цілим числом"
@@ -1450,3 +1613,10 @@ uk:
     zipcode: "Поштовий індекс"
     zone: "Торгова зона"
     zones: "Торгові зони"
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,4 +1,6 @@
+---
 vi:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ vi:
         state: Bang
         zipcode: Mã Zip
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ vi:
         name: Tên
         numcode: Mã ISO
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: Kiểu
         month: Tháng
-        name:
+        name: TODO_TRANSLATE
         number: Số
         verification_value: Thông số kiểm tra
         year: Năm
@@ -42,8 +44,8 @@ vi:
       spree/order:
         checkout_complete: Thanh toán hoàn tất
         completed_at: Hoàn tất lúc
-        considered_risky:
-        coupon_code:
+        considered_risky: TODO_TRANSLATE
+        coupon_code: TODO_TRANSLATE
         created_at: Ngày đặt hàng
         email: Email của khách hàng
         ip_address: "Địa chỉ IP"
@@ -72,17 +74,18 @@ vi:
         zipcode: "Đỉa chị giao hàng - mã zip"
       spree/payment:
         amount: Giá trị
+        number: TODO_TRANSLATE
       spree/payment_method:
-        name:
+        name: TODO_TRANSLATE
       spree/product:
         available_on: Available On
         cost_currency: Tiền giá
-        cost_price:
-        description:
-        master_price:
-        name:
-        on_hand:
-        shipping_category:
+        cost_price: TODO_TRANSLATE
+        description: TODO_TRANSLATE
+        master_price: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        on_hand: TODO_TRANSLATE
+        shipping_category: TODO_TRANSLATE
         tax_category: Mục thuế
       spree/promotion:
         advertise: Quảng cáo
@@ -95,7 +98,8 @@ vi:
         starts_at: Bắt đầu lúc
         usage_limit: Giới hạn sử dụng
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: Tên
         presentation: Thể hiện
@@ -105,138 +109,177 @@ vi:
         amount: Giá trị
       spree/role:
         name: Tên
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: Viết tắt
         name: Tên
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: Chú thích
         name: Tên
       spree/tax_rate:
         amount: Mức giá
-        included_in_price:
-        show_rate_in_label:
+        included_in_price: TODO_TRANSLATE
+        show_rate_in_label: TODO_TRANSLATE
       spree/taxon:
-        name:
-        permalink:
-        position:
+        name: TODO_TRANSLATE
+        permalink: TODO_TRANSLATE
+        position: TODO_TRANSLATE
       spree/taxonomy:
-        name:
+        name: TODO_TRANSLATE
       spree/user:
-        email:
+        email: TODO_TRANSLATE
         password: Mật khẩu
         password_confirmation: Xác nhận mật khẩu
       spree/variant:
         cost_currency: Tiền giá
-        cost_price:
-        depth:
-        height:
-        price:
-        sku:
-        weight:
-        width:
+        cost_price: TODO_TRANSLATE
+        depth: TODO_TRANSLATE
+        height: TODO_TRANSLATE
+        price: TODO_TRANSLATE
+        sku: TODO_TRANSLATE
+        weight: TODO_TRANSLATE
+        width: TODO_TRANSLATE
       spree/zone:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     errors:
       models:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address: "Địa chỉ"
       spree/country: Quốc gia
       spree/credit_card: Thẻ tín dụng
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit: "Đơn vị hàng"
       spree/line_item:
-      spree/option_type:
-      spree/option_value:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order: "Đơn đặt hàng"
       spree/payment: Thanh toán
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product: Sản phẩm
-      spree/promotion:
-      spree/promotion_category:
+      spree/promotion: TODO_TRANSLATE
+      spree/promotion_category: TODO_TRANSLATE
       spree/property: Thuộc tính
       spree/prototype: Mẫu hàng
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
-      spree/return_authorization_reason:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipment:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipping_category:
-      spree/shipping_method:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/tax_rate:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxon:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/taxonomy:
-      spree/tracker:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+      spree/tracker: TODO_TRANSLATE
       spree/user:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/variant:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/zone:
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: Tài khoản của bạn đã được xác nhận thành công. Bạn đang đăng nhập vào.
@@ -275,18 +318,37 @@ vi:
     user_sessions:
       signed_in: "Đăng nhập thành công."
       signed_out: "Đăng xuất thành công."
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: "đã được chứng nhận"
       not_found: không tìm thấy
       not_locked: không bị khoá
       not_saved: "%{count} lỗi cấm %{resource} này lưu:"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: Từ khóa tắt
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: Tài khoản
     account_updated: Tải khoản được cập nhật!
     action: Lệnh
@@ -299,7 +361,7 @@ vi:
       list: Liệt kê
       listing: Lên danh sách
       new: Mới
-      refund:
+      refund: TODO_TRANSLATE
       save: Lưu
       update: Cập nhật
     activate: Kích hoạt
@@ -307,7 +369,7 @@ vi:
     add: Thêm
     add_action_of_type: Thêm hành động loại
     add_country: Thêm quốc gia
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: Tạo Header mới
     add_new_style: Tạo style mới
     add_one: Tạo một
@@ -321,47 +383,52 @@ vi:
     add_to_cart: Cho vào sọt
     add_variant: Tạo biến thể
     additional_item: Giá phải trả thêm
+    address: TODO_TRANSLATE
     address1: "Địa chỉ"
     address2: "Địa chỉ (tiếp)"
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: "Điều chỉnh"
     adjustment_amount: Giá trị
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: "Điều chỉnh đã được đóng!"
     adjustment_successfully_opened: "Điều chỉnh đã được mở!"
     adjustment_total: Tổng Điều chỉnh
     adjustments: "Điều chỉnh"
     admin:
       tab:
-        configuration:
-        option_types:
-        orders:
-        overview:
-        products:
-        promotions:
-        properties:
-        prototypes:
-        reports:
-        taxonomies:
-        taxons:
-        users:
+        configuration: TODO_TRANSLATE
+        option_types: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        overview: TODO_TRANSLATE
+        products: TODO_TRANSLATE
+        promotions: TODO_TRANSLATE
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
+        reports: TODO_TRANSLATE
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
+        users: TODO_TRANSLATE
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: Quản trị
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: "Đồng ý với Điều khoản riêng tư"
     agree_to_terms_of_service: "Đồng ý với Điều khoản dịch vụ"
     all: Tất cả
     all_adjustments_closed: Tất cả điều chỉnh đã được đóng!
     all_adjustments_opened: Tất cả điều chỉnh đã được mở!
     all_departments: Tất cả các mục
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: Cho phép dùng SSL trong môi trường development và test
     allow_ssl_in_production: Cho phép dùng SSL trong môi trường production
     allow_ssl_in_staging: Cho phép dùng SSL trong môi trường staging
@@ -377,70 +444,104 @@ vi:
     analytics_desc_list_4: Hoàn toàn miễn phí!
     analytics_trackers: Theo dõi thông số thống kê
     and: và
-    approve:
-    approved_at:
-    approver:
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
+    approve: TODO_TRANSLATE
+    approved_at: TODO_TRANSLATE
+    approver: TODO_TRANSLATE
     are_you_sure: Bạn có chắn chắn không?
     are_you_sure_delete: Bạn có chắc bạn muốn xóa hồ sơ này không?
     associated_adjustment_closed: "Điều chỉnh liên đới đã bị đóng và không thể tính lại. Bạn có muốn mở nó không?"
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: Không được ủy quyền truy cập
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: Có hàng vào ngày
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: Quay lại
-    back_end:
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_end: TODO_TRANSLATE
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: Quay lại cửa hàng
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: Quay lại Liệt kê người dùng
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: Có thể đặt chỗ
-    backorderable_default:
-    backordered:
-    backorders_allowed:
+    backorderable_default: TODO_TRANSLATE
+    backordered: TODO_TRANSLATE
+    backorders_allowed: TODO_TRANSLATE
     balance_due: Tiền cần thanh toán
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: "Địa chỉ thanh toán"
     billing: Thanh Toán
     billing_address: "Địa chỉ thanh toán"
     both: Both
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: Máy tính
     calculator_settings_warning: Nếu bạn đang thay đổi loại máy tính, bạn phải lưu trước khi thay đổi cấu hình máy tính
     cancel: Hủy
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
+    cannot_create_payment_without_payment_methods: TODO_TRANSLATE
     cannot_create_returns: Không thể trả hàng vì đơn hàng chưa được gửi.
-    cannot_perform_operation:
+    cannot_perform_operation: TODO_TRANSLATE
     cannot_set_shipping_method_without_address: Không thể cài cách thức vận chuyển đến khi thông tin cách hàng được cung cấp.
     capture: Lấy tiền
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: Mã thẻ
     card_number: Số thẻ
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: Loại thẻ là
     cart: Sọt hàng
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: Loại mặt hàng
     category: Loại mặt hàng
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: Kiểm tra thông báo
     checkout: Thủ tục mua hàng
     choose_a_customer: Chọn một khách hàng
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: Chọn đơn vi tiền tệ
     choose_dashboard_locale: Chọn địa hoá cho Dashboard
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: Thành phố
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: Nhân bản
     close: "Đóng"
     close_all_adjustments: "Đóng tất cả chỉnh sửa"
@@ -449,6 +550,7 @@ vi:
     complete: hoàn tất
     configuration: Cấu hình
     configurations: Cấu hình
+    configure_s3: TODO_TRANSLATE
     confirm: Xác nhận
     confirm_delete: Xác nhận xóa
     confirm_password: Xác nhận mật khẩu
@@ -457,7 +559,7 @@ vi:
     cost_currency: Tiền giá
     cost_price: Giá
     could_not_connect_to_jirafe: Không thể kết nối với Jirafe để đồnng bộ hoá dữ liệu. Sẽ tự động thử lại sau.
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: Có một vấn đề lưu cái di chuyển hàng này. Xin vui lòng thử lại.
     count_on_hand: Số hàng có trong tay
     countries: Quốc gia
@@ -465,12 +567,12 @@ vi:
     country_based: Dựa trên quốc gia
     country_name: Tên
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
-    coupon:
-    coupon_code:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
+    coupon: TODO_TRANSLATE
+    coupon_code: TODO_TRANSLATE
     coupon_code_already_applied: Mã khuyến mại đã được dùng cho đơn hàng khác
     coupon_code_applied: The coupon code was successfully applied to your order.
     coupon_code_better_exists: Mã khuyến mại trước đó có nhiều khuyến mại hơn
@@ -478,87 +580,106 @@ vi:
     coupon_code_max_usage: Mã khuyến mại bị vượt qua số lần cho phép sử dụng
     coupon_code_not_eligible: Mã khuyến mại không cho đơn hàng này được
     coupon_code_not_found: Mã khuyến mại bạn nhập vào không tồn tại. Vui lòng thử lại.
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: Tạo
     create_a_new_account: Tạo một tài khoản mới
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: Tạo lúc
     credit: Tín dụng
     credit_card: Thẻ tín dụng
-    credit_cards:
+    credit_cards: TODO_TRANSLATE
     credit_owed: Nợ tín dụng
-    credits:
-    currency:
+    credits: TODO_TRANSLATE
+    currency: TODO_TRANSLATE
     currency_decimal_mark: "Điểm phân cách tiền hàng số lẻ"
-    currency_settings:
-    currency_symbol_position:
+    currency_settings: TODO_TRANSLATE
+    currency_symbol_position: TODO_TRANSLATE
     currency_thousands_separator: Phân cách số hàng nghìn
     current: Hiện thời
     current_promotion_usage: "Đang dùng: %{count}"
     customer: Khách hàng
     customer_details: Thông tin khách hàng
     customer_details_updated: The customer's details have been updated.
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: Tìm kiếm khách hàng
-    cut:
-    cvv_response:
+    cut: TODO_TRANSLATE
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
-        app_token:
-        currently_unavailable:
+        app_id: TODO_TRANSLATE
+        app_token: TODO_TRANSLATE
+        currently_unavailable: TODO_TRANSLATE
         explanation: Các mục dưới đây có thể đã được điền nếu bạn chọn đăng kí với Jirafe từ admin dashboard.
-        header:
-        site_id:
-        token:
+        header: TODO_TRANSLATE
+        site_id: TODO_TRANSLATE
+        token: TODO_TRANSLATE
       jirafe_settings_updated: Cấu hình Jirafe đã được cập nhật.
     date: Ngày
-    date_completed:
+    date_completed: TODO_TRANSLATE
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%d/%m/%Y"
       js_format: dd/mm/yy
     date_range: Giới hạn ngày
-    default:
-    default_refund_amount:
-    default_tax:
-    default_tax_zone:
+    default: TODO_TRANSLATE
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
+    default_tax: TODO_TRANSLATE
+    default_tax_zone: TODO_TRANSLATE
     delete: Xóa
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: Delivery
     depth: Sâu
     description: Miêu tả
     destination: "Đích đến"
     destroy: Hủy diệt
-    details:
-    discount_amount:
-    dismiss_banner:
-    display:
-    display_currency:
-    doesnt_track_inventory:
+    details: TODO_TRANSLATE
+    discount_amount: TODO_TRANSLATE
+    dismiss_banner: TODO_TRANSLATE
+    display: TODO_TRANSLATE
+    display_currency: TODO_TRANSLATE
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: Sửa đổi
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: Sửa đổi người dùng
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
-    email:
-    empty:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
+    email: TODO_TRANSLATE
+    empty: TODO_TRANSLATE
     empty_cart: Làm rỗng sọt
     enable_mail_delivery: Cho phép vận chuyển thư
     end: Kết thúc
@@ -589,28 +710,30 @@ vi:
           signup: Người dùng đăng kí
     exceptions:
       count_on_hand_setter: Không thể thay count_on_hand vì giá trị này được tự động thay bởi recalculate_count_on_hand callback. Xin dùng `update_column(:count_on_hand, value)`.
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: Mãn hạn
     extension: Gói mở rộng
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: Tên tệp tin
     fill_in_customer_info: Xin điền vào thông tin khách hàng
+    filter: TODO_TRANSLATE
     filter_results: Kết quả lọc
     finalize: Hoành thành
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: Món hàng đầu tiên giá
     first_name: Tên
     first_name_begins_with: Tên bắt đầu với
     flat_percent: "Định mức phần trăm"
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: Lãi suất sàn (cho từng đơn hàng)
     flexible_rate: Lãi suất dao động
     forgot_password: Quên mật khẩu
     free_shipping: Giao hàng miễn phí
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: Front End
     gateway: Gateway
     gateway_config_unavailable: Không có Gateway cho môi trường này
@@ -626,45 +749,49 @@ vi:
     hide_cents: Dẫu đơn vị cent
     home: Trang chủ
     i18n:
-      available_locales:
-      fields:
-      language:
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      available_locales: TODO_TRANSLATE
+      fields: TODO_TRANSLATE
+      language: TODO_TRANSLATE
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: tiếng Việt (VN)
-      translations:
+      translations: TODO_TRANSLATE
     icon: Biểu tượng
-    identifier:
+    identifier: TODO_TRANSLATE
     image: Hình ảnh
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: Hình ảnh
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: Kèm trong giá
     included_price_validation: không thể chọn trừ khi bạn đã cài Mã vùng thuế mặc định
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: "Điền vào mẫu phía dưới và hướng dẫn cách thay đổi mật khẩu sẽ được gửi qua email đến bạn:"
     insufficient_stock: Không đủ hàng, chỉ còn lại %{on_hand}
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: Can thiệp địa chỉ email
     intercept_email_instructions: Ghi đè người nhận email với địa chỉ này
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: Nhà cung cấp thanh toán không đúng.
     invalid_promotion_action: Hành động khuyến mại không đúng.
     invalid_promotion_rule: Luật khuyến mại không đúng.
     inventory: Hàng
     inventory_adjustment: "Điều chỉnh hàng tồn"
     inventory_error_flash_for_insufficient_quantity: Một sản phẩm trong sọt của bạn đã cháy hàng.
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: không thể chuyển đến địa chỉ chỉ định
     iso_name: Tên ISO
     item: Món
@@ -674,26 +801,32 @@ vi:
       operators:
         gt: lớn hơn
         gte: lớn hơn hoặc bằng
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: "Đường dẫn"
     last_name: Họ
     last_name_begins_with: Tên họ bắt đầu với
     learn_more: "Đọc thêm"
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: Liệt kê
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "Đang tải"
     locale_changed: Thay đổi địa hóa
     location: "Địa điểm"
     lock: Khoá
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: "Đã đăng nhập với"
     logged_in_succesfully: "Đăng nhập thành công"
     logged_out: Bạn đã đăng xuất
@@ -702,23 +835,26 @@ vi:
     login_failed: "Đăng nhập không uy quyền."
     login_name: "Đăng nhập"
     logout: "Đăng xuất"
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: Tìm sản phẩm tương tự
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: Thối tiền
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: Giá chủ
     match_choices:
       all: Tất cả
       none: Không có
     max_items: Số hàng tối đa
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta miểu tả
     meta_keywords: Meta danh sách từ khóa
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: Giá trị tối thiểu
     month: Tháng
@@ -727,13 +863,13 @@ vi:
     my_account: Tài khoản của tôi
     my_orders: "Đơn đặt hàng của tôi"
     name: Tên
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: Tên hoặc SKU
     new: Mới
     new_adjustment: Thông số điều chỉnh mới
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: Khách hàng mới
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: Hình mới
     new_option_type: Kiểu tùy chọn mới
     new_order: "Đơn đặt hàng mới"
@@ -742,14 +878,15 @@ vi:
     new_payment_method: Phương thức thanh toán mới
     new_product: Sản phẩm mới
     new_promotion: Khuyến mại mới
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: "Đặc tính mới"
     new_prototype: Nguyên mẫu mới
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: "Ủy quyền trả về mới"
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: Loại hình vận chuyển mới
     new_shipping_method: Phương pháp vận chuyển mới
     new_state: Bang mới
@@ -766,24 +903,30 @@ vi:
     new_zone: Vùng mới
     next: Tiếp
     no_actions_added: Không cần làm gì
-    no_payment_found:
-    no_pending_payments:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: Không tìm thấy sản phẩm
-    no_resource_found:
-    no_results:
-    no_returns_found:
-    no_rules_added:
-    no_shipping_method_selected:
-    no_state_changes:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
+    no_results: TODO_TRANSLATE
+    no_returns_found: TODO_TRANSLATE
+    no_rules_added: TODO_TRANSLATE
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: Không có thông tin theo dõi được cung cấp.
     none: Rỗng
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normal Amount
     not: không
     not_available: N/A
     not_enough_stock: Không đủ hàng tại địa điểm gốc để hoàn tất thủ tục di chuyển.
-    not_found:
-    note:
+    not_found: TODO_TRANSLATE
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: "Đã nhân bản sản phẩm"
       product_deleted: "Đã xóa sản phẩm"
@@ -791,12 +934,12 @@ vi:
       product_not_deleted: Không thể xóa sản phẩm
       variant_deleted: Biến thể đã được xóa
       variant_not_deleted: Không thể xóa biến thể
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: Có hàng
     open: Mở
     open_all_adjustments: Mở tất cả Chỉnh sửa
     option_type: Option Type
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: Kiểu tùy chọn
     option_value: Option Value
     option_values: Giá trị tùy chọn
@@ -805,101 +948,109 @@ vi:
     or: hoặc
     or_over_price: "%{price} or over"
     order: "Đơn hàng"
-    order_adjustments:
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_adjustments: TODO_TRANSLATE
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: Chi tiết đơn hàng
     order_email_resent: "Đơn hàng đã được gửi email lại"
     order_information: Thông tin đơn hàng
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: Kính chào quý khách,\n
         instructions: "Đơn đặt hàng của quý khách bị hủy. Vui lòng kiểm tra lại đơn hàng của bạn."
-        order_summary_canceled:
-        subject:
-        subtotal:
-        total:
+        order_summary_canceled: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: Kính chào quý khách,\n
         instructions: Vui lòng kiểm tra đơn đặt hàng của bạn.
-        order_summary:
-        subject:
-        subtotal:
-        thanks:
-        total:
+        order_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        subtotal: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        total: TODO_TRANSLATE
     order_not_found: Không tìm thấy đơn hàng. Xin vui lòng thử hành động khác.
-    order_number:
+    order_number: TODO_TRANSLATE
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: "Đơn đặt hàng của bạn đã được xử lý thành công"
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
-      address:
-      awaiting_return:
-      canceled:
-      cart:
-      complete:
-      confirm:
-      considered_risky:
-      delivery:
-      payment:
-      resumed:
-      returned:
+      address: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      considered_risky: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
     order_summary: Tóm tắt đơn đặt hàng
     order_sure_want_to: Bạn có chắc bạn muốn %{event} đơn hàng này?
     order_total: Tổng giá sau thuế
     order_updated: "Đơn hàng được cập nhật"
     orders: "Đơn hàng"
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: Hết hàng
     overview: Tổng kết
     package_from: gói từ
     pagination:
-      next_page:
-      previous_page:
+      first: TODO_TRANSLATE
+      next_page: TODO_TRANSLATE
+      previous: TODO_TRANSLATE
+      previous_page: TODO_TRANSLATE
       truncate: "…"
     password: Mật khẩu
     paste: Paste
     path: "Đường dẫn"
     pay: thanh toán
     payment: Thanh toán
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: Thông tin thanh toán
     payment_method: Phương thức thanh toán
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: Phương thức thanh toán
-    payment_processing_failed:
-    payment_processor_choose_banner_text:
-    payment_processor_choose_link:
-    payment_state:
+    payment_processing_failed: TODO_TRANSLATE
+    payment_processor_choose_banner_text: TODO_TRANSLATE
+    payment_processor_choose_link: TODO_TRANSLATE
+    payment_state: TODO_TRANSLATE
     payment_states:
-      balance_due:
-      checkout:
-      completed:
-      credit_owed:
-      failed:
-      paid:
-      pending:
-      processing:
-      void:
+      balance_due: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      credit_owed: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      paid: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     payment_updated: Thanh toán đã được cập nhật
     payments: Thanh toán
-    pending:
+    pending: TODO_TRANSLATE
     percent: Phần trăm
-    percent_per_item:
-    permalink:
+    percent_per_item: TODO_TRANSLATE
+    permalink: TODO_TRANSLATE
     phone: "Điện thoại"
     place_order: "Đặt hàng"
-    please_define_payment_methods:
-    populate_get_error:
+    please_define_payment_methods: TODO_TRANSLATE
+    please_enter_reasonable_quantity: TODO_TRANSLATE
+    populate_get_error: TODO_TRANSLATE
     powered_by: Tiếp sức bởi
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: Trình bày
     previous: Trước
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: Giá
     price_range: Loại giá
     price_sack: Price Sack
@@ -910,68 +1061,73 @@ vi:
     product_not_available_in_this_currency: Sản phẩm này không được cung cấp ở tiền tệ được chọn.
     product_properties: "Đặc tính sản phẩm"
     product_rule:
-      choose_products:
-      label:
-      match_all:
-      match_any:
-      match_none:
+      choose_products: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
+      match_none: TODO_TRANSLATE
       product_source:
-        group:
-        manual:
+        group: TODO_TRANSLATE
+        manual: TODO_TRANSLATE
     products: Sản phẩm
-    promotion:
-    promotion_action:
+    promotion: TODO_TRANSLATE
+    promotion_action: TODO_TRANSLATE
     promotion_action_types:
       create_adjustment:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_item_adjustments:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       create_line_items:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       free_shipping:
-        description:
-        name:
-    promotion_actions:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_actions: TODO_TRANSLATE
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
-        all:
-        any:
-    promotion_rule:
+        all: TODO_TRANSLATE
+        any: TODO_TRANSLATE
+    promotion_label: TODO_TRANSLATE
+    promotion_rule: TODO_TRANSLATE
     promotion_rule_types:
       first_order:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       item_total:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       landing_page:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       one_use_per_user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       taxon:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       user_logged_in:
-        description:
-        name:
-    promotion_uses:
-    promotionable:
-    promotions:
-    propagate_all_variants:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+    promotion_uses: TODO_TRANSLATE
+    promotionable: TODO_TRANSLATE
+    promotions: TODO_TRANSLATE
+    propagate_all_variants: TODO_TRANSLATE
     properties: "Đặc tính"
     property: "Đặc tính"
     prototype: Nguyên mẫu
@@ -980,49 +1136,51 @@ vi:
     provider_settings_warning: Nếu thay đổi nhà cung cấp, bạn phải lưu trước khi sửa đổi cấu hình nhà cung cấp
     qty: Số lượng
     quantity: Số lượng
-    quantity_returned:
+    quantity_returned: TODO_TRANSLATE
     quantity_shipped: Tổng hàng đã chuyển
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: Lãi suất
     reason: Lí do
     receive: nhận
     receive_stock: Nhận hàng
     received: "Đã nhận"
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: Tham khảo
+    reference_contains: TODO_TRANSLATE
     refund: Thối
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: "Đăng ký như một thành viên mới"
     registration: "Đăng ký"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: Nhớ tôi
     remove: Xóa
-    rename:
-    report:
+    rename: TODO_TRANSLATE
+    report: TODO_TRANSLATE
     reports: Báo cáo
+    resellable: TODO_TRANSLATE
     resend: Gửi lại
     reset_password: Khởi tạo lại mật khẩu
     response_code: Mã phản hồi
@@ -1030,47 +1188,55 @@ vi:
     resumed: "Đã tiếp tục"
     return: trở về
     return_authorization: "Ủy Quyền Trả Về"
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: "Ủy Quyền Trả Về đã được cập nhật"
     return_authorizations: "Ủy Quyền Trả Về"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: Số lượng trả về
     returned: "Đã trả về"
-    returns:
-    review:
-    risk:
-    risk_analysis:
-    risky:
-    rma_credit:
+    returns: TODO_TRANSLATE
+    review: TODO_TRANSLATE
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
+    rma_credit: TODO_TRANSLATE
     rma_number: Số RMA
     rma_value: Giá trị RMA
+    role_id: TODO_TRANSLATE
     roles: Vai trò
     rules: Rules
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: Tổng giá trị
-    sales_total_description:
+    sales_total_description: TODO_TRANSLATE
     sales_totals: Tổng doanh số
     save_and_continue: Lưu và tiếp tục
-    save_my_address:
-    say_no:
-    say_yes:
+    save_my_address: TODO_TRANSLATE
+    say_no: TODO_TRANSLATE
+    say_yes: TODO_TRANSLATE
     scope: Phạm vi
     search: Tìm kiếm
     search_results: Kết quả tìm kiếm cho '%{keywords}'
     searching: Searching
     secure_connection_type: Kiệu kết nối bảo mật
-    security_settings:
+    security_settings: TODO_TRANSLATE
     select: Lựa chọn
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: Lựa chọn từ nguyên mẫu
     select_stock: Chọn hàng
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: Gửi bản sao tất cả thư đến
     send_mails_as: Gửi thư như
     server: Server
@@ -1080,27 +1246,28 @@ vi:
     ship_address: "Địa chỉ giao hàng"
     ship_total: Tổng chuyển hàng
     shipment: Vận chuyển
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: Kính chào quý khách,\n
-        instructions:
-        shipment_summary:
-        subject:
-        thanks:
-        track_information:
+        instructions: TODO_TRANSLATE
+        shipment_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        thanks: TODO_TRANSLATE
+        track_information: TODO_TRANSLATE
         track_link: 'Link để theo dõi: %{url}'
-    shipment_state:
+    shipment_state: TODO_TRANSLATE
     shipment_states:
-      backorder:
-      canceled:
-      partial:
-      pending:
-      ready:
-      shipped:
-    shipment_transfer_error:
-    shipment_transfer_success:
+      backorder: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      partial: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: Vận chuyển
     shipped: "Đã chuyển phát"
     shipping: Vận chuyển
@@ -1114,69 +1281,85 @@ vi:
     shipping_method: Phương thức vận chuyển
     shipping_methods: Phương thức vận chuyển
     shipping_price_sack: Xô giá
-    shipping_total:
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: Mua theo %{taxonomy}
     shopping_cart: Sọt mua sắm
     show: Xem
     show_active: Liệt kê đơn còn hiệu lực
     show_deleted: Hiện đơn hàng đã xóa
     show_only_complete_orders: Chỉ hiện đơn hàng đã hoàn tất
-    show_only_considered_risky:
+    show_only_considered_risky: TODO_TRANSLATE
     show_rate_in_label: Hiện suất giá với nhãn mác
     sku: SKU
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: Nguồn
-    special_instructions:
-    split:
-    spree_gateway_error_flash_for_checkout:
+    special_instructions: TODO_TRANSLATE
+    split: TODO_TRANSLATE
+    spree/order:
+      coupon_code: TODO_TRANSLATE
+    spree_gateway_error_flash_for_checkout: TODO_TRANSLATE
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: Bắt đầu
+    start_date: TODO_TRANSLATE
     state: Bang
     state_based: Dựa trên bang
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: Bang
     states_required: Yêu cầu bang
     status: Tình trạng
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: "Địa điểm hàng"
     stock_location_info: Thông tin địa điểm hàng
     stock_locations: "Địa điểm hàng"
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: Quản lý hàng
-    stock_management_requires_a_stock_location:
+    stock_management_requires_a_stock_location: TODO_TRANSLATE
     stock_movements: Chuyển động của hàng
     stock_movements_for_stock_location: Chuyển động của hàng cho %{stock_location_name}
     stock_successfully_transferred: Hàng đã thành công chuyển giữa dịa điểm.
@@ -1188,28 +1371,30 @@ vi:
     street_address_2: "Địa chỉ (tiếp)"
     subtotal: Tổng giá trước thuế
     subtract: Trừ đi
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} has been successfully created!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} has been successfully removed!"
     successfully_signed_up_for_analytics: Thành công đăng kí cho Spree Analytics
     successfully_updated: "%{resource} has been successfully updated!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: Thuế
     tax_categories: Loại thuế
     tax_category: Biểu thuế
-    tax_code:
-    tax_included:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
     tax_rate_amount_explanation: Mức thuế ở số thập phân để trợ giúp cách tính, (nghĩa là; nếu mức thuế là 5% thì nhập vào 0.05
     tax_rates: Lãi suất thuế
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: "Đơn vị phân loại"
     taxon_edit: Sửa đổi đơn vị phân loại
     taxon_placeholder: Thêm vào một phân loại
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: Phân loại
     taxonomy: Taxonomy
     taxonomy_edit: Sửa đổi phân loại
@@ -1218,66 +1403,72 @@ vi:
     taxons: "Đơn vị phân loại"
     test: Kiểm tra
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
-        greeting:
-        message:
-        subject:
+        greeting: TODO_TRANSLATE
+        message: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
     test_mode: Chế độ kiểm tra
     thank_you_for_your_order: Cảm ơn đã mua hàng. Xin hãy in ra một bản của trang này để tiện cho việc chứng thực nếu cần.
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields:
-    this_order_has_already_received_a_refund:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
+    there_were_problems_with_the_following_fields: TODO_TRANSLATE
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: Hình nhỏ
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: Thời gian
     to_add_variants_you_must_first_define: "Để thêm biến thể, bạn phải định nghĩa trước"
     total: Giá trị
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: Theo dõi
     tracking_number: Số theo dõi
     tracking_url: URL theo dõi
-    tracking_url_placeholder:
-    transaction_id:
+    tracking_url_placeholder: TODO_TRANSLATE
+    transaction_id: TODO_TRANSLATE
     transfer_from_location: Chuyển từ
     transfer_stock: Chuyển hàng
     transfer_to_location: Chuyển tới
     tree: Cây
     type: Loại
-    type_to_search:
+    type_to_search: TODO_TRANSLATE
     unable_to_connect_to_gateway: Không thề kết nối với gateway.
-    unable_to_create_reimbursements:
-    under_price:
+    unable_to_create_reimbursements: TODO_TRANSLATE
+    under_price: TODO_TRANSLATE
     unlock: Mở khoá
     unrecognized_card_type: Không nhận ra được loại thẻ
     unshippable_items: Sản phẩm không vận chuyển được
     update: Cập nhật
     updating: "Đang cập nhật"
     usage_limit: Giới hạn sử dụng
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: Dùng địa chỉ thanh toán
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: Dùng thẻ mới
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Use Amazon S3 For Images
     user: Người dùng
     user_rule:
       choose_users: Choose users
     users: Người dùng
     validation:
-      cannot_be_less_than_shipped_units:
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_be_less_than_shipped_units: TODO_TRANSLATE
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: Vượt quá lượng hàng hiện có. Xin hãy chắc chắn mục dòng có một số lượng hợp lệ.
       is_too_large: quá lớn -- số hàng hiện có không đủ đáp ứng!
       must_be_int: phải là số nguyên
       must_be_non_negative: phải là số dương
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: Giá trị
     variant: Variant
-    variant_placeholder:
+    variant_placeholder: TODO_TRANSLATE
     variants: Biến thể
     version: Phiên bản
     void: Vô hiệu hóa
@@ -1293,3 +1484,10 @@ vi:
     zipcode: Mã Zip
     zone: Vùng
     zones: Vùng
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,4 +1,6 @@
+---
 zh-CN:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ zh-CN:
         state: "省份"
         zipcode: "邮政编码"
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ zh-CN:
         name: "名称"
         numcode: ISO编号
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: "信用卡类型"
         month: "月份"
-        name:
+        name: TODO_TRANSLATE
         number: "卡号"
         verification_value: "验证码"
         year: "年份"
@@ -42,7 +44,7 @@ zh-CN:
       spree/order:
         checkout_complete: "完成结账"
         completed_at: "结账日期"
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: "优惠券号码"
         created_at: "下单日期"
         email: "电子邮件"
@@ -72,6 +74,7 @@ zh-CN:
         zipcode: "邮政编码"
       spree/payment:
         amount: "金额"
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: "名称"
       spree/product:
@@ -95,7 +98,8 @@ zh-CN:
         starts_at: "开始日期"
         usage_limit: "使用次数限制"
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: "名称"
         presentation: "描述"
@@ -105,24 +109,26 @@ zh-CN:
         amount: "金额"
       spree/role:
         name: ming cheng
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: "缩写"
         name: "名称"
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: "描述"
         name: "名称"
@@ -157,48 +163,54 @@ zh-CN:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
-              card_expired:
-              expiry_invalid:
+              card_expired: TODO_TRANSLATE
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address:
         one: "地址"
         other: "地址"
@@ -208,41 +220,43 @@ zh-CN:
       spree/credit_card:
         one: "信用卡"
         other: "信用卡"
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit:
         one: "库存单位"
         other: "库存单位"
       spree/line_item:
         one: "单项"
         other: "单项"
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order:
         one: "订单"
         other: "订单"
       spree/payment:
         one: "支付"
         other: "支付"
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product:
         one: "产品"
         other: "产品"
       spree/promotion: "促销"
-      spree/promotion_category:
+      spree/promotion_category: TODO_TRANSLATE
       spree/property:
         one: "属性"
         other: "属性"
       spree/prototype:
         one: "原型"
         other: "原型"
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: "返回授权"
         other: "返回授权"
-      spree/return_authorization_reason:
+      spree/return_authorization_reason: TODO_TRANSLATE
       spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
         one: "角色"
         other: "角色"
       spree/shipment:
@@ -251,14 +265,14 @@ zh-CN:
       spree/shipping_category:
         one: "物流分类"
         other: "物流分类"
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state:
         one: "省份"
         other: "省份"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category:
         one: "缴税分类"
         other: "缴税分类"
@@ -271,7 +285,7 @@ zh-CN:
       spree/taxonomy:
         one: "分类"
         other: "分类"
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user:
         one: "用户"
         other: "用户"
@@ -281,6 +295,9 @@ zh-CN:
       spree/zone:
         one: "区域"
         other: "区域"
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: "您已成功确认您的帐户信息。您现在已登录。"
@@ -319,18 +336,37 @@ zh-CN:
     user_sessions:
       signed_in: "成功登录。"
       signed_out: "成功注销。"
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: "已被确认"
       not_found: "无法找到"
       not_locked: "未冻结"
       not_saved: "由于以下%{count}个错误，导致%{resource}无法保存："
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: "缩写"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "帐户"
     account_updated: "帐户更新完成!"
     action: "操作"
@@ -343,7 +379,7 @@ zh-CN:
       list: "列表"
       listing: "正在列出"
       new: "新建"
-      refund:
+      refund: TODO_TRANSLATE
       save: "保存"
       update: "更新"
     activate: "激活"
@@ -351,7 +387,7 @@ zh-CN:
     add: "添加"
     add_action_of_type: "添加激活方式"
     add_country: "添加国家"
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: "添加新的头部"
     add_new_style: "添加新的样式"
     add_one: "新建"
@@ -365,11 +401,16 @@ zh-CN:
     add_to_cart: "加入购物车"
     add_variant: "添加具体型号"
     additional_item: "额外项目花费"
+    address: TODO_TRANSLATE
     address1: "地址"
     address2: "地址（继续）"
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: "调整"
     adjustment_amount: "金额"
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: "价格调整已被禁用！"
     adjustment_successfully_opened: "价格调整已被启用！"
     adjustment_total: "调整总数"
@@ -377,35 +418,35 @@ zh-CN:
     admin:
       tab:
         configuration: "配置"
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: "订单"
         overview: "概览"
         products: "产品"
         promotions: "促销"
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: "报告"
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: "用户"
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: "管理"
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: "同意隐私政策"
     agree_to_terms_of_service: "同意服务条款"
     all: "全部"
     all_adjustments_closed: "所有价格调整已被成功禁用！"
     all_adjustments_opened: "所有价格调整已被成功启用！"
     all_departments: "所有部门"
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: "允许在开发以及测试模式下使用SSL"
     allow_ssl_in_production: "允许在生产模式下使用SSL"
     allow_ssl_in_staging: "允许在演示模式下使用SSL"
@@ -414,77 +455,111 @@ zh-CN:
     alternative_phone: "其他电话"
     amount: "金额"
     analytics_desc_header_1: Spree Analytics
-    analytics_desc_header_2:
-    analytics_desc_list_1:
+    analytics_desc_header_2: TODO_TRANSLATE
+    analytics_desc_list_1: TODO_TRANSLATE
     analytics_desc_list_2: "仅需要一个免费的Spree帐号用于激活"
-    analytics_desc_list_3:
+    analytics_desc_list_3: TODO_TRANSLATE
     analytics_desc_list_4: "完全免费"
     analytics_trackers: "追踪分析"
     and: "以及"
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: "核准"
     approved_at: "核准日期"
     approver: "核准者"
     are_you_sure: "你确定么？"
     are_you_sure_delete: "你确定你要删除这条记录么?"
     associated_adjustment_closed: "相关联的价格调整已被关闭，并且不会被重复计算。您需要启用它吗？"
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: "认证失败"
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: "上架日期"
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: "后退"
     back_end: "后端"
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: "回到商店"
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: "回到用户列表"
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: "可预订"
-    backorderable_default:
+    backorderable_default: TODO_TRANSLATE
     backordered: "待补"
-    backorders_allowed:
+    backorders_allowed: TODO_TRANSLATE
     balance_due: "尚欠款"
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: "账单地址"
     billing: "账单"
     billing_address: "账单地址"
     both: "全部"
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: "计算器"
     calculator_settings_warning: "如果你正在修改计算方式，你必须在编辑计算器设置之前先保存"
     cancel: "取消"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: "您无法在没有定义任何支付方式的情况下进行支付。"
     cannot_create_returns: "没有配送的订单不能申请退货"
     cannot_perform_operation: "无法执行请求的操作"
     cannot_set_shipping_method_without_address: "缺乏客户的详细信息，无法设置配送方式。"
     capture: "付款"
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: "卡验证码"
     card_number: "卡号"
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: "卡的类型是"
     cart: "购物车"
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: "分类"
     category: "分类"
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: "查收Spree的通知"
     checkout: "结账"
     choose_a_customer: "选择用户"
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: "选择货币"
     choose_dashboard_locale: "选择控制面板语言"
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: "城市"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: "复制"
     close: "关闭"
     close_all_adjustments: "禁用所有价格调整"
@@ -493,6 +568,7 @@ zh-CN:
     complete: "完成"
     configuration: "配置"
     configurations: "配置"
+    configure_s3: TODO_TRANSLATE
     confirm: "确认"
     confirm_delete: "确认删除"
     confirm_password: "确认密码"
@@ -501,40 +577,40 @@ zh-CN:
     cost_currency: "成本币种"
     cost_price: "进货价"
     could_not_connect_to_jirafe: "无法连接Jirafe。稍后将会自动重新连接。"
-    could_not_create_customer_return:
-    could_not_create_stock_movement:
+    could_not_create_customer_return: TODO_TRANSLATE
+    could_not_create_stock_movement: TODO_TRANSLATE
     count_on_hand: "库存数量"
     countries: "国家"
     country: "国家"
     country_based: "根据国家"
     country_name: "名称"
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: "优惠券"
     coupon_code: "优惠券号码"
     coupon_code_already_applied: "优惠券号码已在本订单中使用"
     coupon_code_applied: "优惠券号码已在订单中生效。"
-    coupon_code_better_exists:
+    coupon_code_better_exists: TODO_TRANSLATE
     coupon_code_expired: "优惠券号码已过期"
     coupon_code_max_usage: "优惠券号码使用次数超出限制"
     coupon_code_not_eligible: "您的订单号码无法在您的订单上生效。"
     coupon_code_not_found: "您所输入的优惠券号码不存在。请重新输入。"
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: "创建"
     create_a_new_account: "创建一个新帐号"
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: "创建日期"
     credit: "欠款??"
     credit_card: "信用卡"
     credit_cards: "信用卡"
     credit_owed: "应予退款"
-    credits:
+    credits: TODO_TRANSLATE
     currency: "币种"
-    currency_decimal_mark:
+    currency_decimal_mark: TODO_TRANSLATE
     currency_settings: "当前设置"
     currency_symbol_position: "在金额之前或者之后放置币种符号？"
     currency_thousands_separator: "千元分割符"
@@ -543,64 +619,83 @@ zh-CN:
     customer: "顾客"
     customer_details: "顾客详细信息"
     customer_details_updated: "已更新客户的详细信息"
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: "顾客搜索"
     cut: "剪下"
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
-        app_id:
+        app_id: TODO_TRANSLATE
         app_token: "添加口令"
-        currently_unavailable:
-        explanation:
+        currently_unavailable: TODO_TRANSLATE
+        explanation: TODO_TRANSLATE
         header: Jirafe分析器设置
-        site_id:
+        site_id: TODO_TRANSLATE
         token: "口令"
       jirafe_settings_updated: Jirafe设置已更新。
     date: "日期"
     date_completed: "完成日期"
     date_picker:
-      first_day:
+      first_day: TODO_TRANSLATE
       format: "%Y/%m/%d"
       js_format: yy/mm/dd
     date_range: "时间范围"
     default: "默认"
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: "默认缴税"
     default_tax_zone: "默认缴税区域"
     delete: "删除"
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: "配送"
     depth: "长"
     description: "描述"
     destination: "目的地"
     destroy: "删除"
-    details:
+    details: TODO_TRANSLATE
     discount_amount: "折扣金额"
     dismiss_banner: "不，谢谢！我对此不感兴趣，请不要再显示此信息。"
     display: "显示"
     display_currency: "显示货币符号"
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: "编辑"
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: "编辑用户"
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: "电子邮件"
     empty: Empty
     empty_cart: "清空购物车"
@@ -633,28 +728,30 @@ zh-CN:
           signup: "用户注册"
     exceptions:
       count_on_hand_setter: "无法手动设置 count_on_hand, 将会在 recalculate_count_on_hand 中被自动设定。请使用 `update_column(:count_on_hand, value)`"
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: "过期"
     extension: "扩展"
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: "文件名"
     fill_in_customer_info: "请填写顾客信息"
+    filter: TODO_TRANSLATE
     filter_results: "过滤结果"
     finalize: "完成"
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: "首件产品价格??"
     first_name: "名"
     first_name_begins_with: "名的开始"
     flat_percent: "固定费率"
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: "固定费率 (每订单)"
     flexible_rate: "灵活费率"
     forgot_password: "忘记密码"
     free_shipping: "免运送费"
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: "前端"
     gateway: "网关"
     gateway_config_unavailable: "当前运行环境下无可用的网关"
@@ -673,42 +770,46 @@ zh-CN:
       available_locales: "可用的语言"
       fields: "好友"
       language: "语言"
-      localization_settings:
-      only_complete:
-      only_incomplete:
-      select_locale:
-      show_only:
-      supported_locales:
+      localization_settings: TODO_TRANSLATE
+      only_complete: TODO_TRANSLATE
+      only_incomplete: TODO_TRANSLATE
+      select_locale: TODO_TRANSLATE
+      show_only: TODO_TRANSLATE
+      store_translations: TODO_TRANSLATE
+      supported_locales: TODO_TRANSLATE
       this_file_language: "中文(简体)"
-      translations:
+      translations: TODO_TRANSLATE
     icon: "图标"
-    identifier:
+    identifier: TODO_TRANSLATE
     image: "图片"
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: "图片"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: "包含在售价中"
     included_price_validation: "除非您设置了默认的缴税区域，否则无法选择"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: "请填写如下表格来重置你的密码，重置后的密码会通过电子邮件发送给您"
     insufficient_stock: "库存不足，当前还剩下%{on_hand}件库存"
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: "用于接收邮件的邮箱地址"
     intercept_email_instructions: "使用以下邮箱地址覆盖所有收件人邮箱"
-    internal_name:
-    invalid_credit_card:
-    invalid_exchange_variant:
+    internal_name: TODO_TRANSLATE
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: "无效的支付服务提供商。"
     invalid_promotion_action: "无效的优惠方式。"
     invalid_promotion_rule: "无效的促销规则。"
     inventory: "库存"
     inventory_adjustment: "库存调整"
     inventory_error_flash_for_insufficient_quantity: "您的购物车中的一个商品已经不可购买。"
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: "无法送达要求的配送地址"
     iso_name: ISO名称
     item: "商品项"
@@ -718,26 +819,32 @@ zh-CN:
       operators:
         gt: "大于"
         gte: "大于或等于"
-        lt:
-        lte:
-    items_cannot_be_shipped:
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
+    items_cannot_be_shipped: TODO_TRANSLATE
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: "姓"
     last_name_begins_with: "姓的开始"
     learn_more: "更多"
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: "列表"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "加载"
     locale_changed: Locale已变更
     location: "位置"
     lock: "锁住/冻结"
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: "已登陆为"
     logged_in_succesfully: "登陆成功"
     logged_out: "您已经登出系统"
@@ -746,38 +853,41 @@ zh-CN:
     login_failed: "登陆认证失败。"
     login_name: "用户名"
     logout: "登出/注销"
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: "寻找类似的产品"
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: "进行退款??"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: "默认价格"
     match_choices:
       all: "全部"
       none: "清空"
     max_items: "最大商品项??"
-    member_since:
-    memo:
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: "元描述"
     meta_keywords: "关键字"
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: "元数据"
     minimal_amount: "少量"
     month: "月"
     more: "更多"
-    move_stock_between_locations:
+    move_stock_between_locations: TODO_TRANSLATE
     my_account: "我的帐户"
     my_orders: "我的订单"
     name: "名称"
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: "名称或条形码（输入产品名称中的至少4个字母）"
     new: "新建"
     new_adjustment: "新建调整"
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: "新建客户"
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: "新建图片"
     new_option_type: "新建选项类型"
     new_order: "新建订单"
@@ -786,20 +896,21 @@ zh-CN:
     new_payment_method: "新建支付方式"
     new_product: "新建产品"
     new_promotion: "新建促销活动"
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: "新建属性"
     new_prototype: "新建原型"
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: "新建退货"
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: "新建配送分类"
     new_shipping_method: "新建配送方式"
     new_state: "新建省份"
     new_stock_location: "添加仓库位置"
-    new_stock_movement:
-    new_stock_transfer:
+    new_stock_movement: TODO_TRANSLATE
+    new_stock_transfer: TODO_TRANSLATE
     new_tax_category: "新建缴税类型"
     new_tax_rate: "新建税率"
     new_taxon: "新建分类"
@@ -810,24 +921,30 @@ zh-CN:
     new_zone: "新建区域"
     next: "下一页"
     no_actions_added: "未添加动作"
-    no_payment_found:
-    no_pending_payments:
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: "找不到产品"
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: "无任何结果"
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: "未添加规则"
-    no_shipping_method_selected:
-    no_state_changes:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
     no_tracking_present: "未提供跟踪细节。"
     none: "没有"
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: Normal Amount
     not: false
     not_available: N/A
-    not_enough_stock:
+    not_enough_stock: TODO_TRANSLATE
     not_found: "未找到%{resource}"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: "产品已经被复制"
       product_deleted: "产品已经被删除"
@@ -835,7 +952,7 @@ zh-CN:
       product_not_deleted: "产品无法被删除"
       variant_deleted: "具体型号已经被删除"
       variant_not_deleted: "具体型号不能被删除"
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: "库存"
     open: "打开"
     open_all_adjustments: "启用所有价格调整"
@@ -850,32 +967,37 @@ zh-CN:
     or_over_price: "%{price}或以上"
     order: "订单"
     order_adjustments: "订单调整"
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: "订单详情"
     order_email_resent: "重新发出了订单邮件"
     order_information: "订单信息"
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: "亲爱的顾客，"
         instructions: "您的订单已被取消。请保留此取消信息记录。"
         order_summary_canceled: "订单总览 [已取消]"
         subject: "取消订单"
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: "亲爱的顾客，"
         instructions: "请仔细阅读并保留以下订单信息记录。"
         order_summary: "订单总览"
         subject: "订单确认"
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: "谢谢您的购买。"
-        total:
+        total: TODO_TRANSLATE
     order_not_found: "我们无法找到您的订单。请重新尝试。"
     order_number: "订单号 %{number}"
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: "您的订单已经被成功处理了"
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: "地址"
       awaiting_return: "等待退货"
@@ -883,7 +1005,7 @@ zh-CN:
       cart: "购物车"
       complete: "完成"
       confirm: "确认"
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: "配送"
       payment: "支付"
       resumed: "重新开始"
@@ -893,12 +1015,14 @@ zh-CN:
     order_total: "订单总计"
     order_updated: "订单已更新"
     orders: "订单"
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: "没有库存"
     overview: "首页"
     package_from: "包裹来自"
     pagination:
+      first: TODO_TRANSLATE
       next_page: "下一页 »"
+      previous: TODO_TRANSLATE
       previous_page: "« 上一页"
       truncate: "…"
     password: "密码"
@@ -906,11 +1030,11 @@ zh-CN:
     path: "路径"
     pay: "支付"
     payment: "支付"
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: "支付信息"
     payment_method: "支付方式"
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: "支付方式"
     payment_processing_failed: "无法处理支付信息，请检查您所输入的详细信息"
     payment_processor_choose_banner_text: "如果您需要关于支付处理的帮助，请访问"
@@ -928,22 +1052,23 @@ zh-CN:
       void: "无效"
     payment_updated: "支付已更新"
     payments: "支付"
-    pending:
+    pending: TODO_TRANSLATE
     percent: "百分比"
     percent_per_item: "单件百分比"
     permalink: "永久链接"
     phone: "电话"
     place_order: "下单"
     please_define_payment_methods: "请先设定支付方式。"
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: "出错了，请重新添加项目。"
     powered_by: "技术支持"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: "描述"
     previous: "上一页"
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: "价格"
     price_range: "价格范围"
     price_sack: "袋价格"
@@ -955,10 +1080,10 @@ zh-CN:
     product_properties: "产品属性"
     product_rule:
       choose_products: "选择产品"
-      label:
+      label: TODO_TRANSLATE
       match_all: "全部"
       match_any: "至少一个"
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: "从产品分组"
         manual: "手工选择"
@@ -978,11 +1103,16 @@ zh-CN:
       free_shipping:
         description: "整张订单免费发货"
         name: "免运费"
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: "优惠方式"
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: "匹配任意规则"
         any: "匹配所有规则"
+    promotion_label: TODO_TRANSLATE
     promotion_rule: "促销规则"
     promotion_rule_types:
       first_order:
@@ -998,8 +1128,8 @@ zh-CN:
         description: "每人只可使用一次"
         name: "每人一次"
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: "订单包含指定的产品"
         name: "产品"
@@ -1013,9 +1143,9 @@ zh-CN:
         description: "只对已经登录的用户有效"
         name: "用户登录"
     promotion_uses: "促销使用频率"
-    promotionable:
+    promotionable: TODO_TRANSLATE
     promotions: "促销"
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: "属性"
     property: "属性"
     prototype: "原型"
@@ -1026,47 +1156,49 @@ zh-CN:
     quantity: "数量"
     quantity_returned: "返回的数量"
     quantity_shipped: "已发货数量"
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: "费率"
     reason: "原因"
     receive: "收到"
-    receive_stock:
+    receive_stock: TODO_TRANSLATE
     received: "已收到"
-    reception_status:
-    reference:
+    reception_status: TODO_TRANSLATE
+    reference: TODO_TRANSLATE
+    reference_contains: TODO_TRANSLATE
     refund: "退款"
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: "注册成为新用户"
     registration: "注册"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: "记住我"
     remove: "移出"
     rename: "重命名"
-    report:
+    report: TODO_TRANSLATE
     reports: "报表"
+    resellable: TODO_TRANSLATE
     resend: "重新发送"
     reset_password: "重置密码"
     response_code: "返回代码"
@@ -1074,34 +1206,41 @@ zh-CN:
     resumed: "已恢复"
     return: "退回"
     return_authorization: "退货审批"
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: "退货审批已更新"
     return_authorizations: "退货审批"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: "退货数量"
     returned: "已退回"
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA Credit
     rma_number: "退货单号"
     rma_value: "退货价值"
+    role_id: TODO_TRANSLATE
     roles: "角色"
     rules: Rules
-    safe:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
     sales_total: "销售总计"
     sales_total_description: "所有订单总销量"
     sales_totals: "总销量"
     save_and_continue: "保存并继续"
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: "不"
     say_yes: "是的"
     scope: "范围"
@@ -1111,10 +1250,11 @@ zh-CN:
     secure_connection_type: "安全连接类型"
     security_settings: "安全设置"
     select: "选择"
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: "从原型中选择"
-    select_stock:
+    select_stock: TODO_TRANSLATE
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: "将所有邮件的副本发送至"
     send_mails_as: "发送邮件作为"
     server: "服务器"
@@ -1122,10 +1262,11 @@ zh-CN:
     settings: "设置"
     ship: "发货"
     ship_address: "配送地址"
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: "配送"
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: "亲爱的顾客，"
@@ -1134,17 +1275,17 @@ zh-CN:
         subject: "发货通知"
         thanks: "谢谢您的购买"
         track_information: "货运单号： %{tracking}"
-        track_link:
+        track_link: TODO_TRANSLATE
     shipment_state: "配送状态"
     shipment_states:
       backorder: "延期未交定货"
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: "部分"
       pending: "等待中"
       ready: "就绪"
       shipped: "已经发货"
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: "配送"
     shipped: "已发货"
     shipping: "配送中"
@@ -1157,68 +1298,84 @@ zh-CN:
     shipping_instructions: "配送指南"
     shipping_method: "配送方式"
     shipping_methods: "配送方式"
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "根据%{taxonomy}购物"
     shopping_cart: "购物车"
     show: "显示"
     show_active: "显示激活的"
     show_deleted: "显示删除的"
     show_only_complete_orders: "只显示完整的订单"
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
     sku: "条形码"
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: "来源"
     special_instructions: "特别说明"
     split: "分拆"
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: "您的支付信息存在错误。请检查您的信息后再次尝试。"
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: "开始"
+    start_date: TODO_TRANSLATE
     state: "省份"
     state_based: "根据省份"
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: "省份"
-    states_required:
+    states_required: TODO_TRANSLATE
     status: "状态"
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: "库存区域"
     stock_location_info: "库存区域资讯"
     stock_locations: "库存区域"
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: "库存管理"
     stock_management_requires_a_stock_location: "请先新增库存区域，才可使用库存管理"
     stock_movements: "库存动向"
@@ -1232,28 +1389,30 @@ zh-CN:
     street_address_2: "地址(继续输入)"
     subtotal: "小计"
     subtract: "减去"
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "%{resource} 已被成功添加!"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "%{resource} 已被成功删除!"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "%{resource} 已被成功更新!"
-    summary:
+    summary: TODO_TRANSLATE
     tax: "税"
     tax_categories: "缴税分类"
     tax_category: "缴税分类"
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: "税率"
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: "分类"
     taxon_edit: "编辑分类"
     taxon_placeholder: "添加分类"
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: "分类层级"
     taxonomy: "分类层级"
     taxonomy_edit: "编辑分类层级"
@@ -1262,40 +1421,43 @@ zh-CN:
     taxons: "分类"
     test: "测试"
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: "恭喜!"
         message: "如果您收到此邮件，则说明您的邮件设置是正确的"
         subject: "测试邮件"
     test_mode: "测试模式"
     thank_you_for_your_order: "感谢您的订购，请打印这张订单作为购买凭证。"
-    there_are_no_items_for_this_order:
+    there_are_no_items_for_this_order: TODO_TRANSLATE
     there_were_problems_with_the_following_fields: "以下字段存在错误"
-    this_order_has_already_received_a_refund:
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: "缩略图"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: "时间"
     to_add_variants_you_must_first_define: "要添加具体型号，您需要先定义"
     total: "总计"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: "追踪"
-    tracking_number:
-    tracking_url:
+    tracking_number: TODO_TRANSLATE
+    tracking_url: TODO_TRANSLATE
     tracking_url_placeholder: "比如，http://quickship.com/package?num=:tracking"
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: "树"
     type: "类型"
     type_to_search: "搜索类型"
     unable_to_connect_to_gateway: "无法连接支付网关."
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: "低于 %{price}"
     unlock: "解锁"
     unrecognized_card_type: "无法辨识的支付卡种类"
@@ -1303,9 +1465,11 @@ zh-CN:
     update: "更新"
     updating: "更新中"
     usage_limit: "使用限制"
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: "使用账单地址"
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: "使用一张新卡"
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: "使用Amazon S3存储图片"
     user: "用户"
     user_rule:
@@ -1313,12 +1477,13 @@ zh-CN:
     users: "用户详情"
     validation:
       cannot_be_less_than_shipped_units: "不能少于已配送的单位数。"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: "超出可用的库存。请确认订单项拥有有效的数量。"
       is_too_large: "数量太多了 -- 现有库存无法满足您需要的数量!"
       must_be_int: "必须是整数"
       must_be_non_negative: "不能为负数"
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: "价值"
     variant: "具体型号"
     variant_placeholder: "选择具体型号"
@@ -1337,3 +1502,10 @@ zh-CN:
     zipcode: "邮编"
     zone: "区域"
     zones: "区域"
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,4 +1,6 @@
+---
 zh-TW:
+  Bazaar: TODO_TRANSLATE
   activerecord:
     attributes:
       spree/address:
@@ -12,11 +14,11 @@ zh-TW:
         state: "省/州"
         zipcode: "郵遞區號"
       spree/calculator/tiered_flat_rate:
-        preferred_base_amount:
-        preferred_tiers:
+        preferred_base_amount: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/calculator/tiered_percent:
-        preferred_base_percent:
-        preferred_tiers:
+        preferred_base_percent: TODO_TRANSLATE
+        preferred_tiers: TODO_TRANSLATE
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -24,10 +26,10 @@ zh-TW:
         name: "名稱"
         numcode: ISO 編碼
       spree/credit_card:
-        base:
+        base: TODO_TRANSLATE
         cc_type: "信用卡類型"
         month: "月份"
-        name:
+        name: TODO_TRANSLATE
         number: "卡號"
         verification_value: "驗證碼"
         year: "年份"
@@ -42,7 +44,7 @@ zh-TW:
       spree/order:
         checkout_complete: "完成結帳"
         completed_at: "結帳日期"
-        considered_risky:
+        considered_risky: TODO_TRANSLATE
         coupon_code: "優惠代碼"
         created_at: "訂單日期"
         email: "電子信箱"
@@ -72,6 +74,7 @@ zh-TW:
         zipcode: "郵遞區號"
       spree/payment:
         amount: "金額"
+        number: TODO_TRANSLATE
       spree/payment_method:
         name: "名稱"
       spree/product:
@@ -95,7 +98,8 @@ zh-TW:
         starts_at: "起始日期"
         usage_limit: "使用次數限制"
       spree/promotion_category:
-        name:
+        code: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       spree/property:
         name: "名稱"
         presentation: "描述"
@@ -105,24 +109,26 @@ zh-TW:
         amount: "金額"
       spree/role:
         name: "名稱"
+      spree/shipment:
+        number: TODO_TRANSLATE
       spree/state:
         abbr: "縮寫"
         name: "名稱"
       spree/state_change:
-        state_changes:
-        state_from:
-        state_to:
-        timestamp:
-        type:
-        updated:
-        user:
+        state_changes: TODO_TRANSLATE
+        state_from: TODO_TRANSLATE
+        state_to: TODO_TRANSLATE
+        timestamp: TODO_TRANSLATE
+        type: TODO_TRANSLATE
+        updated: TODO_TRANSLATE
+        user: TODO_TRANSLATE
       spree/store:
-        mail_from_address:
-        meta_description:
-        meta_keywords:
-        name:
-        seo_title:
-        url:
+        mail_from_address: TODO_TRANSLATE
+        meta_description: TODO_TRANSLATE
+        meta_keywords: TODO_TRANSLATE
+        name: TODO_TRANSLATE
+        seo_title: TODO_TRANSLATE
+        url: TODO_TRANSLATE
       spree/tax_category:
         description: "描述"
         name: "名稱"
@@ -157,90 +163,103 @@ zh-TW:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number:
+              keys_should_be_positive_number: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number:
-              values_should_be_percent:
+              keys_should_be_positive_number: TODO_TRANSLATE
+              values_should_be_percent: TODO_TRANSLATE
             preferred_tiers:
-              should_be_hash:
+              should_be_hash: TODO_TRANSLATE
         spree/classification:
           attributes:
             taxon_id:
-              already_linked:
+              already_linked: TODO_TRANSLATE
         spree/credit_card:
           attributes:
             base:
               card_expired: "信用卡已失效"
-              expiry_invalid:
+              expiry_invalid: TODO_TRANSLATE
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency:
+              must_match_order_currency: TODO_TRANSLATE
         spree/refund:
           attributes:
             amount:
-              greater_than_allowed:
+              greater_than_allowed: TODO_TRANSLATE
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match:
+              return_items_order_id_does_not_match: TODO_TRANSLATE
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists:
+              other_completed_return_item_exists: TODO_TRANSLATE
             reimbursement:
-              cannot_be_associated_unless_accepted:
+              cannot_be_associated_unless_accepted: TODO_TRANSLATE
         spree/store:
           attributes:
             base:
-              cannot_destroy_default_store:
+              cannot_destroy_default_store: TODO_TRANSLATE
     models:
+      reimbursement_perform_failed: TODO_TRANSLATE
+      reimbursement_status: TODO_TRANSLATE
+      reimbursement_type: TODO_TRANSLATE
+      reimbursement_type_override: TODO_TRANSLATE
+      reimbursement_types: TODO_TRANSLATE
+      reimbursements: TODO_TRANSLATE
       spree/address: "地址"
       spree/country: "國家"
       spree/credit_card: "信用卡"
-      spree/customer_return:
+      spree/customer_return: TODO_TRANSLATE
       spree/inventory_unit: "庫存單位"
       spree/line_item:
         one: "單項"
         other: "單項"
-      spree/option_type:
-      spree/option_value:
+      spree/option_type: TODO_TRANSLATE
+      spree/option_value: TODO_TRANSLATE
       spree/order: "訂單"
       spree/payment: "付款"
-      spree/payment_method:
+      spree/payment_method: TODO_TRANSLATE
       spree/product: "產品"
       spree/promotion: "促銷"
-      spree/promotion_category:
+      spree/promotion_category: TODO_TRANSLATE
       spree/property: "屬性"
       spree/prototype: "原型"
-      spree/refund_reason:
-      spree/reimbursement:
-      spree/reimbursement_type:
+      spree/refund_reason: TODO_TRANSLATE
+      spree/reimbursement: TODO_TRANSLATE
+      spree/reimbursement_type: TODO_TRANSLATE
       spree/return_authorization:
         one: "返回授權"
         other: "返回授權"
-      spree/return_authorization_reason:
-      spree/role: "角色"
+      spree/return_authorization_reason: TODO_TRANSLATE
+      spree/role:
+        few: TODO_TRANSLATE
+        oher: TODO_TRANSLATE
+        one: TODO_TRANSLATE
+        other: TODO_TRANSLATE
       spree/shipment: "貨運"
       spree/shipping_category: "貨運類別"
-      spree/shipping_method:
+      spree/shipping_method: TODO_TRANSLATE
       spree/state: "州/省"
-      spree/state_change:
-      spree/stock_location:
-      spree/stock_movement:
-      spree/stock_transfer:
+      spree/state_change: TODO_TRANSLATE
+      spree/stock_location: TODO_TRANSLATE
+      spree/stock_movement: TODO_TRANSLATE
+      spree/stock_transfer: TODO_TRANSLATE
       spree/tax_category: "稅金類別"
       spree/tax_rate: "稅率"
       spree/taxon: "分類"
       spree/taxonomy: "分類"
-      spree/tracker:
+      spree/tracker: TODO_TRANSLATE
       spree/user: "使用者"
       spree/variant: "型號"
       spree/zone: "區域"
+  all: TODO_TRANSLATE
+  back_to_resource_list: TODO_TRANSLATE
+  cancel: TODO_TRANSLATE
   devise:
     confirmations:
       confirmed: "您的帳號已驗證成功. 現已登入."
@@ -279,18 +298,37 @@ zh-TW:
     user_sessions:
       signed_in: "登入成功."
       signed_out: "登出成功."
+  editing_resource: TODO_TRANSLATE
   errors:
     messages:
       already_confirmed: "已驗證"
       not_found: "找不到"
       not_locked: "未鎖定"
       not_saved: "在儲存%{resource}時遭遇%{count} 個錯誤"
+  i18n:
+    available_locales: TODO_TRANSLATE
+    fields: TODO_TRANSLATE
+    language: TODO_TRANSLATE
+    locales_displayed_on_frontend_select_box: TODO_TRANSLATE
+    locales_displayed_on_translation_forms: TODO_TRANSLATE
+    localization_settings: TODO_TRANSLATE
+    only_complete: TODO_TRANSLATE
+    only_incomplete: TODO_TRANSLATE
+    supported_locales: TODO_TRANSLATE
+    this_file_language: TODO_TRANSLATE
+    translations: TODO_TRANSLATE
+  number:
+    percentage:
+      format:
+        precision: TODO_TRANSLATE
+  or: TODO_TRANSLATE
+  show: TODO_TRANSLATE
   spree:
     abbreviation: "縮寫"
-    accept:
-    acceptance_errors:
-    acceptance_status:
-    accepted:
+    accept: TODO_TRANSLATE
+    acceptance_errors: TODO_TRANSLATE
+    acceptance_status: TODO_TRANSLATE
+    accepted: TODO_TRANSLATE
     account: "帳戶"
     account_updated: "帳戶已更新"
     action: "操作"
@@ -303,7 +341,7 @@ zh-TW:
       list: "列表"
       listing: "列出中"
       new: "新增"
-      refund:
+      refund: TODO_TRANSLATE
       save: "儲存"
       update: "更新"
     activate: "啓用"
@@ -311,7 +349,7 @@ zh-TW:
     add: "增加"
     add_action_of_type: "增加促銷優惠"
     add_country: "增加國家"
-    add_coupon_code:
+    add_coupon_code: TODO_TRANSLATE
     add_new_header: "增加新 Header"
     add_new_style: "增加新樣式"
     add_one: "新增"
@@ -325,11 +363,16 @@ zh-TW:
     add_to_cart: "加到購物車"
     add_variant: "新增型號"
     additional_item: "額外商品花費"
+    address: TODO_TRANSLATE
     address1: "地址"
     address2: "地址 (接續)"
-    adjustable:
+    adjustable: TODO_TRANSLATE
     adjustment: "其他項目"
     adjustment_amount: "金額"
+    adjustment_labels:
+      tax_rates:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
     adjustment_successfully_closed: "其他項目已成功停用!"
     adjustment_successfully_opened: "其他項目已成功啓用!"
     adjustment_total: "其他項目總計"
@@ -337,35 +380,35 @@ zh-TW:
     admin:
       tab:
         configuration: "設定"
-        option_types:
+        option_types: TODO_TRANSLATE
         orders: "訂單"
         overview: "總覽"
         products: "產品"
         promotions: "宣傳"
-        properties:
-        prototypes:
+        properties: TODO_TRANSLATE
+        prototypes: TODO_TRANSLATE
         reports: "報表"
-        taxonomies:
-        taxons:
+        taxonomies: TODO_TRANSLATE
+        taxons: TODO_TRANSLATE
         users: "使用者"
       user:
-        account:
-        addresses:
-        items:
-        items_purchased:
-        order_history:
-        order_num:
-        orders:
-        user_information:
+        account: TODO_TRANSLATE
+        addresses: TODO_TRANSLATE
+        items: TODO_TRANSLATE
+        items_purchased: TODO_TRANSLATE
+        order_history: TODO_TRANSLATE
+        order_num: TODO_TRANSLATE
+        orders: TODO_TRANSLATE
+        user_information: TODO_TRANSLATE
     administration: "管理介面"
-    advertise:
+    advertise: TODO_TRANSLATE
     agree_to_privacy_policy: "同意隱私條款"
     agree_to_terms_of_service: "同意服務條款"
     all: "全部"
     all_adjustments_closed: "所有調整項目已成功停用!"
     all_adjustments_opened: "所有調整項目已成功啓用!"
     all_departments: "所有部門"
-    all_items_have_been_returned:
+    all_items_have_been_returned: TODO_TRANSLATE
     allow_ssl_in_development_and_test: "允許在 Development / Test 模式下使用SSL"
     allow_ssl_in_production: "允許在 Production 模式下使用SSL"
     allow_ssl_in_staging: "允許在 Staging 模式下使用SSL"
@@ -375,76 +418,110 @@ zh-TW:
     amount: "金額"
     analytics_desc_header_1: Spree Analytics
     analytics_desc_header_2: "整合線上分析至您的Spree 控制台"
-    analytics_desc_list_1:
+    analytics_desc_list_1: TODO_TRANSLATE
     analytics_desc_list_2: "只需一個免費的Spree 帳號便能啓用"
     analytics_desc_list_3: "完全不需要插入程式碼"
     analytics_desc_list_4: "完全免費!"
     analytics_trackers: "分析追蹤"
     and: "以及"
+    api:
+      access: TODO_TRANSLATE
+      clear_key: TODO_TRANSLATE
+      generate_key: TODO_TRANSLATE
+      key: TODO_TRANSLATE
+      no_key: TODO_TRANSLATE
+      regenerate_key: TODO_TRANSLATE
     approve: "核准"
     approved_at: "核准日期"
     approver: "核准者"
     are_you_sure: "你確定嗎?"
     are_you_sure_delete: "你確定要刪除?"
     associated_adjustment_closed: "這個關聯的調整項目已經停用, 而且不會被重複計算, 您要啓用它嗎?"
+    attachment_default_style: TODO_TRANSLATE
+    attachment_default_url: TODO_TRANSLATE
+    attachment_path: TODO_TRANSLATE
+    attachment_styles: TODO_TRANSLATE
+    attachment_url: TODO_TRANSLATE
     authorization_failure: "認証失敗"
-    authorized:
-    auto_capture:
+    authorized: TODO_TRANSLATE
+    auto_capture: TODO_TRANSLATE
     available_on: "上架時間"
-    average_order_value:
-    avs_response:
+    average_order_value: TODO_TRANSLATE
+    avs_response: TODO_TRANSLATE
     back: "返回"
     back_end: "後端"
-    back_to_payment:
-    back_to_resource_list:
-    back_to_rma_reason_list:
+    back_to_adjustments_list: TODO_TRANSLATE
+    back_to_images_list: TODO_TRANSLATE
+    back_to_option_types_list: TODO_TRANSLATE
+    back_to_orders_list: TODO_TRANSLATE
+    back_to_payment: TODO_TRANSLATE
+    back_to_payment_methods_list: TODO_TRANSLATE
+    back_to_payments_list: TODO_TRANSLATE
+    back_to_products_list: TODO_TRANSLATE
+    back_to_promotions_list: TODO_TRANSLATE
+    back_to_properties_list: TODO_TRANSLATE
+    back_to_prototypes_list: TODO_TRANSLATE
+    back_to_reports_list: TODO_TRANSLATE
+    back_to_resource_list: TODO_TRANSLATE
+    back_to_rma_reason_list: TODO_TRANSLATE
+    back_to_shipping_categories: TODO_TRANSLATE
+    back_to_shipping_methods_list: TODO_TRANSLATE
+    back_to_states_list: TODO_TRANSLATE
+    back_to_stock_locations_list: TODO_TRANSLATE
+    back_to_stock_movements_list: TODO_TRANSLATE
+    back_to_stock_transfers_list: TODO_TRANSLATE
     back_to_store: "回商店"
+    back_to_tax_categories_list: TODO_TRANSLATE
+    back_to_taxonomies_list: TODO_TRANSLATE
+    back_to_trackers_list: TODO_TRANSLATE
     back_to_users_list: "返回使用者列表"
+    back_to_zones_list: TODO_TRANSLATE
+    backorder: TODO_TRANSLATE
     backorderable: "可預購"
-    backorderable_default:
+    backorderable_default: TODO_TRANSLATE
     backordered: "待補"
     backorders_allowed: "已允許預購"
     balance_due: "未入帳"
-    base_amount:
-    base_percent:
+    base_amount: TODO_TRANSLATE
+    base_percent: TODO_TRANSLATE
     bill_address: "帳單地址"
     billing: "帳單"
     billing_address: "帳單地址"
     both: "全部"
-    calculated_reimbursements:
+    calculated_reimbursements: TODO_TRANSLATE
     calculator: "計算規則"
     calculator_settings_warning: "如果你更改了計算規則, 需要先儲存才能進行修改"
     cancel: "取消"
-    canceled_at:
-    canceler:
-    cannot_create_customer_returns:
+    canceled_at: TODO_TRANSLATE
+    canceler: TODO_TRANSLATE
+    cannot_create_customer_returns: TODO_TRANSLATE
     cannot_create_payment_without_payment_methods: "你無法在未定義付費方法前產生訂單的付費資訊."
     cannot_create_returns: "無法建立退貨資訊, 因為這筆訂單不需要配送"
     cannot_perform_operation: "無法執行要求的運算"
     cannot_set_shipping_method_without_address: "在消費者細節沒提供前, 無法設定運送方法"
     capture: "入帳完成付款"
-    capture_events:
+    capture_events: TODO_TRANSLATE
     card_code: "信用卡驗證碼"
     card_number: "信用卡卡號"
-    card_type:
+    card_type: TODO_TRANSLATE
     card_type_is: "信用卡類型"
     cart: "購物車"
-    cart_subtotal:
+    cart_subtotal: TODO_TRANSLATE
     categories: "分類"
     category: "分類"
-    charged:
+    charged: TODO_TRANSLATE
     check_for_spree_alerts: "檢查 Spree的警告"
     checkout: "結帳"
     choose_a_customer: "選擇一個消費者"
-    choose_a_taxon_to_sort_products_for:
+    choose_a_taxon_to_sort_products_for: TODO_TRANSLATE
     choose_currency: "選擇幣別"
     choose_dashboard_locale: "選擇控制台語系"
-    choose_location:
+    choose_location: TODO_TRANSLATE
     city: "城市"
-    clear_cache:
-    clear_cache_ok:
-    clear_cache_warning:
-    click_and_drag_on_the_products_to_sort_them:
+    clear_cache: TODO_TRANSLATE
+    clear_cache_ok: TODO_TRANSLATE
+    clear_cache_warning: TODO_TRANSLATE
+    click_and_drag_on_the_products_to_sort_them: TODO_TRANSLATE
     clone: "複製"
     close: "關閉"
     close_all_adjustments: "停用所有調整項目"
@@ -453,6 +530,7 @@ zh-TW:
     complete: "完成"
     configuration: "偏好設定"
     configurations: "偏好設定"
+    configure_s3: TODO_TRANSLATE
     confirm: "確認"
     confirm_delete: "確認刪除"
     confirm_password: "確認密碼"
@@ -461,7 +539,7 @@ zh-TW:
     cost_currency: "成本貨幣"
     cost_price: "成本價格"
     could_not_connect_to_jirafe: "無法從 Jirafe同步資料, 稍候將自動重新嘗試."
-    could_not_create_customer_return:
+    could_not_create_customer_return: TODO_TRANSLATE
     could_not_create_stock_movement: "在儲存庫存動向時發生了錯誤, 請再試一次."
     count_on_hand: "庫存數量"
     countries: "國家"
@@ -469,10 +547,10 @@ zh-TW:
     country_based: "依據國家"
     country_name: "名稱"
     country_names:
-      CA:
-      FRA:
-      ITA:
-      US:
+      CA: TODO_TRANSLATE
+      FRA: TODO_TRANSLATE
+      ITA: TODO_TRANSLATE
+      US: TODO_TRANSLATE
     coupon: "促銷代碼"
     coupon_code: "促銷代碼"
     coupon_code_already_applied: "優惠代碼已經被使用在這個訂單"
@@ -482,17 +560,17 @@ zh-TW:
     coupon_code_max_usage: "已達優惠代碼使用上限"
     coupon_code_not_eligible: "此優惠代碼不適用於本訂單"
     coupon_code_not_found: "您輸入的優惠代碼不存在. 請再試一次."
-    coupon_code_unknown_error:
+    coupon_code_unknown_error: TODO_TRANSLATE
     create: "建立"
     create_a_new_account: "建立新帳號"
-    create_new_order:
-    create_reimbursement:
+    create_new_order: TODO_TRANSLATE
+    create_reimbursement: TODO_TRANSLATE
     created_at: "建立於"
     credit: "額度"
     credit_card: "信用卡"
     credit_cards: "信用卡"
     credit_owed: "負債"
-    credits:
+    credits: TODO_TRANSLATE
     currency: "幣別"
     currency_decimal_mark: "幣別小數點符號"
     currency_settings: "幣別設定"
@@ -503,11 +581,11 @@ zh-TW:
     customer: "客戶"
     customer_details: "客戶資料"
     customer_details_updated: "客戶資料更新完成"
-    customer_return:
-    customer_returns:
+    customer_return: TODO_TRANSLATE
+    customer_returns: TODO_TRANSLATE
     customer_search: "搜尋客戶"
     cut: "剪下"
-    cvv_response:
+    cvv_response: TODO_TRANSLATE
     dash:
       jirafe:
         app_id: App ID
@@ -526,41 +604,60 @@ zh-TW:
       js_format: yy/mm/dd
     date_range: "日期範圍"
     default: "預設"
-    default_refund_amount:
+    default_meta_description: TODO_TRANSLATE
+    default_meta_keywords: TODO_TRANSLATE
+    default_refund_amount: TODO_TRANSLATE
+    default_seo_title: TODO_TRANSLATE
     default_tax: "預設稅項"
     default_tax_zone: "預設稅區"
     delete: "刪除"
-    deleted_variants_present:
+    delete_from_taxon: TODO_TRANSLATE
+    deleted_variants_present: TODO_TRANSLATE
     delivery: "抵達"
     depth: "深"
     description: "描述"
     destination: "目的地"
     destroy: "刪除"
-    details:
+    details: TODO_TRANSLATE
     discount_amount: "折扣金額"
     dismiss_banner: "不。謝謝！我沒有興趣，不要再顯示此訊息。"
     display: "顯示"
     display_currency: "顯示貨幣"
-    doesnt_track_inventory:
+    doesnt_track_inventory: TODO_TRANSLATE
     edit: "編輯"
-    editing_resource:
-    editing_rma_reason:
+    editing_option_type: TODO_TRANSLATE
+    editing_payment_method: TODO_TRANSLATE
+    editing_product: TODO_TRANSLATE
+    editing_promotion: TODO_TRANSLATE
+    editing_property: TODO_TRANSLATE
+    editing_prototype: TODO_TRANSLATE
+    editing_resource: TODO_TRANSLATE
+    editing_rma_reason: TODO_TRANSLATE
+    editing_shipping_category: TODO_TRANSLATE
+    editing_shipping_method: TODO_TRANSLATE
+    editing_state: TODO_TRANSLATE
+    editing_stock_location: TODO_TRANSLATE
+    editing_stock_movement: TODO_TRANSLATE
+    editing_tax_category: TODO_TRANSLATE
+    editing_tax_rate: TODO_TRANSLATE
+    editing_tracker: TODO_TRANSLATE
     editing_user: "編輯使用者"
+    editing_zone: TODO_TRANSLATE
     eligibility_errors:
       messages:
-        has_excluded_product:
-        item_total_less_than:
-        item_total_less_than_or_equal:
-        item_total_more_than:
-        item_total_more_than_or_equal:
-        limit_once_per_user:
-        missing_product:
-        missing_taxon:
-        no_applicable_products:
-        no_matching_taxons:
-        no_user_or_email_specified:
-        no_user_specified:
-        not_first_order:
+        has_excluded_product: TODO_TRANSLATE
+        item_total_less_than: TODO_TRANSLATE
+        item_total_less_than_or_equal: TODO_TRANSLATE
+        item_total_more_than: TODO_TRANSLATE
+        item_total_more_than_or_equal: TODO_TRANSLATE
+        limit_once_per_user: TODO_TRANSLATE
+        missing_product: TODO_TRANSLATE
+        missing_taxon: TODO_TRANSLATE
+        no_applicable_products: TODO_TRANSLATE
+        no_matching_taxons: TODO_TRANSLATE
+        no_user_or_email_specified: TODO_TRANSLATE
+        no_user_specified: TODO_TRANSLATE
+        not_first_order: TODO_TRANSLATE
     email: Email
     empty: "空"
     empty_cart: "清空購物車"
@@ -593,28 +690,30 @@ zh-TW:
           signup: "使用者登記"
     exceptions:
       count_on_hand_setter: "無法手動設置 count_on_hand, 將會在 recalculate_count_on_hand 中被自動設定. 請使用 `update_column(:count_on_hand, value)`"
-    exchange_for:
-    excl:
-    existing_shipments:
-    expedited_exchanges_warning:
+    exchange_for: TODO_TRANSLATE
+    excl: TODO_TRANSLATE
+    existing_shipments: TODO_TRANSLATE
+    expedited_exchanges_warning: TODO_TRANSLATE
     expiration: "過期"
     extension: "擴展"
-    failed_payment_attempts:
+    failed_payment_attempts: TODO_TRANSLATE
     filename: "檔案名稱"
     fill_in_customer_info: "請填寫消費者資訊"
+    filter: TODO_TRANSLATE
     filter_results: "過濾結果"
     finalize: "完成"
-    finalized:
-    find_a_taxon:
+    finalized: TODO_TRANSLATE
+    find_a_taxon: TODO_TRANSLATE
     first_item: "第一項商品價格"
     first_name: "名"
     first_name_begins_with: "名字開始"
     flat_percent: "固定比例"
+    flat_rate_per_item: TODO_TRANSLATE
     flat_rate_per_order: "固定金額(單一訂單)"
     flexible_rate: "變動金額"
     forgot_password: "忘記密碼"
     free_shipping: "免運費"
-    free_shipping_amount:
+    free_shipping_amount: TODO_TRANSLATE
     front_end: "前端"
     gateway: Gateway
     gateway_config_unavailable: Gateway unavailable for environment
@@ -638,37 +737,41 @@ zh-TW:
       only_incomplete: "只限非完成"
       select_locale: "選擇語系"
       show_only: "只顯示"
+      store_translations: TODO_TRANSLATE
       supported_locales: "支援語系"
       this_file_language: "中文 (繁體)"
       translations: "翻譯"
     icon: "圖示"
-    identifier:
+    identifier: TODO_TRANSLATE
     image: "圖片"
+    image_settings: TODO_TRANSLATE
+    image_settings_updated: TODO_TRANSLATE
+    image_settings_warning: TODO_TRANSLATE
     images: "圖片"
-    implement_eligible_for_return:
-    implement_requires_manual_intervention:
-    inactive:
-    incl:
+    implement_eligible_for_return: TODO_TRANSLATE
+    implement_requires_manual_intervention: TODO_TRANSLATE
+    inactive: TODO_TRANSLATE
+    incl: TODO_TRANSLATE
     included_in_price: "已包括於售價"
     included_price_validation: "除非您設置了默認的繳稅區域，否則無法選擇"
-    incomplete:
-    info_number_of_skus_not_shown:
-    info_product_has_multiple_skus:
+    incomplete: TODO_TRANSLATE
+    info_number_of_skus_not_shown: TODO_TRANSLATE
+    info_product_has_multiple_skus: TODO_TRANSLATE
     instructions_to_reset_password: "請填寫如下表格來重置你的密碼，重置後的密碼會通過電子郵件發送給您"
     insufficient_stock: "庫存不足，當前還剩下 %{on_hand} 件庫存"
-    insufficient_stock_lines_present:
+    insufficient_stock_lines_present: TODO_TRANSLATE
     intercept_email_address: "攔截電郵地址"
     intercept_email_instructions: "更改電子郵件回函收件位址為這個位址"
     internal_name: "內部名稱"
-    invalid_credit_card:
-    invalid_exchange_variant:
+    invalid_credit_card: TODO_TRANSLATE
+    invalid_exchange_variant: TODO_TRANSLATE
     invalid_payment_provider: "不正確的付費供應商."
     invalid_promotion_action: "不正確的宣傳操作."
     invalid_promotion_rule: "不正確的宣傳規則."
     inventory: "庫存"
     inventory_adjustment: "庫存調整"
     inventory_error_flash_for_insufficient_quantity: "您購物車內的商品已無法使用."
-    inventory_state:
+    inventory_state: TODO_TRANSLATE
     is_not_available_to_shipment_address: "沒有可用的出貨地址"
     iso_name: ISO 名稱
     item: "商品"
@@ -678,26 +781,32 @@ zh-TW:
       operators:
         gt: "大於"
         gte: "大於等於"
-        lt:
-        lte:
+        lt: TODO_TRANSLATE
+        lte: TODO_TRANSLATE
     items_cannot_be_shipped: "我們無法遞送物品至您的運送地址. 請選擇其他運送位置."
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: TODO_TRANSLATE
+    items_reimbursed: TODO_TRANSLATE
+    items_to_be_reimbursed: TODO_TRANSLATE
     jirafe: Jirafe
     landing_page_rule:
       path: Path
     last_name: "姓"
     last_name_begins_with: "姓氏開頭"
     learn_more: Learn More
-    lifetime_stats:
-    line_item_adjustments:
+    lifetime_stats: TODO_TRANSLATE
+    line_item_adjustments: TODO_TRANSLATE
     list: "列表"
+    listing_countries: TODO_TRANSLATE
+    listing_orders: TODO_TRANSLATE
+    listing_products: TODO_TRANSLATE
+    listing_reports: TODO_TRANSLATE
+    listing_tax_categories: TODO_TRANSLATE
+    listing_users: TODO_TRANSLATE
     loading: "載入中"
     locale_changed: "語系已變更"
     location: "位置"
     lock: "鎖定"
-    log_entries:
+    log_entries: TODO_TRANSLATE
     logged_in_as: "目前帳號"
     logged_in_succesfully: "登入成功"
     logged_out: "你已經完成登出"
@@ -706,23 +815,26 @@ zh-TW:
     login_failed: "登入認証失敗"
     login_name: "使用者名稱"
     logout: "登出"
-    logs:
+    logs: TODO_TRANSLATE
     look_for_similar_items: "瀏覽相似的商品"
+    maestro_or_solo_cards: TODO_TRANSLATE
+    mail_method_settings: TODO_TRANSLATE
+    mail_methods: TODO_TRANSLATE
     make_refund: "退款"
-    make_sure_the_above_reimbursement_amount_is_correct:
-    manage_promotion_categories:
-    manage_variants:
-    manual_intervention_required:
+    make_sure_the_above_reimbursement_amount_is_correct: TODO_TRANSLATE
+    manage_promotion_categories: TODO_TRANSLATE
+    manage_variants: TODO_TRANSLATE
+    manual_intervention_required: TODO_TRANSLATE
     master_price: "主要定價"
     match_choices:
       all: "全部"
       none: "清空"
-    max_items:
-    member_since:
-    memo:
+    max_items: TODO_TRANSLATE
+    member_since: TODO_TRANSLATE
+    memo: TODO_TRANSLATE
     meta_description: Meta 描述
     meta_keywords: Meta 關鍵字
-    meta_title:
+    meta_title: TODO_TRANSLATE
     metadata: Metadata
     minimal_amount: "最小個數"
     month: "月"
@@ -731,13 +843,13 @@ zh-TW:
     my_account: "我的帳戶"
     my_orders: "我的訂單"
     name: "名稱"
-    name_on_card:
+    name_on_card: TODO_TRANSLATE
     name_or_sku: "商品名稱或編號"
     new: "新增"
     new_adjustment: "新增訂單項目"
-    new_country:
+    new_country: TODO_TRANSLATE
     new_customer: "新增客戶"
-    new_customer_return:
+    new_customer_return: TODO_TRANSLATE
     new_image: "新增圖片"
     new_option_type: "新增商品選項類型"
     new_order: "新增訂單"
@@ -746,14 +858,15 @@ zh-TW:
     new_payment_method: "新增付費方式"
     new_product: "新增商品"
     new_promotion: "新增優惠推廣"
-    new_promotion_category:
+    new_promotion_category: TODO_TRANSLATE
     new_property: "新增商品屬性"
     new_prototype: "新增商品原型"
-    new_refund:
-    new_refund_reason:
+    new_refund: TODO_TRANSLATE
+    new_refund_reason: TODO_TRANSLATE
     new_return_authorization: "新增退貨資料"
-    new_rma_reason:
-    new_shipment_at_location:
+    new_rma_reason: TODO_TRANSLATE
+    new_role: TODO_TRANSLATE
+    new_shipment_at_location: TODO_TRANSLATE
     new_shipping_category: "新增出貨類型"
     new_shipping_method: "新增出貨方式"
     new_state: "新增省份"
@@ -764,30 +877,36 @@ zh-TW:
     new_tax_rate: "新增稅���"
     new_taxon: "新增分類"
     new_taxonomy: "新增分類"
-    new_tracker:
+    new_tracker: TODO_TRANSLATE
     new_user: "新增使用者"
     new_variant: "新增款式系列"
     new_zone: "新增區域"
     next: "下一頁"
-    no_actions_added:
-    no_payment_found:
-    no_pending_payments:
+    no_actions_added: TODO_TRANSLATE
+    no_orders_found: TODO_TRANSLATE
+    no_payment_found: TODO_TRANSLATE
+    no_payment_methods_found: TODO_TRANSLATE
+    no_pending_payments: TODO_TRANSLATE
     no_products_found: "找不到商品"
-    no_resource_found:
+    no_promotions_found: TODO_TRANSLATE
+    no_resource_found: TODO_TRANSLATE
     no_results: "沒有結果"
-    no_returns_found:
+    no_returns_found: TODO_TRANSLATE
     no_rules_added: No rules added
-    no_shipping_method_selected:
-    no_state_changes:
-    no_tracking_present:
+    no_shipping_method_selected: TODO_TRANSLATE
+    no_shipping_methods_found: TODO_TRANSLATE
+    no_state_changes: TODO_TRANSLATE
+    no_stock_locations_found: TODO_TRANSLATE
+    no_trackers_found: TODO_TRANSLATE
+    no_tracking_present: TODO_TRANSLATE
     none: "沒有"
-    none_selected:
+    none_selected: TODO_TRANSLATE
     normal_amount: "一般數量"
     not: "不"
     not_available: N/A
     not_enough_stock: "來源地沒有足夠的庫存以完成遞送."
     not_found: "%{resource} is not found"
-    note:
+    note: TODO_TRANSLATE
     notice_messages:
       product_cloned: "商品已經被覆制"
       product_deleted: "商品已經被刪除"
@@ -795,47 +914,52 @@ zh-TW:
       product_not_deleted: "商品無法被刪除"
       variant_deleted: "具體型號已經被刪除"
       variant_not_deleted: "具體型號不能被刪除"
-    num_orders:
+    num_orders: TODO_TRANSLATE
     on_hand: "庫存"
-    open:
+    open: TODO_TRANSLATE
     open_all_adjustments: "啟用所有價格調整"
     option_type: "商品選項類型"
-    option_type_placeholder:
+    option_type_placeholder: TODO_TRANSLATE
     option_types: "商品選項類型"
     option_value: "商品選項"
     option_values: "商品選項"
-    optional:
+    optional: TODO_TRANSLATE
     options: "選項"
     or: "或"
     or_over_price: "%{price} 或以上"
     order: "訂單"
     order_adjustments: "訂單調整"
-    order_already_updated:
-    order_approved:
-    order_canceled:
+    order_already_updated: TODO_TRANSLATE
+    order_approved: TODO_TRANSLATE
+    order_canceled: TODO_TRANSLATE
     order_details: "訂單資料"
     order_email_resent: "重新發送了訂單郵件"
     order_information: "訂單資訊"
+    order_line_items: TODO_TRANSLATE
     order_mailer:
       cancel_email:
         dear_customer: "親愛的顧客，"
         instructions: "您的訂單已被取消。請保留此取消信息記錄。"
         order_summary_canceled: "訂單總覽 [已取消]"
         subject: "註銷訂單"
-        subtotal:
-        total:
+        subtotal: TODO_TRANSLATE
+        total: TODO_TRANSLATE
       confirm_email:
         dear_customer: "親愛的顧客，"
         instructions: "請仔細閱讀並保留以下訂單信息記錄。"
         order_summary: "訂單總覽"
         subject: "訂單確認"
-        subtotal:
+        subtotal: TODO_TRANSLATE
         thanks: "謝謝你的購物和信賴。"
-        total:
+        total: TODO_TRANSLATE
     order_not_found: "找不到您的訂單. 請再試一次."
     order_number: "訂單編號 %{number}"
+    order_populator:
+      out_of_stock: TODO_TRANSLATE
+      please_enter_reasonable_quantity: TODO_TRANSLATE
+      selected_quantity_not_available: TODO_TRANSLATE
     order_processed_successfully: "您的訂單已被接收"
-    order_resumed:
+    order_resumed: TODO_TRANSLATE
     order_state:
       address: "地址"
       awaiting_return: "等待寄回"
@@ -843,7 +967,7 @@ zh-TW:
       cart: "購物車"
       complete: "完成"
       confirm: "確認"
-      considered_risky:
+      considered_risky: TODO_TRANSLATE
       delivery: "寄送方式"
       payment: "付款"
       resumed: "重新開始"
@@ -853,12 +977,14 @@ zh-TW:
     order_total: "總金額"
     order_updated: "訂單已更新"
     orders: "訂單"
-    other_items_in_other:
+    other_items_in_other: TODO_TRANSLATE
     out_of_stock: "缺貨中"
     overview: "總覽"
     package_from: "包裝自"
     pagination:
+      first: TODO_TRANSLATE
       next_page: "下一頁 »"
+      previous: TODO_TRANSLATE
       previous_page: "« 上一頁"
       truncate: "…"
     password: "密碼"
@@ -866,13 +992,13 @@ zh-TW:
     path: "路徑"
     pay: "付款"
     payment: "付款"
-    payment_could_not_be_created:
-    payment_identifier:
+    payment_could_not_be_created: TODO_TRANSLATE
+    payment_identifier: TODO_TRANSLATE
     payment_information: "付費資訊"
     payment_method: "付費方式"
-    payment_method_not_supported:
+    payment_method_not_supported: TODO_TRANSLATE
     payment_methods: "付費方式"
-    payment_processing_failed:
+    payment_processing_failed: TODO_TRANSLATE
     payment_processor_choose_banner_text: "如果您需要關於支付處理的幫助，請訪問"
     payment_processor_choose_link: "我們的支付頁面"
     payment_state: "付費狀態"
@@ -880,7 +1006,7 @@ zh-TW:
       balance_due: "未入帳"
       checkout: "付款"
       completed: "已完成"
-      credit_owed:
+      credit_owed: TODO_TRANSLATE
       failed: "失敗"
       paid: "已付費"
       pending: "擱置"
@@ -888,22 +1014,23 @@ zh-TW:
       void: "無效"
     payment_updated: "付費資料已更新"
     payments: "付費資料"
-    pending:
+    pending: TODO_TRANSLATE
     percent: "百分比"
     percent_per_item: "單件百分比"
     permalink: "永久連結"
     phone: "電話"
     place_order: "落單"
     please_define_payment_methods: "請先設定支付方式。"
+    please_enter_reasonable_quantity: TODO_TRANSLATE
     populate_get_error: "發生錯誤，請再添加項目。"
     powered_by: "技術支持"
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
-    preferred_reimbursement_type:
+    pre_tax_amount: TODO_TRANSLATE
+    pre_tax_refund_amount: TODO_TRANSLATE
+    pre_tax_total: TODO_TRANSLATE
+    preferred_reimbursement_type: TODO_TRANSLATE
     presentation: "描述"
     previous: "上一個"
-    previous_state_missing:
+    previous_state_missing: TODO_TRANSLATE
     price: "價格"
     price_range: "價格範圍"
     price_sack: "袋價格"
@@ -915,10 +1042,10 @@ zh-TW:
     product_properties: "商品屬性"
     product_rule:
       choose_products: "選擇產品"
-      label:
+      label: TODO_TRANSLATE
       match_all: "全部"
       match_any: "最新一個"
-      match_none:
+      match_none: TODO_TRANSLATE
       product_source:
         group: "從產品分組"
         manual: "手動選擇"
@@ -938,11 +1065,16 @@ zh-TW:
       free_shipping:
         description: "整張訂單免費發貨"
         name: "免運費"
+      give_store_credit:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
     promotion_actions: "優惠方式"
+    promotion_category: TODO_TRANSLATE
     promotion_form:
       match_policies:
         all: "符合所有條件"
         any: "符合任一條件"
+    promotion_label: TODO_TRANSLATE
     promotion_rule: "促銷規則"
     promotion_rule_types:
       first_order:
@@ -958,8 +1090,8 @@ zh-TW:
         description: "每人只可使用一次"
         name: "每人一次"
       option_value:
-        description:
-        name:
+        description: TODO_TRANSLATE
+        name: TODO_TRANSLATE
       product:
         description: "訂單中包含特定商品"
         name: "商品"
@@ -973,9 +1105,9 @@ zh-TW:
         description: "網站已註冊的使用者"
         name: "已註冊使用者登入"
     promotion_uses: "促銷使用頻率"
-    promotionable:
+    promotionable: TODO_TRANSLATE
     promotions: "優惠推廣"
-    propagate_all_variants:
+    propagate_all_variants: TODO_TRANSLATE
     properties: "屬性"
     property: "屬性"
     prototype: "原型"
@@ -986,47 +1118,49 @@ zh-TW:
     quantity: "數量"
     quantity_returned: "退貨數量"
     quantity_shipped: "出貨數量"
-    quick_search:
+    quick_search: TODO_TRANSLATE
     rate: "費率"
     reason: "理由"
     receive: "收到"
     receive_stock: "接收存貨"
     received: "已收到"
-    reception_status:
+    reception_status: TODO_TRANSLATE
     reference: "參考"
+    reference_contains: TODO_TRANSLATE
     refund: "退款"
-    refund_amount_must_be_greater_than_zero:
-    refund_reasons:
-    refunded_amount:
-    refunds:
+    refund_amount_must_be_greater_than_zero: TODO_TRANSLATE
+    refund_reasons: TODO_TRANSLATE
+    refunded_amount: TODO_TRANSLATE
+    refunds: TODO_TRANSLATE
     register: "註冊新用戶"
     registration: "註冊"
-    reimburse:
-    reimbursed:
-    reimbursement:
+    reimburse: TODO_TRANSLATE
+    reimbursed: TODO_TRANSLATE
+    reimbursement: TODO_TRANSLATE
     reimbursement_mailer:
       reimbursement_email:
-        days_to_send:
-        dear_customer:
-        exchange_summary:
-        for:
-        instructions:
-        refund_summary:
-        subject:
-        total_refunded:
-    reimbursement_perform_failed:
-    reimbursement_status:
-    reimbursement_type:
-    reimbursement_type_override:
-    reimbursement_types:
-    reimbursements:
-    reject:
-    rejected:
+        days_to_send: TODO_TRANSLATE
+        dear_customer: TODO_TRANSLATE
+        exchange_summary: TODO_TRANSLATE
+        for: TODO_TRANSLATE
+        instructions: TODO_TRANSLATE
+        refund_summary: TODO_TRANSLATE
+        subject: TODO_TRANSLATE
+        total_refunded: TODO_TRANSLATE
+    reimbursement_perform_failed: TODO_TRANSLATE
+    reimbursement_status: TODO_TRANSLATE
+    reimbursement_type: TODO_TRANSLATE
+    reimbursement_type_override: TODO_TRANSLATE
+    reimbursement_types: TODO_TRANSLATE
+    reimbursements: TODO_TRANSLATE
+    reject: TODO_TRANSLATE
+    rejected: TODO_TRANSLATE
     remember_me: "記住我"
     remove: "移除"
     rename: Rename
-    report:
+    report: TODO_TRANSLATE
     reports: "報告"
+    resellable: TODO_TRANSLATE
     resend: "重寄"
     reset_password: "重設密碼"
     response_code: "回應代碼"
@@ -1034,34 +1168,41 @@ zh-TW:
     resumed: "已恢復"
     return: "退回"
     return_authorization: "退貨資料"
-    return_authorization_reasons:
+    return_authorization_reasons: TODO_TRANSLATE
     return_authorization_updated: "退貨資料已更新"
     return_authorizations: "退貨資料"
-    return_item_inventory_unit_ineligible:
-    return_item_inventory_unit_reimbursed:
-    return_item_rma_ineligible:
-    return_item_time_period_ineligible:
-    return_items:
-    return_items_cannot_be_associated_with_multiple_orders:
-    return_number:
+    return_item_inventory_unit_ineligible: TODO_TRANSLATE
+    return_item_inventory_unit_reimbursed: TODO_TRANSLATE
+    return_item_order_not_completed: TODO_TRANSLATE
+    return_item_rma_ineligible: TODO_TRANSLATE
+    return_item_time_period_ineligible: TODO_TRANSLATE
+    return_items: TODO_TRANSLATE
+    return_items_cannot_be_associated_with_multiple_orders: TODO_TRANSLATE
+    return_number: TODO_TRANSLATE
     return_quantity: "退貨數量"
     returned: "已退回"
-    returns:
+    returns: TODO_TRANSLATE
     review: Review
-    risk:
-    risk_analysis:
-    risky:
+    risk: TODO_TRANSLATE
+    risk_analysis: TODO_TRANSLATE
+    risky: TODO_TRANSLATE
     rma_credit: RMA 額度
     rma_number: RMA 數字
     rma_value: RMA 值
+    role_id: TODO_TRANSLATE
     roles: "角色"
     rules: "規則"
-    safe:
-    sales_total:
-    sales_total_description:
-    sales_totals:
+    s3_access_key: TODO_TRANSLATE
+    s3_bucket: TODO_TRANSLATE
+    s3_headers: TODO_TRANSLATE
+    s3_protocol: TODO_TRANSLATE
+    s3_secret: TODO_TRANSLATE
+    safe: TODO_TRANSLATE
+    sales_total: TODO_TRANSLATE
+    sales_total_description: TODO_TRANSLATE
+    sales_totals: TODO_TRANSLATE
     save_and_continue: "儲存後繼續"
-    save_my_address:
+    save_my_address: TODO_TRANSLATE
     say_no: "不"
     say_yes: "是的"
     scope: "範圍"
@@ -1071,10 +1212,11 @@ zh-TW:
     secure_connection_type: "安全連線類型"
     security_settings: "安全設定"
     select: "選擇"
-    select_a_return_authorization_reason:
-    select_a_stock_location:
+    select_a_return_authorization_reason: TODO_TRANSLATE
+    select_a_stock_location: TODO_TRANSLATE
     select_from_prototype: "從商品原型選擇"
     select_stock: "選擇庫存"
+    selected_quantity_not_available: TODO_TRANSLATE
     send_copy_of_all_mails_to: "將所有郵件的副本發送至"
     send_mails_as: "發送郵件作為"
     server: "伺服器"
@@ -1082,10 +1224,11 @@ zh-TW:
     settings: "設定"
     ship: "出貨"
     ship_address: "出貨地址"
-    ship_total:
+    ship_total: TODO_TRANSLATE
     shipment: "出貨資料"
-    shipment_adjustments:
-    shipment_details:
+    shipment_adjustments: TODO_TRANSLATE
+    shipment_details: TODO_TRANSLATE
+    shipment_inc_vat: TODO_TRANSLATE
     shipment_mailer:
       shipped_email:
         dear_customer: "親愛的顧客，"
@@ -1098,13 +1241,13 @@ zh-TW:
     shipment_state: "出貨狀態"
     shipment_states:
       backorder: "預購"
-      canceled:
+      canceled: TODO_TRANSLATE
       partial: "部份出貨"
       pending: "擱置"
       ready: "準備出貨"
       shipped: "已出貨"
-    shipment_transfer_error:
-    shipment_transfer_success:
+    shipment_transfer_error: TODO_TRANSLATE
+    shipment_transfer_success: TODO_TRANSLATE
     shipments: "出貨資料"
     shipped: "已寄出"
     shipping: "運費"
@@ -1117,68 +1260,84 @@ zh-TW:
     shipping_instructions: "配送嚮導"
     shipping_method: "出貨方式"
     shipping_methods: "出貨方式"
-    shipping_price_sack:
-    shipping_total:
+    shipping_price_sack: TODO_TRANSLATE
+    shipping_rates:
+      display_price:
+        excluding_tax: TODO_TRANSLATE
+        including_tax: TODO_TRANSLATE
+    shipping_total: TODO_TRANSLATE
     shop_by_taxonomy: "依照%{taxonomy}排序"
     shopping_cart: "購物車"
     show: "顯示"
     show_active: "顯示使用中的資料"
     show_deleted: "顯示被刪除的資料"
     show_only_complete_orders: "顯示已完成的訂單"
-    show_only_considered_risky:
-    show_rate_in_label:
+    show_only_considered_risky: TODO_TRANSLATE
+    show_rate_in_label: TODO_TRANSLATE
     sku: "商品編號"
-    skus:
-    slug:
+    skus: TODO_TRANSLATE
+    slug: TODO_TRANSLATE
+    smtp: TODO_TRANSLATE
+    smtp_authentication_type: TODO_TRANSLATE
+    smtp_domain: TODO_TRANSLATE
+    smtp_mail_host: TODO_TRANSLATE
+    smtp_password: TODO_TRANSLATE
+    smtp_port: TODO_TRANSLATE
+    smtp_send_all_emails_as_from_following_address: TODO_TRANSLATE
+    smtp_send_copy_to_this_addresses: TODO_TRANSLATE
+    smtp_username: TODO_TRANSLATE
     source: "來源"
     special_instructions: "特殊說明"
     split: "分拆"
+    spree/order:
+      coupon_code: TODO_TRANSLATE
     spree_gateway_error_flash_for_checkout: "你的付費資訊有問題. 請檢查後再試一次."
     ssl:
-      change_protocol:
+      change_protocol: TODO_TRANSLATE
     start: "開始"
+    start_date: TODO_TRANSLATE
     state: "省份"
     state_based: "依據省份"
     state_machine_states:
-      accepted:
-      address:
-      authorized:
-      awaiting:
-      awaiting_return:
-      backordered:
-      canceled:
-      cart:
-      checkout:
-      closed:
-      complete:
-      completed:
-      confirm:
-      delivery:
-      errored:
-      failed:
-      given_to_customer:
-      invalid:
-      manual_intervention_required:
-      on_hand:
-      open:
-      order:
-      payment:
-      pending:
-      processing:
-      ready:
-      reimbursed:
-      resumed:
-      returned:
-      shipped:
-      void:
+      accepted: TODO_TRANSLATE
+      address: TODO_TRANSLATE
+      authorized: TODO_TRANSLATE
+      awaiting: TODO_TRANSLATE
+      awaiting_return: TODO_TRANSLATE
+      backordered: TODO_TRANSLATE
+      canceled: TODO_TRANSLATE
+      cart: TODO_TRANSLATE
+      checkout: TODO_TRANSLATE
+      closed: TODO_TRANSLATE
+      complete: TODO_TRANSLATE
+      completed: TODO_TRANSLATE
+      confirm: TODO_TRANSLATE
+      delivery: TODO_TRANSLATE
+      errored: TODO_TRANSLATE
+      failed: TODO_TRANSLATE
+      given_to_customer: TODO_TRANSLATE
+      invalid: TODO_TRANSLATE
+      manual_intervention_required: TODO_TRANSLATE
+      on_hand: TODO_TRANSLATE
+      open: TODO_TRANSLATE
+      order: TODO_TRANSLATE
+      payment: TODO_TRANSLATE
+      pending: TODO_TRANSLATE
+      processing: TODO_TRANSLATE
+      ready: TODO_TRANSLATE
+      reimbursed: TODO_TRANSLATE
+      resumed: TODO_TRANSLATE
+      returned: TODO_TRANSLATE
+      shipped: TODO_TRANSLATE
+      void: TODO_TRANSLATE
     states: "省份"
     states_required: "需要州別"
     status: "狀態"
-    stock:
+    stock: TODO_TRANSLATE
     stock_location: "庫存區域"
     stock_location_info: "庫存區域資訊"
     stock_locations: "庫存區域"
-    stock_locations_need_a_default_country:
+    stock_locations_need_a_default_country: TODO_TRANSLATE
     stock_management: "庫存管理"
     stock_management_requires_a_stock_location: "請先新增庫存區域，才可使用庫存管理"
     stock_movements: "庫存動向"
@@ -1192,28 +1351,30 @@ zh-TW:
     street_address_2: "地址(繼續)"
     subtotal: "小計"
     subtract: "減去"
-    success:
+    success: TODO_TRANSLATE
     successfully_created: "建立%{resource}成功！"
-    successfully_refunded:
+    successfully_refunded: TODO_TRANSLATE
     successfully_removed: "刪除%{resource}成功！"
-    successfully_signed_up_for_analytics:
+    successfully_signed_up_for_analytics: TODO_TRANSLATE
     successfully_updated: "更新%{resource}成功！"
-    summary:
+    summary: TODO_TRANSLATE
     tax: "稅"
     tax_categories: "課稅類別"
     tax_category: "課稅類別"
-    tax_code:
-    tax_included:
-    tax_rate_amount_explanation:
+    tax_code: TODO_TRANSLATE
+    tax_included: TODO_TRANSLATE
+    tax_rate_amount_explanation: TODO_TRANSLATE
     tax_rates: "稅率"
+    tax_settings: TODO_TRANSLATE
+    tax_total: TODO_TRANSLATE
     taxon: "分類"
     taxon_edit: "編輯分類"
-    taxon_placeholder:
+    taxon_placeholder: TODO_TRANSLATE
     taxon_rule:
-      choose_taxons:
-      label:
-      match_all:
-      match_any:
+      choose_taxons: TODO_TRANSLATE
+      label: TODO_TRANSLATE
+      match_all: TODO_TRANSLATE
+      match_any: TODO_TRANSLATE
     taxonomies: "分類"
     taxonomy: Taxonomy
     taxonomy_edit: "編輯分類"
@@ -1222,50 +1383,55 @@ zh-TW:
     taxons: "分類"
     test: "測試"
     test_mailer:
+      greeting: TODO_TRANSLATE
+      message: TODO_TRANSLATE
+      subject: TODO_TRANSLATE
       test_email:
         greeting: Congratulations!
         message: If you have received this email, then your email settings are correct.
         subject: Testmail
     test_mode: "測試模式"
-    thank_you_for_your_order:
-    there_are_no_items_for_this_order:
-    there_were_problems_with_the_following_fields:
-    this_order_has_already_received_a_refund:
+    thank_you_for_your_order: TODO_TRANSLATE
+    there_are_no_items_for_this_order: TODO_TRANSLATE
+    there_were_problems_with_the_following_fields: TODO_TRANSLATE
+    this_order_has_already_received_a_refund: TODO_TRANSLATE
     thumbnail: "縮圖"
-    tiered_flat_rate:
-    tiered_percent:
-    tiers:
+    tiered_flat_rate: TODO_TRANSLATE
+    tiered_percent: TODO_TRANSLATE
+    tiers: TODO_TRANSLATE
     time: "時間"
-    to_add_variants_you_must_first_define:
+    to_add_variants_you_must_first_define: TODO_TRANSLATE
     total: "總金額"
-    total_per_item:
-    total_pre_tax_refund:
-    total_price:
-    total_sales:
-    track_inventory:
+    total_per_item: TODO_TRANSLATE
+    total_pre_tax_refund: TODO_TRANSLATE
+    total_price: TODO_TRANSLATE
+    total_sales: TODO_TRANSLATE
+    track_inventory: TODO_TRANSLATE
     tracking: "物流追蹤碼"
     tracking_number: "追蹤號碼"
     tracking_url: "追蹤網址"
     tracking_url_placeholder: "例如: http://quickship.com/package?num=:tracking"
-    transaction_id:
-    transfer_from_location:
-    transfer_stock:
-    transfer_to_location:
+    transaction_id: TODO_TRANSLATE
+    transfer_from_location: TODO_TRANSLATE
+    transfer_stock: TODO_TRANSLATE
+    transfer_to_location: TODO_TRANSLATE
     tree: "樹"
     type: "類型"
     type_to_search: "輸入搜尋關鍵字"
     unable_to_connect_to_gateway: "無法連上 gateway"
-    unable_to_create_reimbursements:
+    unable_to_create_reimbursements: TODO_TRANSLATE
     under_price: Under %{price}
     unlock: "解鎖"
     unrecognized_card_type: "無法辨識的信用卡類別"
-    unshippable_items:
+    unshippable_items: TODO_TRANSLATE
     update: "更新"
     updating: "更新中"
     usage_limit: "使用次數限制"
-    use_app_default:
+    use_app_default: TODO_TRANSLATE
     use_billing_address: "使用帳單地址"
+    use_existing_cc: TODO_TRANSLATE
     use_new_cc: "使用新卡"
+    use_new_cc_or_payment_method: TODO_TRANSLATE
     use_s3: Use Amazon S3 For Images
     user: "使用者"
     user_rule:
@@ -1273,12 +1439,13 @@ zh-TW:
     users: "使用者"
     validation:
       cannot_be_less_than_shipped_units: "不能少於已配送的單位數。"
-      cannot_destroy_line_item_as_inventory_units_have_shipped:
+      cannot_destory_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
+      cannot_destroy_line_item_as_inventory_units_have_shipped: TODO_TRANSLATE
       exceeds_available_stock: "超出可用的庫存。請確認訂單項的有效的數量。"
       is_too_large: "數量太多了，現有庫存無法滿足您需要的數量！"
       must_be_int: "必須是整數"
       must_be_non_negative: "必須為非負數"
-      unpaid_amount_not_zero:
+      unpaid_amount_not_zero: TODO_TRANSLATE
     value: "值"
     variant: "具體型號"
     variant_placeholder: "選擇具体型号"
@@ -1297,3 +1464,10 @@ zh-TW:
     zipcode: "區域代碼"
     zone: "區域"
     zones: "區域"
+  update: TODO_TRANSLATE
+  views:
+    pagination:
+      first: TODO_TRANSLATE
+      last: TODO_TRANSLATE
+      next: TODO_TRANSLATE
+      previous: TODO_TRANSLATE

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,11 @@
+require 'i18n/tasks'
+
+describe 'I18n' do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+
+  it 'does not have missing keys' do
+    expect(missing_keys).to be_empty,
+      "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+end

--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'spree_core', '~> 3.0.0'
 
   s.add_development_dependency 'byebug'
+  s.add_development_dependency 'i18n-tasks', '~> 0.8.3'
   s.add_development_dependency 'capybara', '~> 2.4.4'
   s.add_development_dependency 'coffee-rails', '~> 4.0.0'
   s.add_development_dependency 'database_cleaner', '~> 1.3.0'


### PR DESCRIPTION
Spree has a lot of missing translations and its hard to support all these languages at once.

The ` i18n-task & i18n-spec` tries to num the pain and make these translations files consistent towards the future.

Newly added translations would have to be added to all translation files.
But this is where the task `i18n-task` comes in.

```
i18n-tasks add-missing # Generates future missing key-value pairs in all files
or
i18n-tasks add-missing --value 'TODO_TRANSLATE'
```

This command will generate placeholder values based on default locale which I've set on `en-GB`.
Which could then easily be found and translated by people native to the language they want to support.

