### PR TITLE
Swedish translation improvements

### DIFF
--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -548,7 +548,7 @@ sv:
     bill_address: Faktureringsadress
     billing: Fakturering
     billing_address: Faktureringsadress
-    both: Båda
+    both: Butikskassa & Administrationsgränssnitt
     calculated_reimbursements: Ersättningar som beräknats
     calculator: Kalkylator
     calculator_settings_warning: Om du ändra kalkylatortypen, måste du först spara innan du kan ändra kalkylatorinställningar
@@ -701,7 +701,7 @@ sv:
     discount_amount: Rabattbelopp
     discontinue_on: Utgår fr.o.m.
     dismiss_banner: Nej tack. Jag är inte intresserad, och visa inte detta meddelande igen
-    display: Visa
+    display: Visa i
     display_currency: Visa valuta
     doesnt_track_inventory: Det spårar inte inventeringen
     dont_have_account: Inget konto?
@@ -780,7 +780,7 @@ sv:
     forgot_password: Glömt Lösenord?
     free_shipping: Gratis leverans
     free_shipping_amount: "-"
-    front_end: Publik
+    front_end: Butikskassan
     gateway: Gateway
     gateway_config_unavailable: Gateway är inte tillgänglig för miljön
     gateway_error: Gateway-fel

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -23,6 +23,7 @@ sv:
         iso_name: ISO-namn
         name: Namn
         numcode: ISO-kod
+        states_required: Län obligatoriskt
       spree/credit_card:
         base:
         cc_type: Typ
@@ -31,6 +32,15 @@ sv:
         number: Nummer
         verification_value: Verifikationvärde
         year: "År"
+      spree/customer_return:
+        number: Returnnummer
+        pre_tax_total: Belopp före skatt
+        total: Total
+        reimbursement_status: Ersättningsstatus
+        name: Name
+      spree/image:
+        alt: Beskrivning
+        attachment: Filnamn
       spree/inventory_unit:
         state: Status
       spree/line_item:
@@ -38,7 +48,7 @@ sv:
         quantity: Antal
       spree/option_type:
         name: Namn
-        presentation: Presentation
+        presentation: Visa som
       spree/order:
         checkout_complete: Utcheckning genomförd
         completed_at: Fullständig vid
@@ -50,40 +60,43 @@ sv:
         item_total: Totalt antal
         number: Nummer
         payment_state: Betalningsstatus
-        shipment_state: Fraktstatus
+        shipment_state: Leveransstatus
         special_instructions: Särskilda instruktioner
         state: Status
         total: Totalt
       spree/order/bill_address:
         address1: Faktureringsadress, gata
         city: Faktureringsadress, ort
+        country: Land
         firstname: Faktureringsadress, förnamn
         lastname: Faktureringsadress, efternamn
         phone: Faktureringsadress, telefon
         state: Faktureringsadress, län
         zipcode: Faktureringsadress, postnr.
       spree/order/ship_address:
-        address1: Fraktadress, gata
-        city: Fraktadress, ort
-        firstname: Fraktadress, förnamn
-        lastname: Fraktadress, efternamn
-        phone: Fraktadress, telefon
-        state: Fraktadress, län
-        zipcode: Fraktadress, postnr.
+        address1: Leveransadress, gata
+        city: Leveransadress, ort
+        country: Land
+        firstname: Leveransadress, förnamn
+        lastname: Leveransadress, efternamn
+        phone: Leveransadress, telefon
+        state: Leveransadress, län
+        zipcode: Leveransadress, postnr.
       spree/payment:
         amount: Belopp
       spree/payment_method:
         name: Namn
       spree/product:
-        available_on: Tillgänglig
+        available_on: Tillgänglig fr.o.m.
         cost_currency: Kostnadsvaluta
         cost_price: Kostnadspris
         description: Beskrivning
+        less_than: <
         master_price: Grundpris
         name: Namn
         on_hand: På lager
-        shipping_category: Fraktkategori
-        tax_category: Momskategori
+        shipping_category: Leveranskategori
+        tax_category: Momsgrupp
       spree/promotion:
         advertise: Annonsera
         code: Rabattkod
@@ -94,28 +107,40 @@ sv:
         path: Sökväg
         starts_at: Startar
         usage_limit: Utnyttjargräns
+        promotion_category: "Kampanjkategori"
       spree/promotion_category:
-        name: Namn
+        name: "Namn"
+        code: "Kod"
       spree/property:
         name: Namn
-        presentation: Presentation
+        presentation: Visa som
       spree/prototype:
+        name: Namn
+      spree/refund_reason:
+        name: Namn
+      spree/reimbursement_type:
         name: Namn
       spree/return_authorization:
         amount: Belopp
+      spree/return_authorization_reason:
+        name: Namn
+      spree/return_reason:
+        name: Namn
       spree/role:
         name: Namn
       spree/state:
         abbr: Förkortning
         name: Namn
       spree/state_change:
-        state_changes: Status ändringar
+        state_changes: Statusändringar
         state_from: Status från
-        state_to: Status för
-        timestamp: Tidsstämpel
+        state_to: Status till
+        timestamp: Tid
         type: Typ
         updated: Uppdaterad
         user: Användare
+      spree/stock_location:
+        admin_name: Internt namn
       spree/store:
         mail_from_address: Mejl från adress
         meta_description: Ingress
@@ -176,10 +201,14 @@ sv:
             base:
               card_expired: Kortet har löpt ut
               expiry_invalid: Kortets utgångsdatum är ogiltig
+        spree/image:
+          attributes:
+            attachment:
+              attachment_must_be_present: för bilden saknas
         spree/line_item:
           attributes:
             currency:
-              must_match_order_currency: Måste matcha bestälningsvaluta
+              must_match_order_currency: Måste matcha orderns valuta
         spree/refund:
           attributes:
             amount:
@@ -187,7 +216,7 @@ sv:
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match: En eller flera av returposter som anges tillhör inte samma beställning som ersättningen.
+              return_items_order_id_does_not_match: En eller flera av returposter som anges tillhör inte samma order som ersättningen.
         spree/return_item:
           attributes:
             inventory_unit:
@@ -199,18 +228,24 @@ sv:
             base:
               cannot_destroy_default_store: Kan inte radera den primära butiken.
     models:
+      spree/image:
+        one: Bild
+        other: bilder
+      spree/adjustment:
+        one: Justering
+        other: justeringar
       spree/address:
         one: Adress
         other: Adresser
       spree/country:
-        one: Country
-        other: Land
+        one: Land
+        other: Länder
       spree/credit_card:
         one: Kreditkort
         other: Kreditkort
       spree/customer_return:
-        one: Kundretur
-        other: Kundreturer
+        one: Mottagen retur
+        other: mottagna returer
       spree/inventory_unit:
         one: Inventarie-enhet
         other: Inventarie-enheter
@@ -225,7 +260,7 @@ sv:
         other: Tillvalsvärden
       spree/order:
         one: Order
-        other: Order
+        other: Ordrar
       spree/payment:
         one: Betalning
         other: Betalningar
