### PR TITLE
Fix typo ES: aprovado -> aprobado

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1167,7 +1167,7 @@ es:
     order: Pedido
     order_adjustments: Ajustes de pedido
     order_already_updated: El pedido ya se ha actualizado
-    order_approved: Pedido Aprovado
+    order_approved: Pedido Aprobado
     order_canceled: Pedido Cancelado
     order_details: Detalles del pedido
     order_email_resent: Email de pedido reenviado


### PR DESCRIPTION
### Summary

This patch just fixes a small typo in the Spanish translation. 'Aprobado' is always written with 'b'.