### PR TITLE
Corrected the "back_end" entry on pt-BR translation

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -463,7 +463,7 @@ pt-BR:
     average_order_value: Média de valor por compra
     avs_response: Resposta do AVS
     back: Voltar
-    back_end: Voltar e
+    back_end: Back End
     back_to_payment: Voltar para lista de Pagamentos
     back_to_resource_list: "Voltar para lista de %{resource}"
     back_to_rma_reason_list:


### PR DESCRIPTION
It was previously a literal translation ("Voltar e") I updated to match the same translation of the front_end entry, so it reads now "Back End" as I believe it should be.