@@ -248,8 +283,8 @@ sv:
         one: Prototype
         other: Prototyper
       spree/refund_reason:
-        one: "Återbetalning skäl"
-        other: "Återbetalning skäl"
+        one: "Återbetalningsorsak"
+        other: "Återbetalningsorsaker"
       spree/reimbursement:
         one: Ersättning
         other: Ersättningar
@@ -257,20 +292,21 @@ sv:
         one: Ersättningstyp
         other: Ersättningtyper
       spree/return_authorization:
-        one: Returauktorisering
-        other: Returauktorisationer
+        one: Returmedgivande
+        other: returmedgivanden
       spree/return_authorization_reason:
-        one: Retur auktorisation skäl
-        other: Retur auktorisations skäl
+        one: Returneringsorsak
+        other: Returneringsorsak
       spree/role:
-        one: Uppgift
-        other: Uppgifter
+        few: Roller
+        one: Roll
+        other: Roller
       spree/shipment:
-        one: Frakt
-        other: Frakter
+        one: Leverans
+        other: Leveranser
       spree/shipping_category:
-        one: Fraktkategori
-        other: Fraktkategorier
+        one: Leveranskategori
+        other: Leveranskategorier
       spree/shipping_method:
         one: Leveransmetod
         other: Leveransmetoder
@@ -281,24 +317,27 @@ sv:
         one: Status ändring
         other: Status ändringar
       spree/stock_location:
-        one: Leverans plats
-        other: Leverans platser
+        one: Lagerplats
+        other: Lagerplatser
       spree/stock_movement:
       spree/stock_transfer:
         one: Lageröverföring
         other: Lageröverföringar
+      spree/store_credit_category:
+        one: Tillgodokategori
+        other: Tillgodokategorier
       spree/tax_category:
-        one: Momskategori
-        other: Momskategorier
+        one: Momsgrupp
+        other: Momsgrupper
       spree/tax_rate:
-        one: Momsklass
-        other: Momsklasser
+        one: Momsats
+        other: Momsatser
       spree/taxon:
         one: Klass
         other: Klasser
       spree/taxonomy:
-        one: Klassifikation
-        other: Klassifikationer
+        one: Klassifisering
+        other: Klassifiseringar
       spree/tracker:
         one: Spårare
         other: Spårare
@@ -381,36 +420,46 @@ sv:
     activate: Aktivera
     active: Aktiv
     add: Lägg till
+    added_to_cart: Lagd i varukorgen
     add_action_of_type: Lägg till åtgärd av typen
     add_country: Lägg till land
     add_coupon_code: Lägg till kupongkod
+    add_new_address: Lägg till adress
     add_new_header: Lägg till ny Header
     add_new_style: Lägg till ny stil
-    add_one: Addera en
-    add_option_value: Lägg till alternativvärde
+    add_one: lägg till en ny
+    add_option_value: Lägg till tillvalsvärde
     add_product: Lägg till produkt
     add_product_properties: Lägg till produktegenskaper
     add_rule_of_type: Lägg till regel av typ
     add_state: Lägg till län
     add_stock: Lägg till lager
     add_stock_management: Lägg till lagerhantering
+    add_store: Lägg till butik
+    add_store_credit: Lägg till tillgodohavande
     add_to_cart: Lägg i varukorgen
     add_variant: Lägg till variant
     additional_item: Ytterligare artikelkostnad
     address1: Adress
     address2: Adress (forts.)
+    addresses: Adresser
+    address_action_popup:
+      delete_title: Ta bort titel
+      delete_text: Ta bort text
+      delete_button: Ta bort knapp
     adjustable: Justerbar
     adjustment: Justering
     adjustment_amount: Belopp
-    adjustment_successfully_closed: "Ändring är framgångsrikt stängd!"
-    adjustment_successfully_opened: "Ändring är framgångsrikt öppnad!"
+    adjustment_successfully_closed: "Ändring stängd!"
+    adjustment_successfully_opened: "Ändring öppnad!"
     adjustment_total: Summa justeringar
     adjustments: "Ändringar"
     admin:
       tab:
         configuration: Konfiguration
+        customer_returns: Mottagna returer
         option_types: Tillvalstyper
-        orders: Beställningar
+        orders: Ordrar
         overview: "Översikt"
         products: Produkter
         promotions: Kampanjer
@@ -418,32 +467,37 @@ sv:
         properties: Egenskaper
         prototypes: Prototyper
         reports: Rapporter
-        taxonomies: Taxonomier
+        return_authorizations: "Returmedgivanden"
+        taxonomies: Klassificeringar
         taxons: Klasser
         users: Användare
       user:
         account: Konto
         addresses: Adresser
+        available_store_credit: Tillgodosaldo
         items: Artiklar
         items_purchased: Artiklar som köpts
-        order_history: Beställningshistorik
-        order_num: Beställning
-        orders: Beställningar
+        order_history: Orderhistorik
+        order_num: Ordernummer
+        orders: Ordrar
+        store_credits: Tillgodohavande
         user_information: Användarinformation
+        stores: Butiker
     administration: Administration
     advertise: Marknadsför
     agree_to_privacy_policy: Acceptera privatpolicyn
     agree_to_terms_of_service: Acceptera användarvillkoren
     all: Alla
-    all_adjustments_closed: Alla ändringar framgångsrikt stängda!
-    all_adjustments_opened: Alla ändringar framgångsrikt öppnade!
+    all_adjustments_closed: Alla ändringar stängda!
+    all_adjustments_opened: Alla ändringar öppnade!
     all_departments: Alla kategorier
-    all_items_have_been_returned: Alla artiklar har returnerats
+    all_items_have_been_returned: Alla artiklar har returnerats eller så finns det inget returnmedgivande för den här ordern.
+    all_rights_reserved: Alla rättigheter förbehållna
     allow_ssl_in_development_and_test: Tillåt SSL att användas i utvecklar- och test-läge
     allow_ssl_in_production: Tillåt SSL att användas i produktionsläge
     allow_ssl_in_staging: Allow SSL to be used in staging mode
     already_signed_up_for_analytics: Du har redan anmält dig till Spree Analytics
-    alt_text: Alternativ text
+    alt_text: Variant beskrivning
     alternative_phone: Alternativt telefonnummer
     amount: Belopp
     analytics_desc_header_1: Spree Analytics
@@ -454,6 +508,15 @@ sv:
     analytics_desc_list_4: Det är helt gratis!
     analytics_trackers: Statistikspårare
     and: och
+    api:
+      access: Integering med API
+      key: API-nyckel
+      key_generated: API-nyckel skapad
+      key_cleared: API-nyckel borttagen
+      clear_key: Ta bort API-nyckel
+      regenerate_key: Återskapa API-nyckel
+      no_key: Ingen API-nyckel
+      generate_key: Skapa API-nyckel
     approve: godkänn
     approved_at: Datum godkänt
     approver: Attestant
@@ -462,22 +525,23 @@ sv:
     associated_adjustment_closed: Den tillhörande justeringen är stängd, och blir inte omräknad. Vill du öppna den?
     at_symbol: '@'
     authorization_failure: Auktorisationen misslyckades
