### PR TITLE
Update for SD-943

### DIFF
--- a/app/views/spree/layouts/_add_js_params.html.erb
+++ b/app/views/spree/layouts/_add_js_params.html.erb
@@ -1,5 +1,5 @@
 <%= javascript_tag do %>
-  document.addEventListener("load", function(){
+  window.addEventListener("load", function(){
     Spree.url_params["locale"] = "<%= I18n.locale %>";
   })
 <% end %>


### PR DESCRIPTION
Turns out that the `document` load is still too early for `Spree.url_params["locale"] = "<%= I18n.locale %>";` assignment. After wait for a `window` to load, a locale code is successfully assigned in `Spree.url_params`.