### PR TITLE
Fixes the translation used in AvailabilityValidator

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -835,7 +835,6 @@ pt-BR:
     order_number: 'Número do Pedido %{number}'
     order_populator:
       out_of_stock: ! '%{item} está fora de estoque.'
-      selected_quantity_not_available: ! 'A quantidade selecionada do %{item} não está disponível.'
       please_enter_reasonable_quantity: Por favor insira uma quantia válida.
     order_processed_successfully: Seu pedido foi processado com sucesso.
     order_state:
@@ -1020,6 +1019,7 @@ pt-BR:
     select: Selecionar
     select_from_prototype: Selecionar a partir de protótipo
     select_stock: Selecione estoque
+    selected_quantity_not_available: ! 'A quantidade selecionada do %{item} não está disponível.'
     send_copy_of_all_mails_to: Enviar cópias de todos emails para
     send_mails_as: Enviar email como
     server: Servidor


### PR DESCRIPTION
The translate of selected_quantity_not_available probably was moved from order_populator.
On the **en.yml** the translate is move out of **order_populator**. 

See the search that I did https://github.com/spree/spree/search?utf8=%E2%9C%93&q=selected_quantity_not_available