-    authorized: Auktoriserad
-    auto_capture: Auto-capture
-    available_on: Tillgänglig från
-    average_order_value: Genomsnittligt beställningsvärde
+    authorized: Medgivna
+    auto_capture: Fullgör betalning automatiskt
+    availability: Tillgänglighet
+    available_on: Tillgänglig fr.o.m.
+    average_order_value: Genomsnittligt orderbelopp
     avs_response: AVS svar
     back: Tillbaka
     back_end: Administrationsgränssnitt
     back_to_payment: Tillbaka till betalningen
     back_to_resource_list: Tillbaka till %{resource} listan
-    back_to_rma_reason_list: Tillbaka till RMA skäls listan
+    back_to_rma_reason_list: Tillbaka till returorsaks listan
     back_to_store: Tillbaka till butiken
     back_to_users_list: Tillbaka till användarlistan
-    backorderable: Möjligt att förhandsbeställa
-    backorderable_default:
+    backorderable: Möjligt att restnotera
+    backorderable_default: Alltid möjlig att restnotera
     backordered:
-    backorders_allowed: förhandsbeställning tillåtet
+    backorders_allowed: restnotering tillåtet
     balance_due: Summa att betala
     base_amount: Basbelopp
     base_percent: Grundprocent
@@ -489,30 +553,44 @@ sv:
     calculator: Kalkylator
     calculator_settings_warning: Om du ändra kalkylatortypen, måste du först spara innan du kan ändra kalkylatorinställningar
     cancel: avbryt
+    canceled: Avbrutna
     canceled_at: Avbeställd datum
     canceler: Avbeställare
-    cannot_create_customer_returns: Kan inte skapa kundreturer pg.a. att denna beställning har inga levererade artiklar.
+    cannot_create_customer_returns: Kan inte skapa mottagna returer eftersom artiklar har levererats för den här ordern.
     cannot_create_payment_without_payment_methods: Du kan inte skapa en betalning för en order utan några definierade betalningsmetoder
     cannot_create_returns: Kan inte returnera ordern eftersom den inte har levererats än.
     cannot_perform_operation: Kan inte utföra efterfrågad aktivitet
-    cannot_set_shipping_method_without_address: Kan inte använda fraktmetod förrän kunddetaljerna är angivna
-    capture: Fånga
+    cannot_set_shipping_method_without_address: Kan inte använda leveransmetod förrän kunddetaljerna är angivna
+    capture: Fullgör betalning
     capture_events:
     card_code: Säkerhetskod
     card_number: Kortnummer
     card_type: Varumärke
     card_type_is: Typ av kort är
     cart: Varukorg
+    cart_page:
+      add_promo_code: Rabattkod
+      checkout: Till kassan
+      empty_info: Varukorgen är tom
+      header: Varukorg
+      product: Produkt
+      title: Varukorg
+      quantity: Antal
     cart_subtotal:
       one: Delsumma (1 artikel)
       other: Delsumma (%{count} artiklar)
     categories: Kategorier
     category: Kategori
+    channel: Kanal
     charged: Debiterad
     check_for_spree_alerts: Kontrollera om det finns Spree larm
     checkout: Kassa
+    checkout_page:
+      back_to_cart: Fortsätt handla
+      delivery_method: Leveransalternativ
+      header: Varukorg
     choose_a_customer: Välj en kund
-    choose_a_taxon_to_sort_products_for: Välj ett grupp att sortera produkter för
+    choose_a_taxon_to_sort_products_for: Välj ett klass att sortera produkter för
     choose_currency: Välj valuta
     choose_dashboard_locale: Välj språk för Dashboard
     choose_location: Välj plats
@@ -525,6 +603,7 @@ sv:
     close: Stäng
     close_all_adjustments: Stäng alla ändringar
     code: Kod
+    commission: "Provision:"
     company: Företag
     complete: komplett
     configuration: Konfiguration
@@ -532,12 +611,13 @@ sv:
     confirm: Bekräfta
     confirm_delete: Bekräfta borttagning
     confirm_password: Bekräfta lösenord
+    contact_us: Kontanta oss
     continue: Fortsätt
     continue_shopping: Fortsätt handla
     cost_currency: Kostnadsvaluta
     cost_price: Kostnadspris
     could_not_connect_to_jirafe: Kunde inte ansluta till Jirafe för att synca data. Nytt försök görs automatiskt senare.
-    could_not_create_customer_return: Kunde inte skapa kundretur
+    could_not_create_customer_return: Kunde inte skapa mottagen retur
     could_not_create_stock_movement: Det blev ett problem att spara lagerrörelsen. Försök senare.
     count_on_hand: Tillgängligt
     countries: Länder
@@ -558,13 +638,16 @@ sv:
     coupon_code_max_usage: Kupongkodens brukbarhet överskriden
     coupon_code_not_eligible: Denna kupongkod är inte giltig för denna order
     coupon_code_not_found: Kupongkoden du angav finns ej. Försök på nytt
+    coupon_code_removed: Rabattkod borttagen
     coupon_code_unknown_error: Denna kupongkod kunde inte tillämpas i varukorgen vid denna tidpunkt.
     create: Skapa
+    created_by: Skapad av
     create_a_new_account: Skapa nytt konto
-    create_new_order: Skapa ny beställning
+    create_new_order: Skapa ny order
     create_reimbursement: Skapa ersättning
     created_at: Skapad
-    credit: Kredit
+    credit: Tillgodo
+    credited: Tillgodo
     credit_card: Kreditkort
     credit_cards: Kreditkort
     credit_owed: Kreditskulder
@@ -579,10 +662,11 @@ sv:
     customer: Kund
     customer_details: Detaljer om kund
     customer_details_updated: Kundens detaljer är uppdaterade
-    customer_return: Kundretur
-    customer_returns: Kundreturer
+    customer_return: Mottagen retur
+    customer_returns: Mottagna returer
     customer_search: Sök kund
     cut: Klipp
+    cvv: CVC
     cvv_response: CVV svar
     dash:
       jirafe:
@@ -606,7 +690,8 @@ sv:
     default_tax: Förvald moms
     default_tax_zone: Förvald moms-zon
     delete: Ta bort
-    deleted_variants_present: Vissa poster i denna beställning har produkter som inte längre finns.
+    delete_from_taxon: Ta bort klass
+    deleted_variants_present: Vissa poster i denna order har produkter som inte längre finns.
     delivery: Leverera
     depth: Djup
     description: Beskrivning
@@ -614,29 +699,31 @@ sv:
     destroy: Förstöra
     details: Detaljer
     discount_amount: Rabattbelopp
+    discontinue_on: Utgår fr.o.m.
     dismiss_banner: Nej tack. Jag är inte intresserad, och visa inte detta meddelande igen
     display: Visa
     display_currency: Visa valuta
     doesnt_track_inventory: Det spårar inte inventeringen
+    dont_have_account: Inget konto?
     edit: Redigera
     editing_resource: Redigerar %{resource}
