### PR TITLE
zeitwerk load errors fix

### DIFF
--- a/lib/ignore_generator.rb
+++ b/lib/ignore_generator.rb
@@ -1,0 +1,5 @@
+require 'zeitwerk'
+
+loader = Zeitwerk::Loader.for_gem
+generator_ext = "#{__dir__}/generators/spree_i18n/install"
+loader.ignore(generator_ext)

--- a/lib/spree_i18n.rb
+++ b/lib/spree_i18n.rb
@@ -6,3 +6,5 @@ require 'spree_i18n/version'
 require 'spree/i18n_utils'
 require 'spree_extension'
 require 'deface'
+
+require 'ignore_generator'

--- a/lib/spree_i18n/version.rb
+++ b/lib/spree_i18n/version.rb
@@ -4,10 +4,10 @@ module SpreeI18n
   # Returns the version of the currently loaded SpreeI18n as a
   # <tt>Gem::Version</tt>.
   def version
-    Gem::Version.new VERSION::STRING
+    Gem::Version.new Version::STRING
   end
 
-  module VERSION
+  module Version
     MAJOR = 3
     MINOR = 3
     TINY  = 2


### PR DESCRIPTION
When running Rails 6.0.2.1, spree 4.0.3 on ruby 2.5.1 , zeitwerk - new default loader throwing following errors

- uninitialized constant SpreeI18n::Version (NameError)
Did you mean?  SpreeI18n::Version
               SpreeI18n::VERSION

- expected file bundler/gems/spree_i18n-215ae7eaafb7/lib/generators/spree_i18n/install/install_generator.rb to define constant Generators::SpreeI18n::Install::InstallGenerator, but didn't (Zeitwerk::NameError)