### PR TITLE
Rename 'logged_in_succesfully' => 'logged_in_successfully'

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -740,7 +740,7 @@ ar:
     lock: " قفل "
     log_entries: " إدخالات السجل "
     logged_in_as: " تم تسجيل الدخول باسم "
-    logged_in_succesfully: " تم تسجيل الدخول بنجاح "
+    logged_in_successfully: " تم تسجيل الدخول بنجاح "
     logged_out: " لقد تم تسجيل خروجك "
     login: " دخول "
     login_as_existing: " تسجيل الدخول كزبون موجود "

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -815,7 +815,7 @@ be:
     lock: Закрыта
     log_entries: Запісы журнала
     logged_in_as: Карыстальнік
-    logged_in_succesfully: Вы ўвайшлі ў сістэму
+    logged_in_successfully: Вы ўвайшлі ў сістэму
     logged_out: Вы выйшлі з сістэмы.
     login: Лагін
     login_as_existing: Увайсці як пакупнік

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -810,7 +810,7 @@ bg:
     lock: Закючи
     log_entries:
     logged_in_as: Влезте като
-    logged_in_succesfully: Успешно влизане
+    logged_in_successfully: Успешно влизане
     logged_out: Успешен изход.
     login: Вход
     login_as_existing: Влезте като настоящ клиент

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -734,7 +734,7 @@ ca:
     lock:
     log_entries:
     logged_in_as: Identificat com
-    logged_in_succesfully: Connectat amb èxit
+    logged_in_successfully: Connectat amb èxit
     logged_out: S'ha tancat la sessió.
     login: Validació
     login_as_existing: Validar-se com a client existent

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -763,7 +763,7 @@ cs:
     lock: Uzamknout
     log_entries: Záznamy logu
     logged_in_as: Přihlášen jako
-    logged_in_succesfully: Přihlášení proběhlo úspěšně
+    logged_in_successfully: Přihlášení proběhlo úspěšně
     logged_out: Byli jste odhlášeni
     login: Přihlášení
     login_as_existing: Přihlásit se jako existující zákazník

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -744,7 +744,7 @@ da:
     lock: Lås
     log_entries:
     logged_in_as: Logget ind som
-    logged_in_succesfully: Du er nu logget ind
+    logged_in_successfully: Du er nu logget ind
     logged_out: Du er nu logget ud.
     login: Log ind
     login_as_existing: Log ind som eksisterende kunde

--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -688,7 +688,7 @@ de-CH:
     lock:
     log_entries:
     logged_in_as: Angemeldet als
-    logged_in_succesfully: Erfolgreich angemeldet
+    logged_in_successfully: Erfolgreich angemeldet
     logged_out: Sie sind nun ausgeloggt.
     login:
     login_as_existing: Als bestehender Kunde einloggen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1262,7 +1262,7 @@ de:
     log_in: Anmelden
     log_in_to_continue: Anmelden um fortzufahren
     logged_in_as: Angemeldet als
-    logged_in_succesfully: Anmeldung erfolgreich
+    logged_in_successfully: Anmeldung erfolgreich
     logged_out: Sie haben sich ausgeloggt.
     login: Login
     login_as_existing: Anmeldung für registrierte Benutzer

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -828,7 +828,7 @@ el:
     log_entries:
     log_in: Είσοδος
     logged_in_as: Συνδεμένος σαν
-    logged_in_succesfully: Επιτυχής σύνδεση
+    logged_in_successfully: Επιτυχής σύνδεση
     logged_out: Αποσυνδεθήκατε.
     login: Σύνδεση
     login_as_existing: Σύνδεχη σαν ήδη υπάρχων πελάτης

--- a/config/locales/en-AU.yml
+++ b/config/locales/en-AU.yml
@@ -734,7 +734,7 @@ en-AU:
     lock:
     log_entries:
     logged_in_as: Logged in as
-    logged_in_succesfully: Logged in successfully
+    logged_in_successfully: Logged in successfully
     logged_out: You have been logged out.
     login: Login
     login_as_existing: Log In as Existing Customer

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -738,7 +738,7 @@ en-GB:
     lock: Lock
     log_entries:
     logged_in_as: Logged in as
-    logged_in_succesfully: Logged in successfully
+    logged_in_successfully: Logged in successfully
     logged_out: You have been logged out.
     login: Login
     login_as_existing: Log In as Existing Customer

--- a/config/locales/en-IN.yml
+++ b/config/locales/en-IN.yml
@@ -736,7 +736,7 @@ en-IN:
     lock: Lock
     log_entries:
     logged_in_as: Logged in as