-    editing_rma_reason: Redigerar RMA skäl
+    editing_rma_reason: Redigerar returneringorsak
     editing_user: Redigerar användare
     eligibility_errors:
       messages:
         has_excluded_product: Din varukorg innehåller en produkt som förhindrar detta kupongkod från att tillämpas.
-        item_total_less_than: Denna kupongkod kan inte tillämpas på beställningar med färre än %{amount}.
-        item_total_less_than_or_equal: Denna kupongkod kan inte tillämpas på beställningar med färre än eller lika med %{amount}.
-        item_total_more_than: Denna kupongkod kan inte tillämpas på beställningar högre än %{amount}.
-        item_total_more_than_or_equal: Denna kupongkod kan inte tillämpas på beställningar högre eller lika med %{amount}.
+        item_total_less_than: Denna kupongkod kan inte tillämpas på ordrar med färre än %{amount}.
+        item_total_less_than_or_equal: Denna kupongkod kan inte tillämpas på ordrar med färre än eller lika med %{amount}.
+        item_total_more_than: Denna kupongkod kan inte tillämpas på ordrar högre än %{amount}.
+        item_total_more_than_or_equal: Denna kupongkod kan inte tillämpas på ordrar högre eller lika med %{amount}.
         limit_once_per_user: Denna kupongkod kan bara användas en gång per användare.
-        missing_product: Denna kupongkod kan inte tillämpas eftersom du inte har alla nödvändiga produkter i din kundvagn.
-        missing_taxon: Du måste lägga till en produkt från alla nödvändiga kategorier innan du använder denna kupongkod.
+        missing_product: Denna kupongkod kan inte tillämpas eftersom du inte har alla nödvändiga produkter i din varukorg.
+        missing_taxon: Du måste lägga till en produkt från alla nödvändiga klass innan du använder denna kupongkod.
         no_applicable_products: Du måste lägga till en gällande produkt innan tillämpa denna kupongkod.
-        no_matching_taxons: Du måste lägga till en produkt från en gällande kategori innan du applicerar denna kupongkod.
+        no_matching_taxons: Du måste lägga till en produkt från en gällande klass innan du applicerar denna kupongkod.
         no_user_or_email_specified: Du måste logga in eller lämna din e-post innan tillämpa denna kupongkod.
         no_user_specified: Du måste logga in innan du applicerar denna kupongkod.
-        not_first_order: Denna kupongkod kan endast tillämpas på din första beställning.
+        not_first_order: Denna kupongkod kan endast tillämpas på din första order.
     email: Epost
     empty: Tom
     empty_cart: Töm varukorgen
@@ -649,7 +736,7 @@ sv:
       messages:
         could_not_create_taxon: Kunde inte skapa klass
         no_payment_methods_available: Inga betalningsmetoder är konfigurerade för denna miljö
-        no_shipping_methods_available: Inget fraktsätt är tillgängligt för den valda platsen. Var god ändra din adress och försök igen.
+        no_shipping_methods_available: Inget leveransmetod är tillgängligt för den valda platsen. Var god ändra din adress och försök igen.
     errors_prohibited_this_record_from_being_saved:
       one: 1 fel hindrade detta inlägg att sparas
       other: "%{count} fel hindrade detta inlägg att sparas"
@@ -669,19 +756,21 @@ sv:
           signup: Användarregistrering
     exceptions:
       count_on_hand_setter: Kan inte sätta tillgängligt manuellt eftersom det ställs in automatisk av recalculate_count_on_hand callback. Använd istället 'update_column(:count_on_hand, value)'
-    exchange_for:
+    exchange_for: byt till
     excl: exkl.
     existing_shipments: Existerande leveranser
     expedited_exchanges_warning:
     expiration: Upphörande
     extension: Utökning
+    extensions_directory: Insticksprogram
     failed_payment_attempts: Misslyckade betalningsförsök
     filename: Filnamn
     fill_in_customer_info: Fyll i kundens information
+    filter: Filter
     filter_results: Filtrera resultaten
     finalize: Slutför
     finalized: Slutförd
-    find_a_taxon: Hitta en grupp
+    find_a_taxon: Hitta en klass
     first_item: Första artikelns kostnad
     first_name: Förnamn
     first_name_begins_with: Förnamn börjar med
@@ -689,7 +778,7 @@ sv:
     flat_rate_per_order: Fast pris (per order)
     flexible_rate: Flexibelt sats
     forgot_password: Glömt Lösenord?
-    free_shipping: Gratis frakt
+    free_shipping: Gratis leverans
     free_shipping_amount: "-"
     front_end: Publik
     gateway: Gateway
@@ -697,19 +786,41 @@ sv:
     gateway_error: Gateway-fel
     general: Allmänt
     general_settings: Allmänna inställningar
+    generate_code: "Generera kod"
+    go_to_category: Kategorier
     google_analytics: Google Analytics
     google_analytics_id: Analytics-ID
     guest_checkout: Gästkassa
     guest_user_account: Gå till kassan som gäst
     has_no_shipped_units: har inga levererade enheter
     height: Höjd
+    help_center: Hjälp
     hide_cents: Dölj ören
     home: Hem
+    homepage:
+      bestsellers: bestsellers
+      fashion_trends: modetrender
+      fashion_trends_note: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+      men: Män
+      new: Nytt
+      new_collection: Ny kollektion
+      read_more: Läs mer
+      shoes: Skor
+      shop_now: Handla nu
+      sportswear: Sportkläder
+      streetstyle: Street
+      summer_2019: Sommar 2019
+      summer_collection: Sommarkollektion
+      summer_sale: Sommarrea
+      trending: Populärt
+      up_to_60: Upp till 60%
+      women: Kvinnor
     i18n:
       available_locales: Tillgängliga språk
       language: Språk
       localization_settings: Lokaliseringsinställningar
       this_file_language: Svenska (SE)
+      locales_displayed_on_frontend_select_box: Tillgängliga språk visas på kundsidan
     icon: Ikon
     identifier: Identifierare
     image: Bild
@@ -717,6 +828,7 @@ sv:
     implement_eligible_for_return: Måste genomföra
     implement_requires_manual_intervention: Måste genomföra
     inactive: Inaktiv
+    in_stock: På lager
     incl: inkl.
     included_in_price: Inkluderat i pris
     included_price_validation: kan inte väljas om du inte har ställt in en förvald momszon
@@ -729,7 +841,7 @@ sv:
       other: 'Denna produkt har %{count} varianter:'
     instructions_to_reset_password: Skriv in din e-post i formuläret nedan
     insufficient_stock: Otillräckligt lager tillgängligt, endast %{on_hand} återstår
-    insufficient_stock_lines_present: Vissa poster i denna beställning har otillräcklig mängd.
+    insufficient_stock_lines_present: Vissa poster i denna order har otillräcklig mängd.
     intercept_email_address: Fånga e-postadress
     intercept_email_instructions: Skriv över epost-mottagarens adress och ersätt med denna.
     internal_name: Internt namn
