### PR TITLE
bump version to 3.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: '3-1-stable'
 
 gemspec

--- a/app/overrides/spree/admin/general_settings/edit/localization_settings.html.erb.deface
+++ b/app/overrides/spree/admin/general_settings/edit/localization_settings.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_after '.row .security' -->
+<!-- insert_after '.row .currency' -->
 <div class="panel panel-default panel-localization">
   <div class="panel-heading">
     <h1 class="panel-title">

--- a/lib/spree_i18n/version.rb
+++ b/lib/spree_i18n/version.rb
@@ -11,7 +11,7 @@ module SpreeI18n
     MAJOR = 3
     MINOR = 1
     TINY  = 0
-    PRE   = 'beta'
+    PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
   end


### PR DESCRIPTION
- Bump version to 3.1.0
- Change Spree branch to 3-1-stable
- Fix translations_spec failure due of spree security general setting moved to conditional block.