### PR TITLE
Correcting a replace-all of state to country

### DIFF
--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1,12 +1,12 @@
---- 
-en-GB: 
+---
+en-GB:
   a_copy_of_all_mail_will_be_sent_to_the_following_addresses: A copy of all mail be sent to the following addresses
   abbreviation: Abbreviation
   access_denied: "Access Denied"
   account: Account
   account_updated: "Account updated!"
   action: Action
-  actions: 
+  actions:
     cancel: Cancel
     create: Create
     destroy: Destroy
@@ -16,9 +16,9 @@ en-GB:
     update: Update
   activate: "Activate"
   active: "Active"
-  activerecord: 
-    attributes: 
-      spree/address: 
+  activerecord:
+    attributes:
+      spree/address:
         address1: Address
         address2: "Address (contd.)"
         city: City
@@ -28,24 +28,24 @@ en-GB:
         phone: Phone
         state: "County"
         zipcode: "Post Code"
-      spree/country: 
+      spree/country:
         iso: ISO
         iso3: ISO3
         iso_name: "ISO Name"
         name: Name
         numcode: "ISO Code"
-      spree/credit_card: 
+      spree/credit_card:
         cc_type: Type
         month: Month
         number: Number
         verification_value: "Verification Value"
         year: Year
-      spree/inventory_unit: 
+      spree/inventory_unit:
         state: County
-      spree/line_item: 
+      spree/line_item:
         price: Price
         quantity: Quantity
-      spree/option_type: 
+      spree/option_type:
         name: Name
         presentation: Presentation
       spree/order:
@@ -56,12 +56,12 @@ en-GB:
         ip_address: "IP Address"
         item_total: "Item Total"
         number: Number
-        payment_state: Payment County
-        shipment_state: Shipment County
+        payment_state: Payment State
+        shipment_state: Shipment State
         special_instructions: "Special Instructions"
         state: County
         total: Total
-      spree/order/bill_address: 
+      spree/order/bill_address:
         address1: "Billing address street"
         city: "Billing address city"
         firstname: "Billing address first name"
@@ -69,7 +69,7 @@ en-GB:
         phone: "Billing address phone"
         state: "Billing address county"
         zipcode: "Billing address post code"
-      spree/order/ship_address: 
+      spree/order/ship_address:
         address1: "Shipping address street"
         city: "Shipping address city"
         firstname: "Shipping address first name"
@@ -79,7 +79,7 @@ en-GB:
         zipcode: "Shipping address post code"
       spree/payment_method:
         name: Name
-      spree/product: 
+      spree/product:
         available_on: "Available On"
         cost_price: "Cost Price"
         description: Description
@@ -89,7 +89,7 @@ en-GB:
         on_hand: "On Hand"
         shipping_category: "Shipping Category"
         tax_category: "Tax Category"
-      spree/promotion: 
+      spree/promotion:
         advertise: Advertise
         code: Code
         description: Description
@@ -99,36 +99,36 @@ en-GB:
         path: Path
         starts_at: Starts At
         usage_limit: Usage Limit
-      spree/property: 
+      spree/property:
         name: Name
         presentation: Presentation
-      spree/prototype: 
+      spree/prototype:
         name: Name
-      spree/return_authorization: 
+      spree/return_authorization:
         amount: Amount
-      spree/role: 
+      spree/role:
         name: Name
-      spree/state: 
+      spree/state:
         abbr: Abbreviation
         name: Name
-      spree/tax_category: 
+      spree/tax_category:
         description: Description
         name: Name
-      spree/tax_rate: 
+      spree/tax_rate:
         amount: Rate
         included_in_price: Included in Price
         show_rate_in_label: Show rate in label
-      spree/taxon: 
+      spree/taxon:
         name: Name
         permalink: Permalink
         position: Position
-      spree/taxonomy: 
+      spree/taxonomy:
         name: Name
-      spree/user: 
+      spree/user:
         email: Email
         password: "Password"
         password_confirmation: "Password Confirmation"