@@ -742,7 +854,7 @@ sv:
     inventory_adjustment: Inventariejustering
     inventory_error_flash_for_insufficient_quantity: En artikel i din varukorg är inte längre tillgänglig.
     inventory_state: Lagerstatus
-    is_not_available_to_shipment_address: "är inte tillgänglig till fraktadress"
+    is_not_available_to_shipment_address: "är inte tillgänglig till leveransadress"
     iso_name: Iso namn
     item: Artikel
     item_description: Artikelbeskrivning
@@ -754,10 +866,12 @@ sv:
         lt: mindre än
         lte: mindre än eller lika med
     items_cannot_be_shipped: Vi kan inte skicka till den angivna adressen. Var vänlig välj en annan adress.
-    items_in_rmas:
-    items_reimbursed:
-    items_to_be_reimbursed:
+    items_in_rmas: Artikel i byte
+    items_reimbursed: Ersatta artiklar
+    items_to_be_reimbursed: Atriklar att ersättas
+    issued_on: Utfärdat
     jirafe: Jirafe
+    join_slack: Anslut till Slack
     landing_page_rule:
       path: Sökväg
     last_name: Efternamn
@@ -778,6 +892,8 @@ sv:
     login_as_existing: Logga in som existerande kund
     login_failed: Inloggningen misslyckades.
     login_name: Inloggning
+    log_in: Logga in
+    log_in_to_continue: Logga in
     logout: Logga ut
     logs: Loggar
     look_for_similar_items: Visa liknande artiklar
@@ -787,12 +903,13 @@ sv:
     manage_variants: Hantera varianter
     manual_intervention_required:
     master_price: Grundpris
+    master_sku: Huvud-SKU
     match_choices:
       all: Alla
       none: Ingen
     max_items: Max antal varor
     member_since: Medlem sedan
-    memo: PM
+    memo: Anteckningar
     meta_description: Metabeskrivning
     meta_keywords: Metanyckelord
     meta_title: Rubrik
@@ -801,18 +918,30 @@ sv:
     month: Månad
     more: Mer
     move_stock_between_locations: Flytta lager mellan platser
+    mutable: Föränderlig
     my_account: Mitt konto
-    my_orders: Mina beställningar
+    my_orders: Mina ordrar
     name: Namn
     name_on_card: Namn på kortet
     name_or_sku: Namn eller SKU (ange minst de 4 första bokstäverna i produktnamnet)
+    nav_bar:
+      show_search: "Sök"
+      show_user_menu: Användare
+      close_menu: Stäng meny
+      go_to_previous_menu: Gå till föregående meny
+      log_in: Logga in
+      log_out: Logga ut
+      my_account: Mitt konto
+      my_orders: Mina ordrar
+      show_menu: Visa meny
+      sign_up: Skaffa konto
     new: Ny
     new_adjustment: Ny ändring
     new_country: Nytt land
     new_customer: Ny kund
-    new_customer_return: Ny kundretur
+    new_customer_return: Ny mottagen retur
     new_image: Ny bild
-    new_option_type: Ny alternativtyp
+    new_option_type: Ny tillvalstyp
     new_order: Ny order
     new_order_completed: Ny order slutförd
     new_payment: Ny betalning
@@ -823,20 +952,23 @@ sv:
     new_property: Ny egenskap
     new_prototype: Ny prototyp
     new_refund: Ny återbetalning
-    new_refund_reason: Nytt återbetalning skäl
-    new_return_authorization: Ny returauktorisation
-    new_rma_reason: Nytt RMA skäl
+    new_refund_reason: Ny återbetalningsorsak
+    new_reimbursement_type: Ny ersättningstyp
+    new_return_authorization: Nytt returmedgivande
+    new_role: Ny roll
+    new_rma_reason: Ny returneringsorsak
     new_shipment_at_location: Ny leverans på plats
-    new_shipping_category: Ny fraktkategori
-    new_shipping_method: Ny fraktmetod
+    new_shipping_category: Ny leveranskategori
+    new_shipping_method: Ny leveransmetod
     new_state: Nytt län
     new_stock_location: Ny lagerplats
     new_stock_movement: Ny lagerrörelse
     new_stock_transfer: Ny lageröverföring
-    new_tax_category: Ny momskategori
+    new_store_credit_category: Ny tillgodokategori
+    new_tax_category: Ny momsgrupp
     new_tax_rate: Ny momssats
     new_taxon: Ny klass
-    new_taxonomy: Ny klassifikation
+    new_taxonomy: Ny klassifisering
     new_tracker: Ny statistikspårare
     new_user: Ny användare
     new_variant: Ny variant
@@ -845,14 +977,17 @@ sv:
     no_actions_added: Inga handlingar tillagda
     no_payment_found: Ingen betalning hittades
     no_pending_payments: Inga förestående betalningar
+    no_product_available:
+      opps: Hoppsan!
+      for_this_quantity: Så många produkter är inte tillgängliga
     no_products_found: Inga produkter hittades
-    no_resource_found: ingen %{resource} hittades
+    no_resource_found: Inga %{resource} hittades
     no_results: Inga resultat
     no_returns_found: Inga returer hittades
     no_rules_added: Inga regler tillagda
     no_shipping_method_selected: Ingen leveransmetod vald.
     no_state_changes: Inga status förändringar ännu.
-    no_tracking_present: Inga spårningsdetaljer tillgodosedda
+    no_tracking_present: Inga spårningsdetaljer tillgängliga
     none: Ingen
     none_selected: Ingen vald
     normal_amount: Normalt belopp
@@ -868,24 +1003,26 @@ sv:
       product_not_deleted: Produkten kunde inte tas bort
       variant_deleted: Varianten har tagits bort
       variant_not_deleted: Varianten kunde inte tas bort
-    num_orders: "# Beställningar"
+    num_orders: "Totalt antal ordrar"
+    number: Nummer
+    ok: OK
     on_hand: Tillgängligt
     open: "Öppen"
     open_all_adjustments: "Öppna alla ändringar"
-    option_type: Alternativtyp
-    option_type_placeholder: Välj typ av alternativ
-    option_types: Alternativtyper
-    option_value: Alternativsvärde
-    option_values: Alternativsvärden
+    option_type: Tillvalstyp
+    option_type_placeholder: Välj typ av tillval
+    option_types: Tillvalstyper
+    option_value: Tillvalsvärde
+    option_values: Tillvalsvärden
     optional: Extra
-    options: Alternativ
+    options: Tillval
     or: eller
     or_over_price: "%{price} eller över"
     order: Order
     order_adjustments: Orderändring
-    order_already_updated: Beställningen har redan uppdaterats.
-    order_approved: Beställningen godkänd
-    order_canceled: Beställningen annullerad
+    order_already_updated: Ordern har redan uppdaterats.
+    order_approved: Ordern godkänd
+    order_canceled: Ordern annullerad
     order_details: Orderdetaljer
     order_email_resent: Order epost har skickats igen
     order_information: Orderinformation
