### PR TITLE
Terminology revision and add RMA translations

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -212,8 +212,8 @@ pt-BR:
         one: Protótipo
         other: Protótipos
       spree/refund_reason:
-        one: Razão de reembolso
-        other: Razões de reembolso
+        one: Motivo de reembolso
+        other: Motivos de reembolso
       spree/reimbursement:
         one: Restituição
         other: Restituições
@@ -224,8 +224,8 @@ pt-BR:
         one: Autorização de Devolução
         other: Autorização de Devoluções
       spree/return_authorization_reason:
-        one: Razão de autorização de devolução
-        other: Razões de autorização de devoluções
+        one: Motivo de autorização de devolução
+        other: Motivos de autorização de devolução
       spree/role:
         one: Função
         other: Funções
@@ -434,7 +434,7 @@ pt-BR:
     add: Adicionar
     add_action_of_type: Adicionar Ação do Tipo
     add_country: Adicionar país
-    add_coupon_code: Adicionar código de Coupon
+    add_coupon_code: Adicionar código de Cupom
     add_new_header: Adicionar Novo Cabeçalho
     add_new_style: Adicionar Novo Estilo
     add_one: Adicione
@@ -539,7 +539,7 @@ pt-BR:
     backordered: Pendente
     back_to_payment: Voltar para lista de Pagamentos
     back_to_resource_list: "Voltar para lista de %{resource}"
-    back_to_rma_reason_list:
+    back_to_rma_reason_list: Voltar para a lista de Motivos de Autorização de Devolução
     back_to_store: Voltar Para a Loja
     back_to_users_list: Voltar a lista de usuários
     backorderable: Aceita pedido sem estoque
@@ -622,7 +622,7 @@ pt-BR:
       label: Este escolha deve ser enviada para este país
     coupon: Cupom
     coupon_code: Código do Cupom
-    coupon_code_apply: Apply
+    coupon_code_apply: Aplicar Cupom
     coupon_code_already_applied: O cupom já foi adicionado ao pedido
     coupon_code_applied: O Código do cupom foi acrecentado ao seu pedido
     coupon_code_better_exists: O pedido já possui um cupom com melhor desconto
@@ -770,7 +770,7 @@ pt-BR:
     free_shipping_amount: "-"
     front_end: Front End
     gateway: Gateway
-    gateway_error: Erro na Gateway
+    gateway_error: Erro no Gateway
     general: Geral
     general_settings: Configurações Gerais
     google_analytics: Google Analytics
@@ -958,7 +958,7 @@ pt-BR:
       variant_deleted: Variante Deletada
       variant_not_deleted: Variante não Pode ser Deletada
     num_orders: Número de pedidos
-    number: Number
+    number: Número
     on_hand: Em Estoque
     open: Abrir
     open_all_adjustments: Abrir todos os ajustes
@@ -1202,7 +1202,7 @@ pt-BR:
     return_item_inventory_unit_ineligible: Unidade de Inventório do Item Devolvido Inelegível
     return_item_inventory_unit_reimbursed: Unidade de Inventório do Item Devolvido Reembolsado
     return_item_order_not_completed: Devolução de item do pedido deve ser finalizado.
-    return_item_rma_ineligible: RMA de Item Devolvido Inelegível
+    return_item_rma_ineligible: Autorização de Devolução de Item Inelegível
     return_item_time_period_ineligible: Período de Item Devolvido Inelegível
     return_items: Itens Devolvidos
     return_items_cannot_be_associated_with_multiple_orders: Itens devolvidos não pode estar associado a múltiplos pedidos.
@@ -1224,9 +1224,9 @@ pt-BR:
     risk: Risco
     risk_analysis: Análise de Risco
     risky: Arriscado
-    rma_credit: Crédito RMA
-    rma_number: Número RMA
-    rma_value: Valor RMA
+    rma_credit: Crédito em Devolução Aut.
+    rma_number: Número de Devolução Aut.
+    rma_value: Valor de Devolução Aut.
     role_id: ID da função
     roles: Funções
     rules: Regras
@@ -1247,9 +1247,9 @@ pt-BR:
     security_settings: Configurações de segurança
     select: Selecionar
     select_from_prototype: Selecionar a partir de protótipo
-    select_a_return_authorization_reason: Selecione uma razão de autorização de retorno
+    select_a_return_authorization_reason: Selecione um motivo de autorização de devolução
     select_a_stock_location: Selecione uma localização de estoque
-    select_a_store_credit_reason: Select a reason for the store credit
+    select_a_store_credit_reason: Selecione um motivo para crédito em loja
     select_stock: Selecione estoque
     selected_quantity_not_available: ! 'seleção de %{item} não disponível.'
     send_copy_of_all_mails_to: Enviar cópias de todos emails para
@@ -1466,7 +1466,7 @@ pt-BR:
     tracking: Rastreio
     tracking_number: Número de rastreio
     tracking_url: URL de rastreio
-    tracking_url_placeholder: e.g. http://websro.correios.com.br/sro_bin/txect01$.QueryList?P_LINGUA=001&P_TIPO=001&P_COD_UNI=:tracking
+    tracking_url_placeholder: ex. http://websro.correios.com.br/sro_bin/txect01$.QueryList?P_LINGUA=001&P_TIPO=001&P_COD_UNI=:tracking
     transaction_id: ID da Transação
     transfer_from_location: Transferir de
     transfer_stock: Estoque de transferência
@@ -1516,7 +1516,7 @@ pt-BR:
     you_have_no_orders_yet: Você não possui pedidos ainda.
     your_cart_is_empty: O carrinho está vazio
     your_order_is_empty_add_product: Seu pedido está vazio, por favor procure e adicione um produto
-    zip: Codigo postal
-    zipcode: Código zip
+    zip: CEP
+    zipcode: CEP
     zone: Região
     zones: Regiões


### PR DESCRIPTION
- Add proper translation from en to pt-br copied keys;
- Revision of specific terminology as _cupom_ for Coupon, _motivo_ for reason instead of _razão_ and RMA as _Devolução Autorizada_.
- Revision of zipcode keys as the brazilian standard terminology _CEP_.