### PR TITLE
Fix credit_owed ja translation.

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -914,7 +914,7 @@ ja:
       balance_due: "未支払い"
       checkout: "決算中"
       completed: "完了"
-      credit_owed: "一部未払"
+      credit_owed: "過払い額"
       failed: "失敗しました"
       paid: "支払い済み"
       pending: "支払い待ち"


### PR DESCRIPTION
This translation was fixed in one place but not where it appears in `payment_states`.