-      spree/variant: 
+      spree/variant:
         cost_price: "Cost Price"
         depth: Depth
         height: Height
@@ -136,83 +136,83 @@ en-GB:
         sku: SKU
         weight: Weight
         width: Width
-      spree/zone: 
+      spree/zone:
         description: Description
         name: Name
-    models: 
-      spree/address: 
+    models:
+      spree/address:
         one: Address
         other: Addresses
-      spree/cheque_payment: 
+      spree/cheque_payment:
         one: Cheque Payment
         other: Cheque Payments
-      spree/country: 
+      spree/country:
         one: Country
         other: Countries
-      spree/credit_card: 
+      spree/credit_card:
         one: "Credit Card"
         other: "Credit Cards"
-      spree/creditcard_payment: 
+      spree/creditcard_payment:
         one: "Credit Card Payment"
         other: "Credit Card Payments"
-      spree/creditcard_txn: 
+      spree/creditcard_txn:
         one: "Credit Card Transaction"
         other: "Credit Card Transactions"
-      spree/inventory_unit: 
+      spree/inventory_unit:
         one: "Inventory Unit"
         other: "Inventory Units"
-      spree/line_item: 
+      spree/line_item:
         one: "Line Item"
         other: "Line Items"
-      spree/order: 
+      spree/order:
         one: Order
         other: Orders
-      spree/payment: 
+      spree/payment:
         one: Payment
         other: Payments
-      spree/product: 
+      spree/product:
         one: Product
         other: Products
-      spree/property: 
+      spree/property:
         one: Property
         other: Properties
-      spree/prototype: 
+      spree/prototype:
         one: Prototype
         other: Prototypes
-      spree/return_authorization: 
+      spree/return_authorization:
         one: Return Authorisation
         other: Return Authorisations
-      spree/role: 
+      spree/role:
         one: Roles
         other: Roles
-      spree/shipment: 
+      spree/shipment:
         one: Shipment
         other: Shipments
-      spree/shipping_category: 
+      spree/shipping_category:
         one: "Shipping Category"
         other: "Shipping Categories"
-      spree/state: 
+      spree/state:
         one: County
         other: Counties
-      spree/tax_category: 
+      spree/tax_category:
         one: "Tax Category"
         other: "Tax Categories"
-      spree/tax_rate: 
+      spree/tax_rate:
         one: "Tax Rate"
         other: "Tax Rates"
-      spree/taxon: 
+      spree/taxon:
         one: Taxon
         other: Taxons
-      spree/taxonomy: 
+      spree/taxonomy:
         one: Taxonomy
         other: Taxonomies
-      spree/user: 
+      spree/user:
         one: User
         other: Users
-      spree/variant: 
+      spree/variant:
         one: Variant
         other: Variants
-      spree/zone: 
+      spree/zone:
         one: Zone
         other: Zones
   add: Add
@@ -237,10 +237,10 @@ en-GB:
   adjustment: Adjustment
   adjustment_total: Adjustment Total
   adjustments: Adjustments
-  admin: 
-    mail_methods: 
+  admin:
+    mail_methods:
       send_testmail: 'Send Testmail'
-      testmail: 
+      testmail:
         delivery_error: 'Testmail delivery error'
         delivery_success: 'Testmail sent successfully'
         error: 'Testmail error: %{e}'
@@ -435,27 +435,27 @@ en-GB:
   environment: "Environment"
   error: error
   error_user_destroy_with_orders: "Users with completed orders may not be deleted"
-  errors: 
-    messages: 
+  errors:
+    messages:
       could_not_create_taxon: "Could not create taxon"
       no_payment_methods_available: "No payment methods are configured for this environment"
       no_shipping_methods_available: "No shipping methods available for selected location, please change your address and try again."
