### PR TITLE
Correct translation for Prototype

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1342,7 +1342,7 @@ de:
     propagate_all_variants: Auf alle Varianten übertragen
     properties: Eigenschaften
     property: Eigenschaft
-    prototype: Prototype
+    prototype: Prototyp
     prototypes: Prototypen
     provider: Anbieter
     provider_settings_warning: Nach einer Änderung des Anbietertyps muss erst gespeichert werden.


### PR DESCRIPTION
Correct translation for Prototype

We are using the translation **Prototyp** at all the places except this one.

https://github.com/spree-contrib/spree_i18n/blob/b230796ed58cd6fe8197b4acdeea9ab89f3070ef/config/locales/de.yml#L426