### PR TITLE
Set spree_core to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rails-i18n', '~> 4.0.1'
   s.add_runtime_dependency 'kaminari-i18n', '~> 0.3.2'
   s.add_runtime_dependency 'routing-filter', '~> 0.5.0'
-  s.add_runtime_dependency 'spree_core', '~> 3.2.0.alpha'
+  s.add_runtime_dependency 'spree_core', '>= 3.1.0', '< 4.0'
 
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'capybara', '~> 2.5'


### PR DESCRIPTION
This PR changes the version of `spree_core` in gemspec to point at `>= 3.1.0` and `< 4.0`.