@@ -893,40 +1030,43 @@ sv:
       cancel_email:
         dear_customer: Bäste kund,\n
         instructions: Din order är AVBRUTEN. Spara denna information.
-        order_summary_canceled: Summering order [AVBRUTEN]
+        order_summary_canceled: Översikt order [AVBRUTEN]
         subject: Annullering av order
         subtotal: 'Delsumma:'
         total: 'Totalsumma:'
       confirm_email:
         dear_customer: Bäste kund,\n
         instructions: Kontrollera och spara denna orderinformation.
-        order_summary: Summering order
+        order_summary: Översikt order
         subject: Orderbekräftelse
         subtotal: 'Delsumma:'
         thanks: Tack för dit köp.
         total: 'Totalsumma:'
     order_not_found: Vi kunde inte hitta din order. Gör ett nytt försök.
-    order_number: Beställning %{number}
+    order_number: Ordernummer
     order_processed_successfully: Din order har tagits emot.
-    order_resumed: Beställningen återupptogs
+    order_resumed: Ordern återupptogs
     order_state:
-      address: adress
-      awaiting_return: väntar på retur
-      canceled: annulerad
-      cart: kundvagn
-      complete: slutförd
-      confirm: bekräfta
-      considered_risky: anses riskabel
-      delivery: leverans
-      payment: betalning
-      resumed: fortsatt
-      returned: returnerad
-    order_summary: Ordersammanfattning
+      address: Adress
+      awaiting_return: Inväntar retur
+      canceled: Annulerad
+      cart: Varukorg
+      complete: Slutförd
+      confirm: Bekräftad
+      considered_risky: Anses riskabel
+      delivery: Leverans
+      payment: Betalning
+      resumed: Återupptagen
+      returned: Returnerad
+      payment_confirm: Betalningsbekräftan
+    order_summary: Order
+    order_success: Toppen!
+    order_success_explain: Ordern mottagen!
     order_sure_want_to: "Är du säker på att du vill %{event} denna order?"
     order_total: Summa att betala
     order_updated: Order uppdaterad
     orders: Ordrar
-    other_items_in_other: Andra artiklar i beställningen
+    other_items_in_other: Andra artiklar i ordern
     out_of_stock: Ej i lager
     overview: "Översikt"
     package_from: paket från
@@ -948,19 +1088,24 @@ sv:
     payment_processing_failed: Betalningen kunde inte behandlas, var god kolla att uppgifterna som du skrev in är korrekta
     payment_processor_choose_banner_text: Om du behöver hjälp med att välja en betaltjänst, besök
     payment_processor_choose_link: vår betalningssida
-    payment_state: Betalningsstatus
+    payment_state: Betalningstatus
     payment_states:
-      balance_due: resterande belopp
-      checkout: kassa
-      completed: slutförd
-      credit_owed: kreditskulder
-      failed: misslyckades
-      paid: betald
-      pending: avvaktande
-      processing: hanteras
-      void: tom
+      balance_due: Inväntar
+      checkout: Kassa
+      completed: Slutförd
+      credit_owed: Restskuld
+      failed: Misslyckades
+      paid: Fullgjord
+      pending: Väntande
+      processing: Behandlas
+      void: Ogiltig
+    payment_type: Betalsätt
     payment_updated: Betalning uppdaterad
     payments: Betalningar
+    pdp:
+      checkout: Till kassan
+      view_cart: Till varukorgen
+      quantity: Antal
     pending: Avvaktande
     percent: Procent
     percent_per_item: Procent per artikel
@@ -968,18 +1113,34 @@ sv:
     phone: Telefon
     place_order: Placera order
     please_define_payment_methods: Definiera först någon betalningsmetod
+    plp:
+      clear_all: Rensa filter
+      default: Alla
+      done: Klart
+      filter_by: Filtrera efter
+      home: Hem
+      newest_first: Nyaste överst
+      no_results: Inga resultat
+      not_found_filters1: Första filtret gav inga resultat
+      not_found_filters2: Andra filtret gav inga resltat
+      not_found_filters3: Andra filtret gav inga resultat
+      price: Pris
+      price_high_to_low: Högsta pris
+      price_low_to_high: Lägsta pris
+      sort_by: Sortera efter
     populate_get_error: Något gick fel. Försök att lägga till artikeln igen.
     powered_by: Powered by
-    pre_tax_amount:
-    pre_tax_refund_amount:
-    pre_tax_total:
+    pre_tax_amount: Belopp före skatt
+    pre_tax_refund_amount: Ersättningsbelopp före skatt
+    pre_tax_total: Belopp före skatt
     preferred_reimbursement_type: "Önskad ersättningstyp"
-    presentation: Presentation
+    presentation: Visa som
     previous: Föregående
-    previous_state_missing:
+    previous_state_missing: Föregående status saknas
     price: Pris
     price_range: Prisintervall
     price_sack: Prisgräns
+    preview_product: Förhandsgranska produkt
     process: Hantera
     product: Produkt
     product_details: Produktdetaljer
@@ -988,15 +1149,17 @@ sv:
     product_properties: Produktegenskaper
     product_rule:
       choose_products: Välj produkter
-      label: Beställningen måste innehålla x mängd av dessa produkter
+      label: Ordern måste innehålla x mängd av dessa produkter
       match_all: alla
       match_any: minst en av
       match_none: ingen
       product_source:
-        group: Från produktgrupp
+        group: Från produktklass
         manual: Välj manuellt
     products: Produkter
     promotion: Kampanj
+    promotions: Kampanjer
+    promotionable: Kan kampanjföras
     promotion_action: Kampanjaction
     promotion_action_types:
       create_adjustment:
@@ -1009,13 +1172,15 @@ sv:
         description: Fyll varukorgen med det angivna antalet av variant
         name: Skapa radartiklar
       free_shipping:
-        description: Gör alla leveranser för beställningen kostnadsfria
+        description: Gör alla leveranser kostnadsfria
         name: Fri leverans
-    promotion_actions: Actions
+    promotion_actions: "Åtgärd"
+    promotion_category: "Kampanjkategori"
     promotion_form:
       match_policies:
         all: Matcha alla dessa regler
         any: Matcha någon av dessa regler
+    promotion_label: Kampanj
     promotion_rule: Kampanjregel
     promotion_rule_types:
       first_order:
@@ -1031,14 +1196,14 @@ sv:
         description: Endast ett bruk per användare
         name: Endast ett bruk per användare
       option_value:
-        description: Beställningen innehåller angivna produkt(er) med matchande alternativvärde(n)
-        name: Alternativvärde(n)
+        description: Ordern innehåller angivna produkt(er) med matchande alternativvärde(n)
+        name: Tillvalsvärde(n)
       product:
         description: Order inkluderar angivna produkt(er)
         name: Produkt(er)
       taxon:
-        description: Beställningen innehåller produkter med specificerade grupp(er)
-        name: Grupp(er)
+        description: Ordern innehåller produkter med specificerade klass(er)
+        name: Klass(er)
       user:
         description: Tillgänglig bara för de angivna användarna
         name: Användare
