### PR TITLE
fixed zietwerk loading in production(2-final)

### DIFF
--- a/lib/spree_i18n/engine.rb
+++ b/lib/spree_i18n/engine.rb
@@ -5,7 +5,7 @@ module SpreeI18n
   class Engine < Rails::Engine
     engine_name 'spree_i18n'
 
-    config.eager_load_paths += %W(#{config.root}/lib)
+    config.autoload_paths += %W(#{config.root}/lib)
 
     initializer 'spree-i18n' do |app|
       SpreeI18n::Engine.instance_eval do

--- a/lib/spree_i18n/version.rb
+++ b/lib/spree_i18n/version.rb
@@ -4,10 +4,10 @@ module SpreeI18n
   # Returns the version of the currently loaded SpreeI18n as a
   # <tt>Gem::Version</tt>.
   def version
-    Gem::Version.new VERSION::STRING
+    Gem::Version.new Version::STRING
   end
 
-  module VERSION
+  module Version
     MAJOR = 3
     MINOR = 3
     TINY  = 2


### PR DESCRIPTION
When running Rails 6.0.2.1, spree 4.0.3 on ruby 2.5.1 in production, zeitwerk - new default loader throwing following errors

uninitialized constant SpreeI18n::Version (NameError)
Did you mean? SpreeI18n::Version
SpreeI18n::VERSION

expected file bundler/gems/spree_i18n-215ae7eaafb7/lib/generators/spree_i18n/install/install_generator.rb to define constant Generators::SpreeI18n::Install::InstallGenerator, but didn't (Zeitwerk::NameError)


- uninitialized constant SpreeI18n::Version (NameError)

Did you mean?  SpreeI18n::Version
               SpreeI18n::VERSION

- expected file bundler/gems/spree_i18n-215ae7eaafb7/lib/generators/spree_i18n/install/install_generator.rb to define constant Generators::SpreeI18n::Install::InstallGenerator, but didn't (Zeitwerk::NameError)