### PR TITLE
add Japanese text to avoid translation missing error

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1283,7 +1283,7 @@ ja:
     tracking: "トラッキング"
     tracking_number:
     tracking_url:
-    tracking_url_placeholder:
+    tracking_url_placeholder: "トラッキングURL"
     transaction_id:
     transfer_from_location:
     transfer_stock:
@@ -1300,7 +1300,7 @@ ja:
     update: "更新"
     updating: "更新中"
     usage_limit: "使用制限"
-    use_app_default:
+    use_app_default: "デフォルトを使用する"
     use_billing_address: "請求先住所を使用する"
     use_new_cc: "新しいカードを使用する"
     use_s3: "商品画像の保存にAmazon S3を使用する"


### PR DESCRIPTION
without Japanese text, translation missing errors occur at admin page.

1. `use_app_default`
this text is used at AUTO CAPTURE drop-down menu of  payment_methods detail page.

1.  `tracking_url_placeholder`
this text is used as a placeholder of tracking url input text form at shipping methods detail page.
