### PR TITLE
Redirect to referrer instead of root on locale set

### DIFF
--- a/app/controllers/spree/locale_controller.rb
+++ b/app/controllers/spree/locale_controller.rb
@@ -5,7 +5,13 @@ module Spree
     end
 
     def set
-      redirect_to root_path(locale: params[:switch_to_locale])
+      if request.referrer
+        path = spree.routes.recognize_path(request.referrer)
+        path[:locale] = params[:switch_to_locale]
+        redirect_to url_for(path)
+      else
+        redirect_to root_path(locale: params[:switch_to_locale])
+      end
     end
   end
 end

--- a/spec/controllers/locales_controller_spec.rb
+++ b/spec/controllers/locales_controller_spec.rb
@@ -20,3 +20,21 @@ RSpec.describe Spree::HomeController, type: :controller do
     end
   end
 end
+
+RSpec.describe Spree::LocaleController, type: :controller do
+  routes { Spree::Core::Engine.routes }
+
+  before do
+    reset_spree_preferences
+    SpreeI18n::Config.available_locales = [:en, :es]
+  end
+
+  describe "#set" do
+    it 'redirects to referrer' do
+      root = request.url
+      request.env['HTTP_REFERER'] = "#{root}/products/some-product"
+      post :set, params: { switch_to_locale: :es }
+      expect(response).to redirect_to("#{root}/es/products/some-product")
+    end
+  end
+end


### PR DESCRIPTION
With this change when you change the locale you are redirected to the same page you've been before instead of root of the Rails application.