### PR TITLE
Date Picker Formating Corrected In All Existing Files.

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -570,8 +570,9 @@ ar:
     date_completed: " تاريخ الانتهاء "
     date_picker:
       first_day: 0
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: " نطاق التاريخ "
     default: " افتراضي "
     default_refund_amount:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -633,9 +633,10 @@ be:
     date: Дата
     date_completed: Дата завяршэння
     date_picker:
-      first_day: 1
-      format: "%d.%m.%Y"
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Перыяд часу
     default: Па змаўчанні
     default_refund_amount: Сума вяртання па змаўчанні

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -630,8 +630,9 @@ bg:
     date_completed:
     date_picker:
       first_day: 0
-      format: '%Y/%m/%d'
-      js_format: yy/mm/dd
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range:
     default: По подразбиране
     default_refund_amount: Стойност по подразбиране

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -563,9 +563,10 @@ ca:
     date: Data
     date_completed:
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Rang de Data
     default: Per omissió
     default_refund_amount:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -591,9 +591,10 @@ cs:
     date: Datum
     date_completed: Datum dokončení
     date_picker:
-      first_day: 1
-      format: "%d.%m.%Y"
-      js_format: dd.mm.yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Datum (od-do)
     default: Výchozí
     default_refund_amount: Výchozí částka refundace

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -573,9 +573,10 @@ da:
     date: Dato
     date_completed: Dato gennemført
     date_picker:
-      first_day:
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Datointerval
     default: Standard
     default_refund_amount:

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -519,9 +519,10 @@ de-CH:
     date:
     date_completed:
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Datum (von/bis)
     default:
     default_refund_amount:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -980,12 +980,10 @@ de:
     date: Datum
     date_completed: Abschlußdatum
     date_picker:
-      date_picker:
-        first_day: Erster Tag
-        js_format: Js Format
       first_day: 0
-      format: "%d.%m.%Y"
-      js_format: dd.mm.yy
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Datum (von/bis)
     default: Standard
     default_country_cannot_be_deleted: Standardland kann nicht gelöscht werden
@@ -1038,6 +1036,7 @@ de:
     empty_cart: Warenkorb leeren
     enable_mail_delivery: E-Mail Versand aktivieren
     end: Ende
+    ending_at: Gültig bis
     ending_in: Gültig bis
     environment: Umgebung
     error: Fehler
@@ -1709,6 +1708,8 @@ de:
     secure_connection_type: Sicherer Verbindungstyp
     security_settings: Sicherheitseinstellungen
     select: Auswählen
+    select_a_date: Wählen Sie ein Datum
+    select_a_date_range: Wählen Sie einen Datumsbereich
     select_a_return_authorization_reason: Rückgabeberechtigungsgrund wählen
     select_a_stock_location: Lager wählen
     select_a_store_credit_reason: Wählen Sie einen Grund aus, um das Guthaben zu erhalten
@@ -1796,6 +1797,7 @@ de:
     ssl:
       change_protocol: Protokoll wechseln
     start: Von
+    starting_from: Ab
     state: Bundesland
     state_based: Basierend auf Bundesland
     state_machine_states:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1708,6 +1708,7 @@ de:
     secure_connection_type: Sicherer Verbindungstyp
     security_settings: Sicherheitseinstellungen
     select: Auswählen
+    select_an_option: Wähle eine Option
     select_a_date: Wählen Sie ein Datum
     select_a_date_range: Wählen Sie einen Datumsbereich
     select_a_return_authorization_reason: Rückgabeberechtigungsgrund wählen

--- a/config/locales/en-AU.yml
+++ b/config/locales/en-AU.yml
@@ -563,9 +563,10 @@ en-AU:
     date:
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -568,8 +568,9 @@ en-GB:
     date_completed: Date Completed
     date_picker:
       first_day: 0
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -678,7 +678,7 @@ en-IN:
       available_locales:
       language:
       localization_settings:
-      this_file_language: English (UK)
+      this_file_language: English (Indian)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -565,9 +565,10 @@ en-IN:
     date: Date
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -563,9 +563,10 @@ en-NZ:
     date:
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -608,9 +608,10 @@ es-CL:
     date: Fecha
     date_completed: Fecha completada
     date_picker:
-      first_day: 1
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Rango de fechas
     default: Por defecto
     default_refund_amount: Valor por defecto del reembolso

--- a/config/locales/es-EC.yml
+++ b/config/locales/es-EC.yml
@@ -567,9 +567,10 @@ es-EC:
     date: Fecha
     date_completed: Fecha completada
     date_picker:
-      first_day: 1
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Rango de fechas
     default: Por defecto
     default_refund_amount:

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -565,9 +565,10 @@ es-MX:
     date: Fecha
     date_completed: Fecha completada
     date_picker:
-      first_day:
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Rango de Fecha
     default: Por omisión
     default_refund_amount:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -757,38 +757,10 @@ es:
     date: Fecha
     date_completed: Fecha completada
     date_picker:
