### PR TITLE
Add order number to ja translation

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -870,7 +870,7 @@ ja:
         thanks:
         total:
     order_not_found:
-    order_number: "注文"
+    order_number: "注文 %{number}"
     order_processed_successfully: "注文が完了しました。"
     order_resumed:
     order_state:


### PR DESCRIPTION
Currently there is a translation for "order number" but it doesn't actually include the number in it, so the customer can't see the actual number.