### PR TITLE
Improve date formatting + file naming

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -569,10 +569,9 @@ ar:
     date: " التاريخ "
     date_completed: " تاريخ الانتهاء "
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: d/m/Y
+      fpr_human_friendly_date_time_format: d/m/Y - H:i
     date_range: " نطاق التاريخ "
     default: " افتراضي "
     default_refund_amount:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -681,7 +681,7 @@ ar:
       available_locales: " الأماكن المتاحة "
       language: " اللغة "
       localization_settings: " إعدادات الترجمة "
-      this_file_language: Arabic
+      this_file_language: Arabic (AR)
     icon: " أيقونة "
     identifier:
     image: " صورة "

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -748,7 +748,7 @@ be:
       available_locales: Даступныя пераклады
       language: Мова
       localization_settings: Налады лакалізацыі
-      this_file_language: Belarusian
+      this_file_language: Belarusian (BE)
     icon: Pначок
     identifier: Ідэнтыфікатар
     image: Малюнак

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -633,10 +633,9 @@ be:
     date: Дата
     date_completed: Дата завяршэння
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Перыяд часу
     default: Па змаўчанні
     default_refund_amount: Сума вяртання па змаўчанні

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -629,10 +629,9 @@ bg:
     date: Дата
     date_completed:
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range:
     default: По подразбиране
     default_refund_amount: Стойност по подразбиране

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -748,7 +748,7 @@ bg:
       available_locales: Достъпни места
       language: Език
       localization_settings: Настройки за локализация
-      this_file_language: Български (БГ)
+      this_file_language: Български (BG)
     icon: Икона
     identifier:
     image: Образ

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -563,10 +563,9 @@ ca:
     date: Data
     date_completed:
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Rang de Data
     default: Per omissió
     default_refund_amount:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -675,7 +675,7 @@ ca:
       available_locales:
       language:
       localization_settings:
-      this_file_language: Català
+      this_file_language: Català (CA)
     icon: Icona
     identifier:
     image: Imatge

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -591,10 +591,9 @@ cs:
     date: Datum
     date_completed: Datum dokončení
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Datum (od-do)
     default: Výchozí
     default_refund_amount: Výchozí částka refundace

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -573,10 +573,9 @@ da:
     date: Dato
     date_completed: Dato gennemført
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Datointerval
     default: Standard
     default_refund_amount:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -685,7 +685,7 @@ da:
       available_locales: Tilgængelige sprog
       language: Sprog
       localization_settings: Lande/sprog indstillinger
-      this_file_language: Danish
+      this_file_language: Danish (DA)
     icon: Ikon
     identifier:
     image: Billed

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -629,7 +629,7 @@ de-CH:
       available_locales:
       language:
       localization_settings:
-      this_file_language: Deutsch (CH)
+      this_file_language: Deutsch (de-CH)
     icon:
     identifier:
     image: Bild

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -519,10 +519,9 @@ de-CH:
     date:
     date_completed:
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Datum (von/bis)
     default:
     default_refund_amount:
@@ -630,7 +629,7 @@ de-CH:
       available_locales:
       language:
       localization_settings:
-      this_file_language: Deutsch (Schweiz)
+      this_file_language: Deutsch (CH)
     icon:
     identifier:
     image: Bild

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -980,10 +980,9 @@ de:
     date: Datum
     date_completed: Abschlußdatum
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y um H:i
     date_range: Datum (von/bis)
     default: Standard
     default_country_cannot_be_deleted: Standardland kann nicht gelöscht werden

--- a/config/locales/ee.yml
+++ b/config/locales/ee.yml
@@ -1,4 +1,4 @@
-et:
+ee:
   activerecord:
     attributes:
       spree/address:
@@ -657,7 +657,7 @@ et:
       available_locales:
       language: Keel
       localization_settings:
-      this_file_language: Eesti keel
+      this_file_language: Eesti keel (EE)
     icon: Icon
     identifier:
     image: Pilt

