### PR TITLE
Missing translations for Stores in es locale

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -371,6 +371,7 @@ es:
     add_state: Añadir provincia
     add_stock: Añadir Stock
     add_stock_management: Añadir gestión de stock
+    add_store: Añadir tienda
     add_to_cart: Añadir al carrito
     add_variant: Añadir variante
     additional_item: Coste de artículo adicional
@@ -410,6 +411,7 @@ es:
         order_history: Historial de Pedidos
         order_num: "Pedido #"
         orders: Pedidos
+        stores: Tiendas
         user_information: Información del Usuario
     administration: Administración
     advertise: Anunciar
@@ -1265,6 +1267,9 @@ es:
     stock_transfers: Transferencias de Stock
     stop: Parar
     store: Tienda
+    stores: Tiendas
+    store_default: Tienda predeterminada
+    store_set_default_button: Definir como predeterminada
     street_address: Calle
     street_address_2: Calle (cont.)
     subtotal: Subtotal


### PR DESCRIPTION
Hi everyone, I just began using spree_i18n and realized that there were some missing translations for *Stores* in the **es** locale, so i added them. Thanks for this awesome gem!