@@ -1046,36 +1211,36 @@ sv:
         description: Tillgänglig endast för inloggade användare
         name: Användare inloggad
     promotion_uses:
-    promotionable:
-    promotions: Kampanjer
-    propagate_all_variants:
+    propagate_all_variants: Propagera i alla varianter
     properties: Egenskaper
     property: Egenskap
     prototype: Prototyp
     prototypes: Prototyper
     provider: Leverantör
     provider_settings_warning: Om du ändrar leverantörstypen, måste du först spara innan du kan ändra leverantörens inställningar
+    purchased_quantity: köpt antal
     qty: Antal
     quantity: Antal
     quantity_returned: Antal returnerade
     quantity_shipped: Antal levererade
     quick_search: Snabbsökning..
-    rate: Kurs
-    reason: Anledning
+    rate: Momssats
+    reason: Orsak
     receive: ta emot
     receive_stock: Motta lager
     received: Mottaget
     reception_status:
     reference: Referens
+    reference_contains: Referens innehåller
     refund: "Återbetala"
     refund_amount_must_be_greater_than_zero:
-    refund_reasons: "Återbetalning anledning"
+    refund_reasons: "Återbetalningsorsaker"
     refunded_amount: "Återbetalningsbelopp"
     refunds: "Återbetalning"
     register: Registrera dig
     registration: Registrering
     reimburse: Ersätta
-    reimbursed:
+    reimbursed: Ersatt
     reimbursement: Ersättning
     reimbursement_mailer:
       reimbursement_email:
@@ -1090,7 +1255,7 @@ sv:
     reimbursement_perform_failed:
     reimbursement_status: Ersättningsstatus
     reimbursement_type: Ersättningstyp
-    reimbursement_type_override:
+    reimbursement_type_override: Annan ersättningstyp
     reimbursement_types: Ersättningstyper
     reimbursements: Ersättningar
     reject: Avvisa
@@ -1101,15 +1266,19 @@ sv:
     report: Rapport
     reports: Rapporter
     resend: Skicka igen
+    resellable: Kan säljas igen
     reset_password: "Återställ mitt lösenord"
     response_code: Svarskod
     resume: "återuppta"
     resumed: "Återupptagen"
     return: returera
-    return_authorization: Returauktorisation
-    return_authorization_reasons:
-    return_authorization_updated: Returauktorisation uppdaterad
-    return_authorizations: Returauktorisation
+    return_authorization: Returmedgivande
+    return_authorization_reasons: Returorsaker
+    return_authorization_states:
+      authorized: medgiven
+      canceled: avbruten
+    return_authorization_updated: Returmedgivande uppdaterad
+    return_authorizations: Returmedgivanden
     return_item_inventory_unit_ineligible:
     return_item_inventory_unit_reimbursed:
     return_item_rma_ineligible:
@@ -1121,18 +1290,22 @@ sv:
     returned: Returnerad
     returns: Returer
     review: Granska
+    required: Obligatoriskt
+    required_fields: Obligatorisk information
     risk: Risk
     risk_analysis: Riskanalys
     risky: Riskabel
-    rma_credit: RMA-kredit
-    rma_number: RMA-nummer
-    rma_value: RMA-värde
-    roles: Uppgifter
+    rma_credit: Returneringskredit
+    rma_number: Returneringsnummer
+    rma_value: Returneringsvärde
+    role_id: Roll
+    roles: Roller
     rules: Regler
     safe: Säker
     sales_total: Total försäljning
     sales_total_description: Total försäljning på alla ordrar
     sales_totals: Total försäljning
+    saving: Sparar...
     save_and_continue: Spara och fortsätt
     save_my_address: Spara min adress
     say_no: Nej
@@ -1144,10 +1317,12 @@ sv:
     secure_connection_type: Säker anslutningstyp
     security_settings: Säkerhetsinställningar
     select: Välj
-    select_a_return_authorization_reason:
+    select_a_return_authorization_reason: Välj orsak till returneringen
     select_a_stock_location: Välj lager pats
     select_from_prototype: Välj från prototyp
     select_stock: Välj lager
+    select_a_store_credit_reason: Orsak tillgodohavande
+    selected_quantity_not_available: "finns inte på lager"
     send_copy_of_all_mails_to: Skicka kopia av alla mail till
     send_mails_as: Skicka e-post som
     server: Server
@@ -1155,7 +1330,7 @@ sv:
     settings: Inställningar
     ship: leverera
     ship_address: Leveransadress
-    ship_total: Leverans totalt
+    ship_total: Leveranskostnad
     shipment: Leverans
     shipment_adjustments: Leveransjusteringar
     shipment_details: Från %{stock_location} via %{shipping_method}
@@ -1163,19 +1338,19 @@ sv:
       shipped_email:
         dear_customer: Bäste kund,\n
         instructions: Din order har levererats
-        shipment_summary: Summering leverans
+        shipment_summary: Översikt leverans
         subject: Leveransbesked
         thanks: Tack för ditt köp.
         track_information: 'Tracking Information: %{tracking}'
         track_link: 'Tracking länk: %{url}'
     shipment_state: Leveransstatus
     shipment_states:
-      backorder: förhandsbeställning
-      canceled: annulerad
-      partial: partiell
-      pending: avvaktande
-      ready: färdig
-      shipped: levererad
+      backorder: Restnoterad
+      canceled: Annulerad
+      partial: Delleverans
+      pending: Väntande
+      ready: Färdig
+      shipped: Levererad
     shipment_transfer_error: Det uppstod ett fel med variant överföringen
     shipment_transfer_success: Varianterna har nu överförts
     shipments: Leveranser
@@ -1191,15 +1366,17 @@ sv:
     shipping_method: Leveransmetod
     shipping_methods: Leveransmetoder
     shipping_price_sack: Prisgräns
-    shipping_total: Frakt totalt
+    shipping_total: Leverans totalt
     shop_by_taxonomy: Köp via %{taxonomy}
+    show_discontinued: Visa utgångna
     shopping_cart: Varukorg
     show: Visa
     show_active: Visa aktiva
     show_deleted: Visa borttagna
-    show_only_complete_orders: Visa endast slutförda beställningar
-    show_only_considered_risky: Visa endast riskfyllda beställningar
+    show_only_complete_orders: Visa endast slutförda ordrar
+    show_only_considered_risky: Visa endast riskfyllda ordrar
     show_rate_in_label: Visa pris i etikett
+    sign_up: Skaffa konto
     sku: SKU
     skus: SKU's
     slug: Permalänk
@@ -1209,7 +1386,7 @@ sv:
     spree_gateway_error_flash_for_checkout: Det var ett problem med din betalningsinformation. Kontrollera din information och försök igen.
     ssl:
       change_protocol: Vänligen ändra till HTTP (snarare än HTTPS) och försök igen.
-    start: Starta
+    start: Start
     state: Län
     state_based: Län-baserad
     state_machine_states:
@@ -1218,23 +1395,23 @@ sv:
       authorized: Auktoriserad
       awaiting: Inväntar
       awaiting_return: Inväntar retur
