### PR TITLE
Updating i18n_data

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'friendly_id-globalize'
   s.add_runtime_dependency 'globalize', '~> 5.0.1'
-  s.add_runtime_dependency 'i18n_data', '~> 0.5.1'
+  s.add_runtime_dependency 'i18n_data', '~> 0.7.0'
   s.add_runtime_dependency 'rails-i18n', '~> 4.0.1'
   s.add_runtime_dependency 'kaminari-i18n', '~> 0.3.2'
   s.add_runtime_dependency 'spree_core', '~> 3.0.0'


### PR DESCRIPTION
0.5 has some age to it and 0.7 fixes a few issues, no api changes. Should be plug and play