-    logged_in_succesfully: Logged in successfully
+    logged_in_successfully: Logged in successfully
     logged_out: You have been logged out.
     login: Login
     login_as_existing: Log In as Existing Customer

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -734,7 +734,7 @@ en-NZ:
     lock:
     log_entries:
     logged_in_as: Logged in as
-    logged_in_succesfully: Logged in successfully
+    logged_in_successfully: Logged in successfully
     logged_out: You have been logged out.
     login: Login
     login_as_existing: Log In as Existing Customer

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -778,7 +778,7 @@ es-CL:
     log_entries: "Registros de entrada"
     logs: Registros
     logged_in_as: Identificado como
-    logged_in_succesfully: Conectado con éxito
+    logged_in_successfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
     login: Login
     login_as_existing: Deseo ingresar con mi cuenta

--- a/config/locales/es-EC.yml
+++ b/config/locales/es-EC.yml
@@ -738,7 +738,7 @@ es-EC:
     lock: Bloquear
     log_entries:
     logged_in_as: Identificado como
-    logged_in_succesfully: Conectado con éxito
+    logged_in_successfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
     login: Validación
     login_as_existing: Validarse como cliente existente

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -736,7 +736,7 @@ es-MX:
     lock: Bloquear
     log_entries:
     logged_in_as: Conectado como
-    logged_in_succesfully: Conectado con éxito
+    logged_in_successfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
     login: Iniciar sesión
     login_as_existing: Iniciar sesión como un cliente existente

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1006,7 +1006,7 @@ es:
     log_in_to_continue: Ingresar para continuar
     logs: "Logs"
     logged_in_as: Identificado como
-    logged_in_succesfully: Conectado con éxito
+    logged_in_successfully: Conectado con éxito
     logged_out: Se ha cerrado la sesión.
     login: Validación
     login_as_existing: Validarse como cliente existente

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -716,7 +716,7 @@ et:
     lock:
     log_entries:
     logged_in_as: 'Sisse logitud:'
-    logged_in_succesfully: Sisselogimine õnnestus!
+    logged_in_successfully: Sisselogimine õnnestus!
     logged_out: Oled välja logitud!
     login: Login
     login_as_existing: Logi sisse

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -679,7 +679,7 @@ fa:
     location:
     lock:
     logged_in_as: شما وارد شدید به عنوان
-    logged_in_succesfully: ورود موفقیت آمیز بود
+    logged_in_successfully: ورود موفقیت آمیز بود
     logged_out: شما خارج شدید
     login: ورود
     login_as_existing: Log In as Existing Customer

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -761,7 +761,7 @@ fi:
     lock: Lukitse
     log_entries:
     logged_in_as: Kirjauduttu
-    logged_in_succesfully: Kirjauduttu onnistuneesti
+    logged_in_successfully: Kirjauduttu onnistuneesti
     logged_out: Olet kirjautunut ulos.
     login: Sisäänkirjautuminen
     login_as_existing: Kirjaudu olemassaolevana asiakkaana

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1256,7 +1256,7 @@ fr:
     log_in: Se connecter
     log_in_to_continue: Connectez-vous pour continuer
     logged_in_as: Identifié en tant que
-    logged_in_succesfully: Connexion réussie
+    logged_in_successfully: Connexion réussie
     logged_out: Vous avez été déconnecté
     login: Connexion
     login_as_existing: Commander en tant que client existant

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -738,7 +738,7 @@ hu:
     lock: Lock
     log_entries:
     logged_in_as: Logged in as
-    logged_in_succesfully: Logged in successfully
+    logged_in_successfully: Logged in successfully
     logged_out: You have been logged out.
     login: Login
     login_as_existing: Log In as Existing Customer
@@ -1336,4 +1336,3 @@ hu:
     zipcode: Irányítószám
     zone: Zóna
     zones: Zónák
-    

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -792,7 +792,7 @@ it:
     lock: Blocca
     log_entries: Voci Log
     logged_in_as: Login come
-    logged_in_succesfully: Login effettuato con successo
+    logged_in_successfully: Login effettuato con successo
     logged_out: Ti sei disconnesso.
     login: Login
     login_as_existing: Login come Utente Registrato

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -736,7 +736,7 @@ ja:
     lock:
     log_entries:
     logged_in_as: "ログイン"
-    logged_in_succesfully: "ログインに成功しました"
+    logged_in_successfully: "ログインに成功しました"
     logged_out: "ログアウトしました。"
     login: "ログイン"
     login_as_existing: "アカウント持ちのお客様ログイン"

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -741,7 +741,7 @@ km:
     lock: បិទ
     log_entries:
     logged_in_as: ចូលប្រើក្នុងនាមជា
