### PR TITLE
Fixing shipping Category translation in new product

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -82,7 +82,7 @@ pt-BR:
         master_price: Preço Total
         name: Nome
         on_hand: Pronta Entrega
-        shipping_category: Tipo de Entraga
+        shipping_category: Tipo de Entrega
         tax_category: Tipo de Taxa
       spree/promotion:
         advertise: Aviso


### PR DESCRIPTION
Fixed 'shipping_category' translation in line number: 85