### PR TITLE
Ransack control params (:m, :s) mangled by translator into :m_, :s_

### DIFF
--- a/lib/spree_i18n/ransack_translator.rb
+++ b/lib/spree_i18n/ransack_translator.rb
@@ -15,7 +15,6 @@ module SpreeI18n
     private
 
     def key_with_translations(key)
-      return key if key.to_s == 's'
       names, pred = split_key key
       translated_names = translate_names(names)
       join_key translated_names, pred
@@ -31,7 +30,7 @@ module SpreeI18n
 
     def join_key(names, pred)
       key = names.join('_or_')
-      key += "_#{pred}" unless pred == ''
+      key += "_#{pred}" unless pred.blank?
       key
     end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -55,6 +55,19 @@ module Spree
         expect(result.to_a).to match_array [product, other_product]
       end
 
+      context 'ransacking by taxonomy' do
+        let(:product_with_taxon) { create(:product, name: 'product-with-taxon') }
+        let(:sack_params) { {m: 'or', name_cont: product.name, taxons_name_cont: product.name} }
+        before do
+          Spree::Product.whitelisted_ransackable_associations.push('taxons')
+          product_with_taxon.taxons << create(:taxon, name: product.name)
+        end
+        it 'handles ransack with and/or grouping parameter safely' do
+          result = described_class.ransack(sack_params).result
+          expect(result.to_a).to match_array [product, product_with_taxon]
+        end
+      end
+
       it 'handles ransack with an invalid key safely' do
         result = described_class.ransack(foo: 'blub').result
         expect(result.to_a).to match_array [product, other_product]


### PR DESCRIPTION
Prevents changing the default grouping of the AND ransack query to OR.

Change uses check blank? instead of == '' for non-values in SpreeI18n::RansackTranslator#join_key. Racksack::Predicate returns nil, really any non-value should be handled without mangling arbitrary params used to control ransack. Also took the liberty of removing the skip of the 's' param in key_with_translations, since I am assuming this was inserted for a similar reason. This fix should be more applicable to future control params as well.