### PR TITLE
Adding and fixing some PT-BR mailer translations

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1155,11 +1155,12 @@ pt-BR:
       shipped_email:
         dear_customer: Caro cliente,\n
         instructions: Seu pedido foi enviado
+        shipping_method: "Método de Entrega: %{shipping_method}"
         shipment_summary: Resumo da entrega
         subject: Notificação de envio
         thanks: Obrigado por comprar.
-        track_information: 'Informação de rasteramento: %{tracking}'
-        track_link: 'Link de rasteramento: %{url}'
+        track_information: 'Informação de rastreamento: %{tracking}'
+        track_link: 'Link de rastreamento: %{url}'
     shipment_state: Estado da entrega
     shipment_states:
       backorder: Devolução

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Spree::Core::Engine.add_routes do
   # from routing-filter gem
-  filter :locale
+  #filter :locale
 
   get '/locales', to: 'locale#index', as: :locales
   post '/locale/set', to: 'locale#set', defaults: { format: :json }, as: :set_locale


### PR DESCRIPTION
Adding missing pt-BR translation for shipment_mailer.shipped_email.shipping_method, and fixing typo on shipment_mailer.shipped_email.track_information and shipment_mailer.shipped_email.track_link (Rasteramento is actually Rastreamento)
