### PR TITLE
Fix SD-943 `Spree is not defined`

### DIFF
--- a/app/views/spree/layouts/_add_js_params.html.erb
+++ b/app/views/spree/layouts/_add_js_params.html.erb
@@ -1,3 +1,5 @@
 <%= javascript_tag do %>
-  Spree.url_params["locale"] = "<%= I18n.locale %>";
+  document.addEventListener("load", function(){
+    Spree.url_params["locale"] = "<%= I18n.locale %>";
+  })
 <% end %>


### PR DESCRIPTION
The proposed fix for `Spree is not defined` issue. Unfortunately not sure what change between Spree 4.0 and 4.1 causes this error.

https://spark-solutions.atlassian.net/secure/RapidBoard.jspa?rapidView=28&projectKey=SD&modal=detail&selectedIssue=SD-943