-  errors_prohibited_this_record_from_being_saved: 
+  errors_prohibited_this_record_from_being_saved:
     one: "1 error prohibited this record from being saved"
     other: "%{count} errors prohibited this record from being saved"
   event: Event
-  events: 
-    spree: 
-      cart: 
+  events:
+    spree:
+      cart:
         add: 'Add to cart'
-      checkout: 
+      checkout:
         coupon_code_added: Coupon code added
-      content: 
+      content:
         visited: Visit static content page
-      order: 
+      order:
         contents_changed: "Order contents changed"
       page_view: "Static page viewed"
-      user: 
+      user:
         signup: 'User signup'
   existing_customer: "Existing Customer"
   expiration: "Expiration"
@@ -533,11 +533,11 @@ en-GB:
   item: Item
   item_description: "Item Description"
   item_total: "Item Total"
-  item_total_rule: 
-    operators: 
+  item_total_rule:
+    operators:
       gt: greater than
       gte: greater than or equal to
-  landing_page_rule: 
+  landing_page_rule:
     path: Path
   last_name: "Last Name"
   last_name_begins_with: "Last Name Begins With"
@@ -572,7 +572,7 @@ en-GB:
   make_refund: Make refund
   mark_shipped: "Mark Shipped"
   master_price: "Master Price"
-  match_choices: 
+  match_choices:
     all: "All"
     none: "None"
     one: "One"
@@ -637,7 +637,7 @@ en-GB:
   not_found: "%{resource} is not found"
   not_shown: "Not Shown"
   note: Note
-  notice_messages: 
+  notice_messages:
     option_type_removed: "Succesfully removed option type."
     product_cloned: "Product has been cloned"
     product_deleted: "Product has been deleted"
@@ -661,15 +661,15 @@ en-GB:
   order_date: "Order Date"
   order_details: "Order Details"
   order_email_resent: "Order Email Resent"
-  order_mailer: 
-    cancel_email: 
+  order_mailer:
+    cancel_email:
       dear_customer: "Dear Customer,"
       instructions: "Your order has been CANCELED.  Please retain this cancellation information for your records."
       order_summary_canceled: "Order Summary [CANCELED]"
       subject: "Cancellation of Order"
       subtotal: "Subtotal:"
       total: "Order Total:"
-    confirm_email: 
+    confirm_email:
       dear_customer: "Dear Customer,"
       instructions: "Please review and retain the following order information for your records."
       order_summary: "Order Summary"
@@ -707,7 +707,7 @@ en-GB:
   overview: Overview
   page_only_viewable_when_logged_in: You attempted to visit a page which can only be viewed when you are logged in
   page_only_viewable_when_logged_out: You attempted to visit a page which can only be viewed when you are logged out
-  pagination: 
+  pagination:
     next_page: "next page &raquo;"
     previous_page: "&laquo; previous page"
     truncate: "&hellip;"
@@ -732,7 +732,7 @@ en-GB:
   payment_processor_choose_banner_text: "If you need help choosing a payment processor, please visit"
   payment_processor_choose_link: "our payments page"
   payment_state: Payment State
-  payment_states: 
+  payment_states:
     balance_due: balance due
     checkout: checkout
     completed: completed
@@ -771,119 +771,119 @@ en-GB:
   product_groups: Product Groups
   product_has_no_description: This product has no description
   product_properties: "Product Properties"
-  product_rule: 
+  product_rule:
     choose_products: Choose products
     label: "Order must contain %{select} of these products"
     match_all: all
     match_any: at least one
-    product_source: 
+    product_source:
       group: From product group
       manual: Manually choose
-  product_scopes: 
-    groups: 
-      price: 
+  product_scopes:
+    groups:
+      price:
         description: "Scopes for selecting products based on Price"
         name: Price
-      search: 
+      search:
         description: "Scopes for selecting products based on name, keywords and description of product"
         name: "Text search"
-      taxon: 
+      taxon:
         description: "Scopes for selecting products based on Taxons"
         name: Taxon
