### PR TITLE
Apply localization in API v2 controller

### DIFF
--- a/app/controllers/spree/api/v2/base_controller_decorator.rb
+++ b/app/controllers/spree/api/v2/base_controller_decorator.rb
@@ -1,0 +1,4 @@
+module Spree::Api::V2::BaseControllerDecorator
+  Spree::Api::V2::BaseController.include(SpreeI18n::ControllerLocaleHelper)
+end
+Spree::Api::V2::BaseController.prepend(Spree::Api::V2::BaseControllerDecorator)


### PR DESCRIPTION
Unlike v1 API, v2 APIs don't currently accept `?locale=xx` param for getting localized entities (e.g. provided via spree-globalize gem).

It's caused by `Spree::API::V2::BaseController` inheriting directly from `ActionController::API`, so it omits `ControllerLocaleHelper` that's included in `Spree::API::BaseController`

In this PR I added a relevant decorator for base v2 API classes that solves this issue.