### PR TITLE
Rename order state "abgebrochen" to "storniert"

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -892,8 +892,8 @@ de:
     order: Bestellung
     order_adjustments: Bestellanpassungen
     order_already_updated: Bestellung bereits geändert
-    order_approved: Bestellung akzeptiert
-    order_canceled: Bestellung abgebrochen
+    order_approved: Bestellung freigegeben
+    order_canceled: Bestellung storniert
     order_details: Details der Bestellung
     order_email_resent: Bestellbestätigung erneut versendet
     order_information: Bestellinformationen
@@ -920,7 +920,7 @@ de:
     order_state:
       address: Adresse
       awaiting_return: erwartet Erstattung
-      canceled: Abgebrochen
+      canceled: Storniert
       cart: Warenkorb
       complete: Abgeschlossen
       confirm: Bestätigt


### PR DESCRIPTION
In line with previous commits, this changes the translation for the
"canceled" order state to "storniert", which makes much more sense in German.