### PR TITLE
3-0-stable ransack and translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'spree', github: 'spree/spree', branch: '3-0-stable'
+gem 'rails', github: 'rails/rails', branch: '4-2-stable'
 
 gemspec

--- a/app/models/spree_i18n/translatable.rb
+++ b/app/models/spree_i18n/translatable.rb
@@ -4,5 +4,22 @@ module SpreeI18n
     included do
       accepts_nested_attributes_for :translations
     end
+
+    class_methods do
+      def ransack(params = {}, options = {})
+        names = params.keys
+
+        names.each do |n|
+          translated_attribute_names.each do |t|
+            if n.to_s.starts_with? t.to_s
+              params[:"translations_#{n}"] = params[n]
+              params.delete n
+            end
+          end
+        end
+
+        super(params, options)
+      end
+    end
   end
 end

--- a/app/models/spree_i18n/translatable.rb
+++ b/app/models/spree_i18n/translatable.rb
@@ -20,6 +20,7 @@ module SpreeI18n
 
         super(params, options)
       end
+      alias :search :ransack unless respond_to? :search
     end
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -22,6 +22,9 @@ module Spree
     it "handle translation in ransack" do
       result = described_class.ransack(name_cont: product.name[0..2]).result
       expect(result.first).to eq product
+
+      result = described_class.search(name_cont: product.name[0..2]).result
+      expect(result.first).to eq product
     end
 
     # Regression tests for #466

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -19,6 +19,11 @@ module Spree
       expect(product.taxons).to include(taxon)
     end
 
+    it "handle translation in ransack" do
+      result = described_class.ransack(name_cont: product.name[0..2]).result
+      expect(result.first).to eq product
+    end
+
     # Regression tests for #466
     describe ".like_any" do
       context "allow searching products through their translations" do

--- a/spec/models/variant_spec.rb
+++ b/spec/models/variant_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+module Spree
+  RSpec.describe Variant do
+    let(:product) do
+      Product.create!(
+        name: 'globalize',
+        price: 19.99,
+        shipping_category: ShippingCategory.create!(name: 'a')
+      )
+    end
+
+    let!(:variant) do
+      Variant.create!(
+        price: 19.99,
+        product: product
+      )
+    end
+
+    it 'fetches variant from product via translation table' do
+      product_relation = Product.where(name: "globalize")
+      variant_relation = described_class.joins(:product).merge(product_relation)
+      described_class.includes(:product).ransack(name_cont: 'globalize').result.to_a
+
+      expect(variant_relation.last).to eq variant
+
+      variants = described_class.includes(:product).ransack(name_cont: 'globalize').result.to_a
+      expect(variants.last).to eq variant
+    end
+  end
+end


### PR DESCRIPTION
This is https://github.com/spree-contrib/spree_i18n/pull/532 for 3-0-stable. Pointint to 4-2-stable here because the fix will only be released on 4.2.4.