### PR TITLE
fix number format precision type

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -375,7 +375,7 @@ de:
   number:
     percentage:
       format:
-        precision: '1'
+        precision: 1
   spree:
     abbreviation: Abkürzung
     accept: Akzeptieren


### PR DESCRIPTION
The precision get fed into `#round` at some point and must be a number, not a string.