### PR TITLE
fix migrate failure with mysql2 adapter

### DIFF
--- a/db/migrate/20150609154031_remove_translations_from_spree_tables.rb
+++ b/db/migrate/20150609154031_remove_translations_from_spree_tables.rb
@@ -38,7 +38,7 @@ class RemoveTranslationsFromSpreeTables < ActiveRecord::Migration
 
     # We can't rely on Globalize drop_translation_table! here,
     # because the Gem has been already removed, so we need to run custom SQL
-    records = execute("SELECT * FROM #{singular_table_name}_translations WHERE locale = '#{current_locale}';")
+    records = exec_query("SELECT * FROM #{singular_table_name}_translations WHERE locale = '#{current_locale}';")
 
     records.each do |record|
       id = record["#{singular_table_name}_id"]


### PR DESCRIPTION
migration fails with mysql2 adapter.
because mysql adapter "execute" return an Array

http://stackoverflow.com/questions/5760100/why-does-rails-3-with-mysql2-gem-activerecordbase-connection-executesql-retu

I test with rails 4.2.3, and it success.