-      values: 
+      values:
         description: "Scopes for selecting products based on option and property values"
         name: Values
-    scopes: 
-      ascend_by_name: 
+    scopes:
+      ascend_by_name:
         name: Ascend by product name
-      ascend_by_updated_at: 
+      ascend_by_updated_at:
         name: Ascend by actualisation date
-      descend_by_name: 
+      descend_by_name:
         name: Descend by product name
-      descend_by_updated_at: 
+      descend_by_updated_at:
         name: Descend by actualisation date
-      in_name: 
-        args: 
+      in_name:
+        args:
           words: Words
         description: "(separated by space or comma)"
         name: "Product name have following"
         sentence: product name contain <em>%s</em>
-      in_name_or_description: 
-        args: 
+      in_name_or_description:
+        args:
           words: Words
         description: "(separated by space or comma)"
         name: "Product name or description have following"
         sentence: name or description contain <em>%s</em>
-      in_name_or_keywords: 
-        args: 
+      in_name_or_keywords:
+        args:
           words: Words
         description: "(separated by space or comma)"
         name: "Product name or meta keywords have following"
         sentence: name or keywords contain <em>%s</em>
-      in_taxons: 
-        args: 
+      in_taxons:
+        args:
           "taxon_names": "Taxon names"
         description: "Taxon names have to be separated by comma or space(eg. adidas,shoes)"
         name: "In taxons and all their descendants"
         sentence: in <em>%s</em> and all their descendants
-      master_price_gte: 
-        args: 
+      master_price_gte:
+        args:
           amount: Amount
         description: ""
         name: "Master price greater or equal to"
         sentence: price greater or equal to <em>%.2f</em>
-      master_price_lte: 
-        args: 
+      master_price_lte:
+        args:
           amount: Amount
         description: ""
         name: "Master price lesser or equal to"
         sentence: price less or equal to <em>%.2f</em>
-      price_between: 
-        args: 
+      price_between:
+        args:
           high: High
           low: Low
         description: ""
         name: "Price between"
         sentence: price between <em>%.2f</em> and <em>%.2f</em>
-      taxons_name_eq: 
-        args: 
+      taxons_name_eq:
+        args:
           taxon_name: "Taxon name"
         description: "In specific taxon - without descendants"
         name: "In Taxon(without descendants)"
         sentence: in <em>%s</em>
-      with: 
-        args: 
+      with:
+        args:
           value: Value
         description: "Select specific products"
         name: Products with IDs
         sentence: with IDs <em>%s</em>
-      with_ids: 
-        args: 
+      with_ids:
+        args:
           ids: IDs
         description: "Select specific products"
         name: Products with IDs
         sentence: with IDs <em>%s</em>
-      with_option: 
-        args: 
+      with_option:
+        args:
           option: Option
         description: "Selects all products that have specified option(eg. color)"
         name: "With option"
         sentence: with option <em>%s</em>
-      with_option_value: 
-        args: 
+      with_option_value:
+        args:
           option: Option
           value: Value
         description: "Selects all products that have at least one variant with specified option and value(eg. color:red)"
         name: "With option and value"
         sentence: with option <em>%s</em> and value <em>%s</em>
-      with_property: 
-        args: 
+      with_property:
+        args:
           property: Property
         description: "Selects all products that have specified property(eg. weight)"
         name: "With property"
         sentence: with property <em>%s</em>
-      with_property_value: 
-        args: 
+      with_property_value:
+        args:
           property: Property
           value: Value
         description: "Selects all products that have at least one variant with specified property and value(eg. weight:10kg)"
@@ -893,40 +893,40 @@ en-GB:
   products_with_zero_inventory_display: "Products with a zero inventory will %{not} be displayed"
   promotion: Promotion
   promotion_action: Promotion Action
-  promotion_action_types: 
-    create_adjustment: 
+  promotion_action_types:
+    create_adjustment:
       description: Creates a promotion credit adjustment on the order
       name: Create adjustment