-      backordered:
+      backordered: Restnoterad
       canceled: Avbruten
-      cart: Kundvagn
+      cart: Varukorg
       checkout: Kassan
-      closed: Stängd
+      closed: "Stängd"
       complete: Genomförd
       completed: Genomförd
       confirm: Bekräfta
       delivery: Leverans
       errored: Fel uppstod
-      failed: Misslyckades
+      failed: Misslyckad
       given_to_customer:
       invalid: Ogiltigt
       manual_intervention_required:
       on_hand: I lager
       open: "Öppen"
-      order: Beställning
+      order: Order
       payment: Betalning
       pending: Avvaktande
       processing: Under bearbetning
@@ -1243,14 +1420,20 @@ sv:
       resumed: "Återupptagen"
       returned: Returnerad
       shipped: Skickad
-      void: Void
+      shipment: Leverans
+      void: Ogiltig
     states: Län
     states_required: Län krävs
     status: Status
+    store_credit:
+      errors:
+        unable_to_create: Kunde inte skapa tillgodohavande
+    store_credit_name: Tillgodohavande
+    store_credit_categories: Tillgodokategorier
     stock: Lager
-    stock_location: Lagerplacering
+    stock_location: Lagerplats
     stock_location_info: Information om lagret
-    stock_locations: Lagerplaceringar
+    stock_locations: Lagerplatser
     stock_locations_need_a_default_country: Du måste skapa ett förvalt land innan du skapar en lager plats.
     stock_management: Lagerhantering
     stock_management_requires_a_stock_location: Skapa en lagerplats för att kunna hantera lagret
@@ -1261,6 +1444,7 @@ sv:
     stock_transfers: Lageröverföringar
     stop: Stopp
     store: Butik
+    stores: Butiker
     street_address: Adress
     street_address_2: Adress (forts.)
     subtotal: Delsumma
@@ -1271,10 +1455,11 @@ sv:
     successfully_removed: "%{resource} är borttagen!"
     successfully_signed_up_for_analytics: Anmälan till Spree Analytics klar
     successfully_updated: "%{resource} är uppdaterad!"
-    summary: Summering
+    summary: Översikt
+    tags_placeholder: Lägg till etikett
     tax: Moms
-    tax_categories: Momskategorier
-    tax_category: Momskategori
+    tax_categories: Momsgrupper
+    tax_category: Momsgrupp
     tax_code: Momskod
     tax_included: Moms (inkl.)
     tax_rate_amount_explanation: Momssatsen anges som decimalsiffor (t.ex. om momssatsen är 25%, skriv 25.0)
@@ -1283,15 +1468,15 @@ sv:
     taxon_edit: Redigera klass
     taxon_placeholder: Lägg till klass
     taxon_rule:
-      choose_taxons: Välj grupp
+      choose_taxons: Välj klass
       label:
       match_all: alla
       match_any: minst en
-    taxonomies: Klassificeringar
-    taxonomy: Klassificering
-    taxonomy_edit: "Ändra Klassificering"
-    taxonomy_tree_error: "Ändringen har inte accepterats och trädet har återställts till sitt tidigare tillstånd. Var god försök igen."
-    taxonomy_tree_instruction: "* Högerklicka på en kategori för att komma åt menyn för att lägga till, ta bort eller sortera klasser."
+    taxonomies: Klassifiseringar
+    taxonomy: Klassifisering
+    taxonomy_edit: "Ändra klassifisering"
+    taxonomy_tree_error: "Ändringen har inte accepterats och trädet har återställts. Var god försök igen."
+    taxonomy_tree_instruction: "* Högerklicka på en klassifisering för att lägga till, ta bort eller sortera klassifiseringar."
     taxons: Klasser
     test: Test
     test_mailer:
@@ -1312,7 +1497,7 @@ sv:
     to_add_variants_you_must_first_define: För att lägga till varianter måste du först definiera
     total: Totalt
     total_per_item: Totalt per artikel
-    total_pre_tax_refund:
+    total_pre_tax_refund: "Total återbetalning före skatt:"
     total_price: Total pris
     total_sales: Total försäljning
     track_inventory: Spåra inventering
@@ -1335,11 +1520,13 @@ sv:
     unshippable_items: Ej leveransmöjliga artiklar
     update: Uppdatera
     updating: Uppdaterar
+    url: URL
     usage_limit: Användargräns
     use_app_default: Använd standard applikation
     use_billing_address: Använd faktureringsadress
     use_new_cc: Använd ett nytt kort
     use_s3: Använd Amazon S3 för bilder
+    used: Använt
     user: Användare
     user_rule:
       choose_users: Välj användare
@@ -1363,7 +1550,7 @@ sv:
     what_is_this: Vad är det här?
     width: Bredd
     year: "År"
-    you_have_no_orders_yet: Du har inga order än.
+    you_have_no_orders_yet: Du har inga ordrar än.
     your_cart_is_empty: Varukorgen är tom
     your_order_is_empty_add_product: Din order är tom, sök och lägg till produkten ovan
     zip: Postnr.

--- a/spec/features/admin/translations_spec.rb
+++ b/spec/features/admin/translations_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Translations', :js do
   context 'localization settings' do
     given(:language) { Spree.t(:this_file_language, scope: 'i18n', locale: 'de') }
     given(:french) { Spree.t(:this_file_language, scope: 'i18n', locale: 'fr') }
+    given(:swedish) { Spree.t(:this_file_language, scope: 'i18n', locale: 'sv') }
 
     background do
       SpreeI18n::Config.available_locales = []
@@ -29,6 +30,13 @@ RSpec.feature 'Translations', :js do
       find('.select2-result-selectable', text: french).click
       click_on 'Update'
       expect(SpreeI18n::Config.available_locales).to include(:fr)
+    end
+
+    scenario 'adds swedish to available locales' do
+      find('#s2id_available_locales_').click
+      find('.select2-result-selectable', text: swedish).click
+      click_on 'Update'
+      expect(SpreeI18n::Config.available_locales).to include(:sv)
     end
   end
 end

--- a/spec/features/translation_spec.rb
+++ b/spec/features/translation_spec.rb
@@ -27,4 +27,12 @@ RSpec.describe 'Translation' do
       expect(translation).to eq 'Código Postal'
     end
   end
+
+    # Swedish is chosen
+  context 'when current locale is Swedish' do
+    it 'translation is available' do
+      I18n.locale = :'sv'
+      expect(translation).to eq 'Postnummer'
+    end
+  end
 end


### PR DESCRIPTION
## Swedish translation improvements #854
- Add some test cases.
- Add Swedish translations for spree 4.1
- Improve terminology consistency: 
-- Beställning/Order -> Order.
-- Momsklass/kategori -> Momsgrupp
-- Frakt->Leverans
-- Kundvagn->Varukorg
--  .. etc.

- Improve semantics: 
-- Auktoriserad->Medgiven
-- Förhandsbeställa->Restnotera
-- Fånga->Fullgöra, 
-- Kredit->Tillgodo
-- Kundretur->Mottagen retur 
-- ...etc