--- a/config/locales/en-AU.yml
+++ b/config/locales/en-AU.yml
@@ -563,10 +563,9 @@ en-AU:
     date:
     date_completed: Date Completed
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:
@@ -676,7 +675,7 @@ en-AU:
       available_locales:
       language:
       localization_settings:
-      this_file_language: English (Australia)
+      this_file_language: English (AU)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/en-AU.yml
+++ b/config/locales/en-AU.yml
@@ -675,7 +675,7 @@ en-AU:
       available_locales:
       language:
       localization_settings:
-      this_file_language: English (AU)
+      this_file_language: English (en-AU)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -679,7 +679,7 @@ en-GB:
       available_locales: Available Locales
       language: Language
       localization_settings: Localisation Settings
-      this_file_language: English (GB)
+      this_file_language: English (en-GB)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -567,10 +567,9 @@ en-GB:
     date: Date
     date_completed: Date Completed
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:
@@ -680,7 +679,7 @@ en-GB:
       available_locales: Available Locales
       language: Language
       localization_settings: Localisation Settings
-      this_file_language: English (UK)
+      this_file_language: English (GB)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -677,7 +677,7 @@ en-IN:
       available_locales:
       language:
       localization_settings:
-      this_file_language: English (IN)
+      this_file_language: English (en-IN)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -565,10 +565,9 @@ en-IN:
     date: Date
     date_completed: Date Completed
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:
@@ -678,7 +677,7 @@ en-IN:
       available_locales:
       language:
       localization_settings:
-      this_file_language: English (Indian)
+      this_file_language: English (IN)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -563,10 +563,9 @@ en-NZ:
     date:
     date_completed: Date Completed
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:
@@ -676,7 +675,7 @@ en-NZ:
       available_locales:
       language:
       localization_settings:
-      this_file_language: English (New Zealand)
+      this_file_language: English (NZ)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -675,7 +675,7 @@ en-NZ:
       available_locales:
       language:
       localization_settings:
-      this_file_language: English (NZ)
+      this_file_language: English (en-NZ)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -717,7 +717,7 @@ es-CL:
       available_locales: Locales Disponibles
       language: Idioma
       localization_settings: Ajustes de Localización
-      this_file_language: Español (CL)
+      this_file_language: Español (es-CL)
     icon: Icono
     image: Imagen
     images: Imágenes

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -608,10 +608,9 @@ es-CL:
     date: Fecha
     date_completed: Fecha completada
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y a \\la\\s H:i
     date_range: Rango de fechas
     default: Por defecto
     default_refund_amount: Valor por defecto del reembolso
@@ -718,7 +717,7 @@ es-CL:
       available_locales: Locales Disponibles
       language: Idioma
       localization_settings: Ajustes de Localización
-      this_file_language: Español (Chile)
+      this_file_language: Español (CL)
     icon: Icono
     image: Imagen
     images: Imágenes

--- a/config/locales/es-EC.yml
+++ b/config/locales/es-EC.yml
@@ -679,7 +679,7 @@ es-EC:
       available_locales: Locales Disponibles
       language: Idioma
       localization_settings: Ajustes Localización
-      this_file_language: Español (EC)
+      this_file_language: Español (es-EC)
     icon: Icono
     identifier:
     image: Imagen

--- a/config/locales/es-EC.yml
+++ b/config/locales/es-EC.yml
@@ -567,10 +567,9 @@ es-EC:
     date: Fecha
     date_completed: Fecha completada
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y a \\la\\s H:i
     date_range: Rango de fechas
     default: Por defecto
     default_refund_amount:
@@ -680,7 +679,7 @@ es-EC:
       available_locales: Locales Disponibles
       language: Idioma
       localization_settings: Ajustes Localización
-      this_file_language: Español
+      this_file_language: Español (EC)
     icon: Icono
     identifier:
     image: Imagen

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -677,7 +677,7 @@ es-MX:
       available_locales: Traduciones Disponibles
       language: Idioma
       localization_settings: Ajustes de traducciones