-    logged_in_succesfully: បានចូលប្រើដោយជោគជ័យ
+    logged_in_successfully: បានចូលប្រើដោយជោគជ័យ
     logged_out: អ្នកបានចាកចេញរួចហើយ ។ 
     login: ចូលប្រើ
     login_as_existing: ចូលប្រើក្នុងនាមជាអតិថិន​ដែល​មាន​ស្រាប់

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -690,7 +690,7 @@ ko:
     lock:
     log_entries:
     logged_in_as:
-    logged_in_succesfully: "로그인 성공"
+    logged_in_successfully: "로그인 성공"
     logged_out: "로그아웃 되었습니다."
     login: "로그인"
     login_as_existing:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -738,7 +738,7 @@ ku:
     lock: Lock
     log_entries:
     logged_in_as: Logged in as
-    logged_in_succesfully: Logged in successfully
+    logged_in_successfully: Logged in successfully
     logged_out: You have been logged out.
     login: Login
     login_as_existing: Log In as Existing Customer

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -857,7 +857,7 @@ lt:
     lock: Užrakinti
     log_entries:
     logged_in_as: Prisijungęs, kaip
-    logged_in_succesfully: Sėkmingai prisijungėte
+    logged_in_successfully: Sėkmingai prisijungėte
     logged_out: Jūs atsijungėte.
     login: Prisijungti
     login_as_existing: Prisijungti

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -731,7 +731,7 @@ lv:
     lock:
     log_entries:
     logged_in_as: Pieslēgties kā
-    logged_in_succesfully: Pieslēgšanās veiksmīga
+    logged_in_successfully: Pieslēgšanās veiksmīga
     logged_out: Jūs esat atslēgts no sistēmas.
     login: Pieslēgties
     login_as_existing: Pieslēgties kā esošais klients

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -971,7 +971,7 @@ nb:
     lock: Låst
     log_entries: "Loggoppføringer"
     logged_in_as: Innlogget som
-    logged_in_succesfully: Logget inn
+    logged_in_successfully: Logget inn
     logged_out: Du har blitt utlogget.
     login: Logg inn
     login_as_existing: Logg inn som eksisterende bruker

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -738,7 +738,7 @@ ne:
     lock: लक गर्नुहोस्
     log_entries: लग प्रविष्टिहरू
     logged_in_as: यस रूपमा लग इन भयो
-    logged_in_succesfully: सफलतापूर्वक लग इन भयो
+    logged_in_successfully: सफलतापूर्वक लग इन भयो
     logged_out: तपाईं लग आउट हुनुभयो।
     login: लग - इन
     login_as_existing: अवस्थित ग्राहकको रूपमा लग इन गर्नुहोस्

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -770,7 +770,7 @@ nl:
     lock: Vergrendel
     log_entries: Logregels
     logged_in_as: aangemeld als
-    logged_in_succesfully: Je bent aangemeld
+    logged_in_successfully: Je bent aangemeld
     logged_out: Je bent nu afgemeld.
     login: Aanmelden
     login_as_existing: Meld aan als bestaande klant

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -961,7 +961,7 @@ pl:
     log_in_to_continue: Zaloguj się aby kontynuować
     logs: Logi
     logged_in_as: Zalogowano jako
-    logged_in_succesfully: Zalogowano
+    logged_in_successfully: Zalogowano
     logged_out: Wylogowano.
     login: Logowanie
     login_as_existing: Zaloguj jako istniejący użytkownik

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -853,7 +853,7 @@ pt-BR:
     lock: Travar
     log_entries: Entradas de Log
     logged_in_as: Logado como
-    logged_in_succesfully: Logou com sucesso
+    logged_in_successfully: Logou com sucesso
     logged_out: Você saiu.
     login: Entrar
     login_as_existing: Entrar Como Usuário Existente

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -690,7 +690,7 @@ pt:
     lock:
     log_entries:
     logged_in_as: Registado como
-    logged_in_succesfully: Autenticação feita com sucesso, obrigado!
+    logged_in_successfully: Autenticação feita com sucesso, obrigado!
     logged_out: Você saiu.
     login: Login
     login_as_existing: Entrar como utilizador existente

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -736,7 +736,7 @@ ro:
     lock: Blochează
     log_entries:
     logged_in_as: Autentificat ca