-      am: 'AM'
-      first_day: 1
-      format: "%d/%m/%Y"
-      hourAriaLabel: 'Hora'
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
       js_date_time: d/m/Y - H:i
-      minuteAriaLabel: 'Minuto'
-      pm: 'PM'
-      rangeSeparator: ' a '
-      scrollTitle: 'Desplaza para aumentar'
-      toggleTitle: 'Pinche para cambiar'
-      weekAbbreviation: 'Sem'
-      yearAriaLabel: 'Año'
-      sun: 'Dom'
-      mon: 'Lun'
-      tue: 'Mar'
-      wed: 'Mié'
-      thu: 'Jue'
-      fri: 'Vie'
-      sat: 'Sáb'
-      lh_jan: 'Enero'
-      lh_feb: 'Febrero'
-      lh_mar: 'Marzo'
-      lh_apr: 'Abril'
-      lh_may: 'Mayo'
-      lh_jun: 'Junio'
-      lh_jul: 'Julio'
-      lh_aug: 'Agosto'
-      lh_sep: 'Septiembre'
-      lh_oct: 'Octubre'
-      lh_nov: 'Noviembre'
-      lh_dec: 'Diciembre'
     date_range: Rango de fechas
     default: Por defecto
     default_country_cannot_be_deleted: El país por defecto no se puede eliminar

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -547,9 +547,10 @@ et:
     date: Kuupäev
     date_completed:
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Vali vahemik
     default:
     default_refund_amount:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -527,9 +527,10 @@ fa:
     date:
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: محدوده ی زمانی
     default: پیش فرض
     default_meta_description: Default Meta Description

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -582,8 +582,9 @@ fi:
     date_completed: Valmistunut
     date_picker:
       first_day: 0
-      format: "%d.%m.%Y"
-      js_format: dd.mm.yy
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Päivämäärä (mistä mihin)
     default: Oletus
     default_refund_amount:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -978,12 +978,10 @@ fr:
     date: Date
     date_completed: Date d'achèvement
     date_picker:
-      date_picker:
-        first_day: Premier jour
-        js_format: Format js
       first_day: 0
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Sélection de dates
     default: Défaut
     default_country_cannot_be_deleted: Le terrain de base ne peut pas être supprimé

--- a/config/locales/gr.yml
+++ b/config/locales/gr.yml
@@ -565,9 +565,10 @@ gr:
     date: Ημερομηνία
     date_completed: Ημερομήνια ολοκλήρωσης
     date_picker:
-      first_day:
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Εύρος Ημερομήνιας
     default: Default
     default_refund_amount:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -562,9 +562,10 @@ id:
     date: Tanggal
     date_completed: Tanggal Selesai
     date_picker:
-      first_day:
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Rentang Tanggal
     default: Nilai Awal
     default_refund_amount:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -610,9 +610,10 @@ it:
     date: Data
     date_completed: Completato il
     date_picker:
-      first_day: 1
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Intervallo di date
     default: Default
     default_refund_amount: Importo Rimborso di default

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -564,9 +564,10 @@ ja:
     date:
     date_completed: "完了日"
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: "日範囲"
     default: "初期設定"
     default_refund_amount:

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -571,8 +571,9 @@ km:
     date_completed: ថ្ងៃបញ្ចប់
     date_picker:
       first_day: 0
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: ចន្លោះថ្ងៃ
     default: ទម្រង់ដើម
     default_refund_amount:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -519,9 +519,10 @@ ko:
     date:
     date_completed:
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: "날짜 범위"
     default: "기본"
     default_refund_amount:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -680,7 +680,7 @@ ku:
       available_locales: Available Locales
       language: Language
       localization_settings: Localisation Settings
-      this_file_language: English (UK)
+      this_file_language: Kurdî (کردی)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -568,8 +568,9 @@ ku:
     date_completed: Date Completed
     date_picker:
       first_day: 0
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -664,12 +664,10 @@ lt:
     date: Data
     date_completed: Baigimo data
     date_picker:
-      date_picker:
-        first_day: Pirma diena
-        js_format: Js Format
       first_day: 0
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Datos intervalas
     default: Numatytas
     default_refund_amount: Numatyta kompensacijos suma

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -560,9 +560,10 @@ lv:
     date:
     date_completed:
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Datuma diapazons
     default:
     default_refund_amount:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -563,9 +563,10 @@ nb:
     date: dato
     date_completed: Fullføringsdato
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Datoområde
     default: Default
     default_refund_amount:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -597,9 +597,10 @@ nl:
     date: Datum
     date_completed: Datum voluit
     date_picker:
