### PR TITLE
Fixes Deprecation warning for #has_rdoc

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.has_rdoc = false
-
   s.add_runtime_dependency 'i18n_data'
   s.add_runtime_dependency 'rails-i18n'
   s.add_runtime_dependency 'kaminari-i18n'


### PR DESCRIPTION
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/jpowell/.rvm/gems/ruby-2.4.4@milner5.1/bundler/gems/spree_i18n-2df03107cdbe/spree_i18n.gemspec:24.
```