-    logged_in_succesfully: Autentificat cu succes
+    logged_in_successfully: Autentificat cu succes
     logged_out: V-ați deconectat.
     login: Autentificare
     login_as_existing: Autentificare ca și client existent

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -838,7 +838,7 @@ ru:
     log_in: "Войти"
     log_in_to_continue: "Войдите для продолжения"
     logged_in_as: "Пользователь"
-    logged_in_succesfully: "Вы вошли в систему"
+    logged_in_successfully: "Вы вошли в систему"
     logged_out: "Вы вышли из системы."
     login: "Логин"
     login_as_existing: "Войти как покупатель"

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -745,7 +745,7 @@ sk:
     lock: "Zamknúť"
     log_entries:
     logged_in_as: "Prihlásený ako"
-    logged_in_succesfully: "Úspešné prihlásenie"
+    logged_in_successfully: "Úspešné prihlásenie"
     logged_out: Odhlásili ste sa.
     login: "Prihlásenie"
     login_as_existing: Prihláste sa ako náš zákazník

--- a/config/locales/sl-SI.yml
+++ b/config/locales/sl-SI.yml
@@ -688,7 +688,7 @@ sl-SI:
     lock:
     log_entries:
     logged_in_as: Prijavljeni ste kot
-    logged_in_succesfully: Prijava uspešna
+    logged_in_successfully: Prijava uspešna
     logged_out: Uspešno ste se odjavili.
     login: Prijava
     login_as_existing: Prijavite se kot obstoječa stranka

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1031,7 +1031,7 @@ sv:
     lock: Lås
     log_entries: Logg poster
     logged_in_as: Inloggad som
-    logged_in_succesfully: Du har nu loggats in
+    logged_in_successfully: Du har nu loggats in
     logged_out: Du har nu loggats ut
     login: Logga in
     login_as_existing: Logga in som existerande kund

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -730,7 +730,7 @@ th:
     lock: "ล๊อก"
     log_entries:
     logged_in_as: "เข้าสู่ระบบเป็น"
-    logged_in_succesfully: "เข้าสู่ระบบสำเร็จ"
+    logged_in_successfully: "เข้าสู่ระบบสำเร็จ"
     logged_out: "คุณได้ออกจากระบบแล้ว"
     login: "เข้าสู่ระบบ"
     login_as_existing: "เข้าสู่ระบบจากบัญขีที่มีอยู่แล้ว"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -688,7 +688,7 @@ tr:
     lock: Kilitle
     log_entries: Log kayıtları
     logged_in_as: 'Açılan Oturum: '
-    logged_in_succesfully: Giriş Başarılı
+    logged_in_successfully: Giriş Başarılı
     logged_out: "Çıkış Yaptınız."
     login: Giriş
     login_as_existing: Varolan bir müşteri hesabıyla giriş yap

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -847,7 +847,7 @@ uk:
     lock: Lock
     log_entries: "Записи журналу"
     logged_in_as: "Користувач"
-    logged_in_succesfully: "Ви увійшли в систему"
+    logged_in_successfully: "Ви увійшли в систему"
     logged_out: "Ви вийшли з системи."
     login: "Логін"
     login_as_existing: "Увійти як існуючий покупець"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -693,7 +693,7 @@ vi:
     lock: Khoá
     log_entries:
     logged_in_as: "Đã đăng nhập với"
-    logged_in_succesfully: "Đăng nhập thành công"
+    logged_in_successfully: "Đăng nhập thành công"
     logged_out: Bạn đã đăng xuất
     login: "Đăng nhập"
     login_as_existing: "Đăng nhập như khách hàng cũ"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -767,7 +767,7 @@ zh-CN:
     lock: "锁住/冻结"
     log_entries:
     logged_in_as: "已登录为"
-    logged_in_succesfully: "登录成功"
+    logged_in_successfully: "登录成功"
     logged_out: "您已经登出系统"
     login: "登录"
     login_as_existing: "作为一个已有客户登录"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1034,7 +1034,7 @@ zh-TW:
     log_in_to_continue: 登入後繼續
     logs: 紀錄
     logged_in_as: 已其他身份登入
-    logged_in_succesfully: 登入成功
+    logged_in_successfully: 登入成功
     logged_out: 登出成功
     login: 登入
     login_as_existing: 以顧客的身份登入


### PR DESCRIPTION
This is a fix for 'logged_in_succesfully' key that I renamed yesterday in this PR:
https://github.com/spree/spree/pull/11254/files#diff-d469b257a4295c5a7db7e8c33ab3f343e5fa0a2721d2cdfe8b991c435987726aR1141