### PR TITLE
es-MX: Fixes date format for date picker

### DIFF
--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -566,8 +566,8 @@ es-MX:
     date_completed: Fecha completada
     date_picker:
       first_day:
-      format: Año/mes/día
-      js_format: aa/mm/dd
+      format: "%d/%m/%Y"
+      js_format: dd/mm/yy
     date_range: Rango de Fecha
     default: Por omisión
     default_refund_amount:


### PR DESCRIPTION
This bad locale entry causes bad format (yet "valid" and saved in DB) for date pickers in the Spree backend. This PR fixes that allowing the user to input a valid date.

How did I find this, you may ask? Well, I spent around 2 days trying to figure out why my products where "disappearing" from the product listing whenever I updated them - it didn't make any sense and I was too frustrated to realize it was the "Available date" field that was missing from the Product edit view.

It was until I created a fresh Spree app to demonstrate the bug that I noticed this when I introduced this locale and triple checking the fields.

One of those bugs... :fire: 