### PR TITLE
for 3-0-stable #619  fix for `method_missing': undefined method `whitelisted_ransack…

### DIFF
--- a/app/models/spree_i18n/translatable.rb
+++ b/app/models/spree_i18n/translatable.rb
@@ -3,7 +3,8 @@ require 'spree_i18n/ransack_translator'
 module SpreeI18n
   module Translatable
     extend ActiveSupport::Concern
-
+    include Spree::RansackableAttributes
+    
     included do |klass|
       accepts_nested_attributes_for :translations
       klass.whitelisted_ransackable_associations ||= []


### PR DESCRIPTION
…able_associations'

@picazoH 's suggestion works for me. Issue trying to upgrade from spree 2.3 to 2.4. Couldn't run rake db:migrate without this line

Solves issue https://github.com/spree-contrib/spree_i18n/issues/619 for spree 3-0-stable
same pull request for spree 3-0-stable 
(https://github.com/spree-contrib/spree_i18n/pull/628)