### PR TITLE
Fix typo in italian translation

### DIFF
--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -123,7 +123,7 @@ it:
         mail_from_address: Indirizzo Mittente Email
         meta_description: Meta Description
         meta_keywords: Meta Keywords
-        name: Nomed
+        name: Nome
         seo_title: Titolo SEO
         url: URL Sito
       spree/tax_category:


### PR DESCRIPTION
The correct spelling is 'Nome' and not 'Nomed'