### PR TITLE
#619  fix for `method_missing': undefined method `whitelisted_ransack…

### DIFF
--- a/app/models/spree_i18n/translatable.rb
+++ b/app/models/spree_i18n/translatable.rb
@@ -1,7 +1,8 @@
 module SpreeI18n
   module Translatable
     extend ActiveSupport::Concern
-
+    include Spree::RansackableAttributes
+    
     included do |klass|
       accepts_nested_attributes_for :translations
       klass.whitelisted_ransackable_associations |= ['translations']


### PR DESCRIPTION
…able_associations'

@picazoH 's suggestion in #619  works for me. Issue trying to upgrade from spree 2.3 to 2.4. Couldn't run rake db:migrate without this line, and couldn't run the server after the successful migration without this line. Running spree 2.4, we need this for our spree-based app in prod.