-      this_file_language: Español (MX)
+      this_file_language: Español (es-MX)
     icon: Icono
     identifier:
     image: Imagen

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -565,10 +565,9 @@ es-MX:
     date: Fecha
     date_completed: Fecha completada
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y a \\la\\s H:i
     date_range: Rango de Fecha
     default: Por omisión
     default_refund_amount:
@@ -678,7 +677,7 @@ es-MX:
       available_locales: Traduciones Disponibles
       language: Idioma
       localization_settings: Ajustes de traducciones
-      this_file_language:
+      this_file_language: Español (MX)
     icon: Icono
     identifier:
     image: Imagen

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -757,10 +757,9 @@ es:
     date: Fecha
     date_completed: Fecha completada
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y a \\la\\s H:i
     date_range: Rango de fechas
     default: Por defecto
     default_country_cannot_be_deleted: El país por defecto no se puede eliminar
@@ -922,7 +921,7 @@ es:
       select_locale: Seleccionar idioma
       show_only: Mostrar solo
       supported_locales: Idiomas soportados
-      this_file_language: Español
+      this_file_language: Español (ES)
       translations: Traducciones
     icon: Icono
     image: Imagen

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1,4 +1,4 @@
-ee:
+et:
   activerecord:
     attributes:
       spree/address:
@@ -657,7 +657,7 @@ ee:
       available_locales:
       language: Keel
       localization_settings:
-      this_file_language: Eesti keel (EE)
+      this_file_language: Eesti keel (ET)
     icon: Icon
     identifier:
     image: Pilt

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -547,10 +547,9 @@ et:
     date: Kuupäev
     date_completed:
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Vali vahemik
     default:
     default_refund_amount:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -527,10 +527,9 @@ fa:
     date:
     date_completed: Date Completed
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: محدوده ی زمانی
     default: پیش فرض
     default_meta_description: Default Meta Description

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -631,7 +631,7 @@ fa:
       available_locales:
       language:
       localization_settings:
-      this_file_language: فارسی(fa)
+      this_file_language: فارسی (FA)
     icon: آیکون
     image: تصویر
     image_settings: Image Settings

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -581,10 +581,9 @@ fi:
     date: Päivä
     date_completed: Valmistunut
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Päivämäärä (mistä mihin)
     default: Oletus
     default_refund_amount:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -700,7 +700,7 @@ fi:
       select_locale: Valitse kieli
       show_only: Näytä vain
       supported_locales: Tuetut kielet
-      this_file_language: Suomi
+      this_file_language: Suomi (FI)
       translations: Käännökset
       locales_displayed_on_frontend_select_box: Kaupassa näytettävät kielet
     Icon: Kuvake

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -978,10 +978,9 @@ fr:
     date: Date
     date_completed: Date d'achèvement
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y à H:i
     date_range: Sélection de dates
     default: Défaut
     default_country_cannot_be_deleted: Le terrain de base ne peut pas être supprimé

--- a/config/locales/gr.yml
+++ b/config/locales/gr.yml
@@ -565,10 +565,9 @@ gr:
     date: Ημερομηνία
     date_completed: Ημερομήνια ολοκλήρωσης
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Εύρος Ημερομήνιας
     default: Default
     default_refund_amount:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -562,10 +562,9 @@ id:
     date: Tanggal
     date_completed: Tanggal Selesai
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Rentang Tanggal
     default: Nilai Awal
     default_refund_amount:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -610,10 +610,9 @@ it:
     date: Data
     date_completed: Completato il
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y a\\l\\le H:i
     date_range: Intervallo di date
     default: Default
     default_refund_amount: Importo Rimborso di default

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -564,10 +564,9 @@ ja:
     date:
     date_completed: "完了日"
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: "日範囲"
     default: "初期設定"
     default_refund_amount:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -677,7 +677,7 @@ ja:
       available_locales:
       language:
       localization_settings:
