### PR TITLE
add Japanese text for returns to avoid translation missing error

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1083,7 +1083,7 @@ ja:
     return_number:
     return_quantity: "返品数"
     returned: "返品済み"
-    returns:
+    returns: "返品"
     review: "内容を確認する"
     risk:
     risk_analysis:


### PR DESCRIPTION
without Japanese text for `returns`, a translation missing error occur at admin page.
I fixed this error with this change.