### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_i18n.gemspec
+++ b/spree_i18n.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'routing-filter'
   s.add_runtime_dependency 'spree_core', '>= 3.1.0', '< 5.0'
   s.add_runtime_dependency 'spree_extension'
+  s.add_runtime_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'byebug'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here