### PR TITLE
Allow to use Spree I18n in a headless scenario

### DIFF
--- a/app/controllers/spree/locale_controller.rb
+++ b/app/controllers/spree/locale_controller.rb
@@ -1,5 +1,5 @@
 module Spree
-  class LocaleController < Spree::StoreController
+  class LocaleController < Spree::BaseController
     def index
       render :index, layout: false
     end


### PR DESCRIPTION
`Spree::StoreController` is only available within `spree_frontend` gem