### PR TITLE
Add German namespaced translations for order events

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -429,6 +429,11 @@ de:
         taxonomies: Klassifikationen
         taxons: Klassifikation
         users: Benutzer
+      order:
+        events:
+          approve: approve
+          cancel: cancel
+          resume: resume
       user:
         account: Konto
         addresses: Adressen


### PR DESCRIPTION
This provides the German translations for the changes introduced in
https://github.com/spree/spree/pull/6615