### PR TITLE
uninitialized constant Generators::Base

### DIFF
--- a/lib/spree_i18n.rb
+++ b/lib/spree_i18n.rb
@@ -1,4 +1,5 @@
 require 'rails-i18n'
+require 'rails/generators'
 require 'spree_core'
 require 'spree_i18n/engine'
 require 'spree_i18n/version'


### PR DESCRIPTION
Regarding problem descripted here:  [issue #717](https://github.com/spree-contrib/spree_i18n/issues/717).
Actually, it contains code introduced in [PR #714](https://github.com/spree-contrib/spree_i18n/pull/714) without an unnecessary "require" statement.