### PR TITLE
Added missing translations

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -554,8 +554,9 @@ pt-BR:
     coupon_code_unknown_error:
     create: Criar
     create_a_new_account: Criar uma Nova Conta
+    create_new_account: "Criar Nova Conta"
     create_new_order: Criar novo pedido
-    create_reimbursement:
+    create_reimbursement: Criar reembolso
     created_at: Criado
     credit: Crédito
     credit_card: Cartão de Crédito


### PR DESCRIPTION
This translation is used when the user is not signed in yet, but tries to checkout. Not to be mistaken for *create_a_new_account* translation, since this is used on another view. Fixed *create_reimbursement* translation, because it was empty.