-      first_day: Eerste Dag
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Datumbereik
     default: Standaard
     default_refund_amount: Standaard Refundvergoeding

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -741,8 +741,9 @@ pl:
     date_completed: Data uaktualniona
     date_picker:
       first_day: 0
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Zakres dat
     default: Domyślny
     default_country_cannot_be_deleted: Nie można usunąć kraju domyślnego

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -669,8 +669,9 @@ pt-BR:
     date_completed: Data do Término
     date_picker:
       first_day: 0
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Entre as Datas
     default: Padrão
     default_country_cannot_be_deleted: País padrão não pode ser removido

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -519,9 +519,10 @@ pt:
     date:
     date_completed: Date Completed
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Entre as Datas
     default: Padrão
     default_refund_amount:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -565,9 +565,10 @@ ro:
     date: Data
     date_completed: Data efectuării
     date_picker:
-      first_day:
-      format: "%d.%m.%Y"
-      js_format: "%d.%m.%Y"
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Perioada
     default: Standard
     default_refund_amount:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -651,9 +651,10 @@ ru:
     date: "Дата"
     date_completed: "Дата завершения"
     date_picker:
-      first_day: 1
-      format: "%d.%m.%Y"
-      js_format: dd.mm.yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: "Временной период"
     default: "По умолчанию"
     default_refund_amount: "Стандартный размер возврата"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -573,9 +573,10 @@ sk:
     date: "Dátum"
     date_completed:
     date_picker:
-      first_day: 1
-      format: "%d.%m.%Y"
-      js_format: dd.mm.rr
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: "Obdobie"
     default:
     default_refund_amount:

--- a/config/locales/sl-SI.yml
+++ b/config/locales/sl-SI.yml
@@ -519,9 +519,10 @@ sl-SI:
     date:
     date_completed:
     date_picker:
-      first_day:
-      format:
-      js_format:
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Obdobje
     default: Privzeto
     default_refund_amount:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -682,8 +682,9 @@ sv:
     date_completed: Datum färdig
     date_picker:
       first_day: 0
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Datumintervall
     default: Förvald
     default_refund_amount:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -559,9 +559,10 @@ th:
     date: "วันที่"
     date_completed: "วันที่เสร็จสิ้น"
     date_picker:
-      first_day:
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: "ช่วงวันที่"
     default: "ค่าเริ่มต้น"
     default_refund_amount:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -519,9 +519,10 @@ tr:
     date: Tarih
     date_completed: Tarih Tamamlandı
     date_picker:
-      first_day:
-      format: "%d.%m%Y"
-      js_format: dd.mm.yyyy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Tarih Aralığı
     default: Varsayılan
     default_refund_amount:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -671,9 +671,10 @@ uk:
     date: "Дата"
     date_completed: "Дата завершення"
     date_picker:
-      first_day: 1
-      format: "%d.%m.%Y"
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: "Період часу"
     default: "За замовчуванням"
     default_refund_amount: "Сума повернення за замовчуванням"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -520,9 +520,10 @@ vi:
     date: Ngày
     date_completed:
     date_picker:
-      first_day:
-      format: "%d/%m/%Y"
-      js_format: dd/mm/yy
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: Giới hạn ngày
     default:
     default_refund_amount:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -594,9 +594,10 @@ zh-CN:
     date: "日期"
     date_completed: "完成日期"
     date_picker:
-      first_day:
-      format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      first_day: 0
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: "时间范围"
     default: "默认"
     default_refund_amount:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -807,38 +807,10 @@ zh-TW:
     date: 日期
     date_completed: 完成日期
     date_picker:
-      am: 'AM'
       first_day: 0
-      format: ! '%Y/%m/%d'
-      hourAriaLabel: '時'
-      js_format: Y/m/d
-      js_date_time: Y/m/d - H:i
-      minuteAriaLabel: '分'
-      pm: 'PM'
-      rangeSeparator: ' 至 '
-      scrollTitle: '捲動增加'
-      toggleTitle: '點選'
-      weekAbbreviation: '週'
-      yearAriaLabel: '年'
-      sun: '日'
-      mon: '一'
-      tue: '二'
-      wed: '三'
-      thu: '四'
-      fri: '五'
-      sat: '六'
-      lh_jan: '一月'
-      lh_feb: '二月'
-      lh_mar: '三月'
-      lh_apr: '四月'
-      lh_may: '五月'
-      lh_jun: '六月'
-      lh_jul: '七月'
-      lh_aug: '八月'
-      lh_sep: '九月'
-      lh_oct: '十月'
-      lh_nov: '十一月'
-      lh_dec: '十二月'
+      format: ! '%d/%m/%Y'
+      js_format: d/m/Y
+      js_date_time: d/m/Y - H:i
     date_range: 日期區間
     default: 預設
     default_country_cannot_be_deleted: 無法刪除預設國家


### PR DESCRIPTION
Bring all translation files in line with new date picker formatting, some were a mess and causing issues with formatting.

Add translation for `select_an_option:` to .de file.

Add better naming to .ku and .en-IN as they both came up in the dropdown selector as` English (UK)`.