-    create_line_items: 
+    create_line_items:
       description: Populates the cart with the specified quantity of variant
       name: Create line items
-    give_store_credit: 
+    give_store_credit:
       description: Gives the user store credit of the amount specified
       name: Give store credit
   promotion_actions: Actions
-  promotion_form: 
-    match_policies: 
+  promotion_form:
+    match_policies:
       all: Match any of these rules
       any: Match all of these rules
   promotion_not_found: The coupon code you entered doesn't exist. Please try again.
   promotion_rule: Promotion Rule
-  promotion_rule_types: 
-    first_order: 
+  promotion_rule_types:
+    first_order:
       description: Must be the customer's first order
       name: First order
-    item_total: 
+    item_total:
       description: Order total meets these criteria
       name: Item total
-    landing_page: 
+    landing_page:
       description: Customer must have visited the specified page
       name: Landing Page
-    product: 
+    product:
       description: Order includes specified product(s)
       name: Product(s)
-    user: 
+    user:
       description: Available only to the specified users
       name: User
-    user_logged_in: 
+    user_logged_in:
       description: Available only to logged in users
       name: User Logged In
   promotions: Promotions
@@ -959,7 +959,7 @@ en-GB:
   resend_confirmation_instructions: "Resend confirmation instructions"
   resend_unlock_instructions: "Resend unlock instructions"
   reset_password: "Reset my password"
-  resource_controller: 
+  resource_controller:
     member_object_not_found: "Member object not found."
     successfully_created: "Successfully created!"
     successfully_removed: "Successfully removed!"
@@ -1015,8 +1015,8 @@ en-GB:
   shipment: Shipment
   shipment_details: Shipment Details
   shipment_inc_vat: "Shipment including VAT"
-  shipment_mailer: 
-    shipped_email: 
+  shipment_mailer:
+    shipped_email:
       dear_customer: "Dear Customer,"
       instructions: "Your order has been shipped"
       shipment_summary: "Shipment Summary"
@@ -1025,7 +1025,7 @@ en-GB:
       track_information: "Tracking Information: %{tracking}"
   shipment_number: "Shipment #"
   shipment_state: Shipment State
-  shipment_states: 
+  shipment_states:
     backorder: backorder
     partial: partial
     pending: pending
@@ -1074,11 +1074,11 @@ en-GB:
   sold: Sold
   sort_ordering: "Sort ordering"
   special_instructions: "Special Instructions"
-  spree/order: 
+  spree/order:
     coupon_code: Coupon Code
-  spree: 
+  spree:
     date: Date
-    date_picker: 
+    date_picker:
       format: ! '%Y/%m/%d'
       js_format: 'yy/mm/dd'
     time: Time
@@ -1129,8 +1129,8 @@ en-GB:
   taxonomy_tree_instruction: "* Right click a child in the tree to access the menu for adding, deleting or sorting a child."
   taxons: Taxons
   test: "Test"
-  test_mailer: 
-    test_email: 
+  test_mailer:
+    test_email:
       greeting: 'Congratulations!'
       message: 'If you have received this email, then your email settings are correct.'
       subject: 'Testmail'
@@ -1170,11 +1170,11 @@ en-GB:
   user: User
   user_account: User Account
   user_created_successfully: "User created successfully"
-  user_rule: 
+  user_rule:
     choose_users: Choose users
   users: Users
   validate_on_profile_create: Validate on profile create
-  validation: 
+  validation:
     cannot_be_greater_than_available_stock: "cannot be greater than available stock."
     cannot_be_less_than_shipped_units: "cannot be less than the number of shipped units."
     cannot_destory_line_item_as_inventory_units_have_shipped: "Cannot destory line item as some inventory units have shipped."


### PR DESCRIPTION
The Order Index page showed headings of 'Payment County' and 'Shipment County' instead of 'Payment State' and 'Shipment State'. 

Argh, find changes on lines 59-60. The rest is white noise.

Thanks!