-      this_file_language: "日本語 (ja-JP)"
+      this_file_language: "日本語 (JA)"
     icon: "アイコン"
     identifier:
     image: "画像"

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -570,10 +570,9 @@ km:
     date: ថ្ងៃ
     date_completed: ថ្ងៃបញ្ចប់
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: ចន្លោះថ្ងៃ
     default: ទម្រង់ដើម
     default_refund_amount:

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -682,7 +682,7 @@ km:
       available_locales: ភាសាដែល​មាន​ស្រាប់
       language: ភាសា
       localization_settings: កំណត់ភាសា
-      this_file_language: ភាសាខ្មែរ
+      this_file_language: ភាសាខ្មែរ (KM)
     icon: រូបតំណាង
     identifier:
     image: រូបភាព

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -519,10 +519,9 @@ ko:
     date:
     date_completed:
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: "날짜 범위"
     default: "기본"
     default_refund_amount:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -679,7 +679,7 @@ ku:
       available_locales: Available Locales
       language: Language
       localization_settings: Localisation Settings
-      this_file_language: Kurdî (کردی)
+      this_file_language: کردی (KU)
     icon: Icon
     identifier:
     image: Image

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -567,10 +567,9 @@ ku:
     date: Date
     date_completed: Date Completed
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Date Range
     default: Default
     default_refund_amount:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -791,7 +791,7 @@ lt:
       select_locale: Pasirinkti kalbą
       show_only: Rodyti tik
       supported_locales: Palaikomos kalbos
-      this_file_language: Lietuvių
+      this_file_language: Lietuvių (LT)
       translations: Vertimai
     icon: Paveikslėlis
     id: ID

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -664,10 +664,9 @@ lt:
     date: Data
     date_completed: Baigimo data
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Datos intervalas
     default: Numatytas
     default_refund_amount: Numatyta kompensacijos suma

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -560,10 +560,9 @@ lv:
     date:
     date_completed:
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Datuma diapazons
     default:
     default_refund_amount:

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -676,7 +676,7 @@ nb:
       available_locales:
       language:
       localization_settings:
-      this_file_language: Norsk
+      this_file_language: Norsk (NB)
     icon: Ikon
     identifier:
     image: Bilde

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -563,10 +563,9 @@ nb:
     date: dato
     date_completed: Fullføringsdato
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Datoområde
     default: Default
     default_refund_amount:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -597,10 +597,9 @@ nl:
     date: Datum
     date_completed: Datum voluit
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Datumbereik
     default: Standaard
     default_refund_amount: Standaard Refundvergoeding

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -740,10 +740,9 @@ pl:
     date: Data
     date_completed: Data uaktualniona
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Zakres dat
     default: Domyślny
     default_country_cannot_be_deleted: Nie można usunąć kraju domyślnego

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -668,10 +668,9 @@ pt-BR:
     date: Data
     date_completed: Data do Término
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Entre as Datas
     default: Padrão
     default_country_cannot_be_deleted: País padrão não pode ser removido

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -791,7 +791,7 @@ pt-BR:
       select_locale: Selecionar idioma
       show_only: Mostrar apenas
       supported_locales: Idiomas suportados
-      this_file_language: Português (BR)
+      this_file_language: Português (pt-BR)
       translations: Traduções
     icon: "Ícone"
     image: Imagem

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -519,10 +519,9 @@ pt:
     date:
     date_completed: Date Completed
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Entre as Datas
     default: Padrão
     default_refund_amount:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -565,10 +565,9 @@ ro:
     date: Data
     date_completed: Data efectuării
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Perioada
     default: Standard
     default_refund_amount:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -772,7 +772,7 @@ ru:
       available_locales: "Доступные переводы"
       language: "Язык"
       localization_settings: "Настройки локализации"
-      this_file_language: Russian
+      this_file_language: Russian (RU)
       locales_displayed_on_frontend_select_box: "Локаль, отображаемая в frontend части (раскрывающийся список)"
       supported_locales: "Поддерживаемые локализации"
       translations: "Перевод"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -651,10 +651,9 @@ ru:
     date: "Дата"
     date_completed: "Дата завершения"
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: "Временной период"
     default: "По умолчанию"
     default_refund_amount: "Стандартный размер возврата"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -686,7 +686,7 @@ sk:
       available_locales: "Dostupné národné prostredia"
       language: "Jazyk"
       localization_settings: "Nastavenia národného prostredia"
