### PR TITLE
missing :one translation for Product Property

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -411,6 +411,7 @@ de:
         one: Produkt
         other: Produkte
       spree/product_property:
+        one: Produkt-Eigenschaft
         other: Produkt-Eigenschaften
       spree/promotion:
         one: Werbung


### PR DESCRIPTION
Spree 3.4.2 gives an error without this
`I18n::InvalidPluralizationData (translation data {:other=>"Produkt-Eigenschaften"} can not be used with :count => 1. key 'one' is missing.):`