### PR TITLE
Homogenize role translations in Spanish

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -241,8 +241,8 @@ es:
         one: Razón de autorización de devolución
         other: Razones de autorización de devolución
       spree/role:
-        one: Función
-        other: Funciones
+        one: Rol
+        other: Roles
       spree/shipment:
         one: Envío
         other: Envíos
@@ -1472,7 +1472,7 @@ es:
     rma_credit: Crédito RMA
     rma_number: Número RMA
     rma_value: Valor RMA
-    role_id: ID de la función
+    role_id: ID del rol
     roles: Funciones
     rules: Reglas
     safe: Seguro


### PR DESCRIPTION
## Summary
Currently there are two different Spanish translations for the resource `role`. I believe this causes confusion as a user could think he/she is viewing "funciones" but then at the time of creating a new resource the button refers to "rol".

This patch homogenizes all translations for Spree's role by using the word "rol" instead of "función", which is the most widely used Spanish translation for this topic in other computer systems and it is already used by the key `spree.role`.