-      this_file_language: Slovenčina
+      this_file_language: Slovenčina (SK)
     icon: "Ikona"
     identifier:
     image: Obrázok

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -573,10 +573,9 @@ sk:
     date: "Dátum"
     date_completed:
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: "Obdobie"
     default:
     default_refund_amount:

--- a/config/locales/sl-SI.yml
+++ b/config/locales/sl-SI.yml
@@ -629,7 +629,7 @@ sl-SI:
       available_locales:
       language:
       localization_settings:
-      this_file_language: Slovenščina (SL)
+      this_file_language: Slovenščina (sl-SL)
     icon: Ikona
     identifier:
     image: Slika

--- a/config/locales/sl-SI.yml
+++ b/config/locales/sl-SI.yml
@@ -519,10 +519,9 @@ sl-SI:
     date:
     date_completed:
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Obdobje
     default: Privzeto
     default_refund_amount:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -681,10 +681,9 @@ sv:
     date: Datum
     date_completed: Datum färdig
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Datumintervall
     default: Förvald
     default_refund_amount:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -559,10 +559,9 @@ th:
     date: "วันที่"
     date_completed: "วันที่เสร็จสิ้น"
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: "ช่วงวันที่"
     default: "ค่าเริ่มต้น"
     default_refund_amount:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -519,10 +519,9 @@ tr:
     date: Tarih
     date_completed: Tarih Tamamlandı
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Tarih Aralığı
     default: Varsayılan
     default_refund_amount:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -671,10 +671,9 @@ uk:
     date: "Дата"
     date_completed: "Дата завершення"
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: "Період часу"
     default: "За замовчуванням"
     default_refund_amount: "Сума повернення за замовчуванням"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -786,7 +786,7 @@ uk:
       available_locales: "Доступні переклади"
       language: "Мова"
       localization_settings: "Налаштування локалізації"
-      this_file_language: Ukrainian
+      this_file_language: Ukrainian (UK)
     icon: "Іконка"
     identifier: "Ідентифікатор"
     image: "Зображення"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -520,10 +520,9 @@ vi:
     date: Ngày
     date_completed:
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: Giới hạn ngày
     default:
     default_refund_amount:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -594,10 +594,9 @@ zh-CN:
     date: "日期"
     date_completed: "完成日期"
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: "时间范围"
     default: "默认"
     default_refund_amount:
@@ -708,7 +707,7 @@ zh-CN:
       available_locales: "可用的语言"
       language: "语言"
       localization_settings:
-      this_file_language: "中文(简体)"
+      this_file_language: "中文 简体 (zh-CN)"
       translations: "翻译"
     icon: "图标"
     identifier:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -707,7 +707,7 @@ zh-CN:
       available_locales: "可用的语言"
       language: "语言"
       localization_settings:
-      this_file_language: "中文 简体 (zh-CN)"
+      this_file_language: 中文 简体 (zh-CN)
       translations: "翻译"
     icon: "图标"
     identifier:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -807,10 +807,9 @@ zh-TW:
     date: 日期
     date_completed: 完成日期
     date_picker:
-      first_day: 0
-      format: ! '%d/%m/%Y'
-      js_format: d/m/Y
-      js_date_time: d/m/Y - H:i
+      # FlatPickr human friendly formatting
+      fpr_human_friendly_date_format: M j, Y
+      fpr_human_friendly_date_time_format: M j, Y - H:i
     date_range: 日期區間
     default: 預設
     default_country_cannot_be_deleted: 無法刪除預設國家


### PR DESCRIPTION
Add human readable date time translations into all files.

Unify naming conventions 
`this_file_language: Español (es-MX)` 
`this_file_language: Español (ES)` 
`this_file_language: Español (es-EC)` 



