### PR TITLE
Add Spanish translations for new Spree 4.3 Admin CMS and Navigation

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -478,6 +478,7 @@ es:
     active: Activa
     add: Añadir
     add_new_credit_card: Agregar nueva tarjeta
+    add_new_store: Añadir nueva tienda
     add_action_of_type: Añadir acción del tipo
     add_country: Añadir País
     add_coupon_code: Agregar Código de Cupón
@@ -535,22 +536,76 @@ es:
     adjustment_total: Total del ajuste
     adjustments: Ajustes
     admin:
+      linkable:
+        seach_for_a_page: Busca una página
+      navigation:
+        all_menus: Todos los Menús
+        add_new_menu: Añadir nuevo Menú
+        add_new_item: 'Añadir nuevo Elemento'
+        code: Código
+        default_menus_info:
+          title: Menús por defecto
+          body: "Los menús por defecto son menús cuyo idioma coincide con el idioma por defecto de tu tienda.<br><br>
+          <h5>Ejemplo</h5>Si tienes una tienda cuyo idioma por defecto es el español pero también ofrece como opciones alemán y francés, el menú por defecto para esta tienda estará configurado para utilizar <b>Español (es)</b> como idioma y <b>Header</b> como la localización.<br><br>
+          <h5>¿Por qué es importante tener un menú por defecto?</h5> El menú por defecto es el que se muestra al visitante en caso de que no exista un menú disponible para el idioma que está utilizando para navegar. Se recomienda que crees un menú por defecto para cada localización en cada tienda.<br><br>
+          <h5>Más información</h5>Para aprender más sobre los menús, visita la documentación oficial de Spree haciendo <a href='https://user-docs.spreecommerce.org/content-management/building-the-main-menu' target='_blank' class='alert-link'>clic aquí</a>."
+          allow_this_menu_item_to_contain_nested_menu_items: Permitir a este elemento contener otros elementos anidados
+        back_to_all_menus: Volver a Todos los Menús
+        click_create_to_load_new_link: 'Haz clic abajo en el botón <b>Crear</b> para cambiar el tipo del enlace.'
+        click_update_to_load_new_link: 'Haz clic abajo en el botón <b>Actualizar</b> para cambiar el tipo del enlace.'
+        give_your_menu_a_unique_name: 'Utiliza un código único para identificar tu menú, por ejemplo: spree-eu-main'
+        link_settings: Prefencias del enlace
+        link_to: Enlace a
+        image_alt_text: Añade un texto alternativo (alt) a tu imagen
+        image_asset: Añade una imagen promocional o un icono para el enlace
+        move_could_not_be_saved: 'ERROR: No se pudo guardar este paso.'
+        managing_by_store_title: 'Gestionando Menús por tienda'
+        managing_by_store: <p>Estás gestionando los menús de <b>%{store}</b>. Para gestionar los menús de otras tiendas, cambia la tienda global utilizando el menú desplegable de la navegación principal que se encuentra en la parte más alta de la pantalla.</p>
+        new_menu_item: Nuevo Elemento de Menú
+        new_menu: Nuevo Menú
+        nested_under: Anidado bajo
+        no_menu_items: '<b>%{menu}</b> no tiene elementos. Haz clic en el botón <b>Añadir nuevo Elemento</b> para comenzar a añadir enlaces a este menú.'
+        nested_under_info: Anida rápidamente tu elemento si ya sabes dónde debe ir.
+        item_type: Tipo de elemento
+        image_info: '<b>NOTA:</b> Puedes adjuntar una imagen a cualquier elemento del menú, pero la imagen sólo se mostrará en el menú principal cuando esta esté anidada dentro de un container con el código <b>promo</b>.<br><br> Para mejores resultados utiliza imágenes con un ancho de 540px y una altura de 350px.'
+        open_link_in_new_window: Abrir este enlace en una nueva ventana
+        menu_item_type_container_message: "Los Containers (Contenedores) son elementos del menú que no tienen enlace. Si estás construyendo el menú principal de navegación de Spree
+        crea contenedores con el código: <b>category</b> o <b>promo</b> y anida tus Links (Enlaces) dentro de estos.
+        <br><br> Para una guía en profundidad sobre cómo construir el menú principal visita la documentación <a href='https://user-docs.spreecommerce.org/content-management/building-the-main-menu' target='_blank' class='alert-link'>Building The Main Menu (inglés)</a>"
+        menus: Menús
+        menu_items: 'Elementos de %{menu_name}'
+        public_details: Detalles Públicos
+        subtitle: Subtítulo
+        url_info: 'El campo URL puede enlazar a un sitio web externo utilizando <b>https://example.com</b>, enlazar con una ruta que sería inalcanzable de otro modo usando <b>/policies/privacy</b>,
+        abrir la aplicación de email utilizando <b>mailto:sales@example.com</b> o ser usado para crear un número de teléfono clicable con <b>tel:123456789</b>'
+        seach_for_a_product: Busca un producto
+        seach_for_a_taxon: Busca un taxón
+        settings: Preferencias
+        set_a_code: "Añadir un código es opcional, pero puede ser util si necesitas identificar este elemento. Cuando construyas
+        el menú principal de Spree usa el código <b>category</b> o <b>promo</b> para crear los containers que organizen categorías y promociones apropiadamente. Para saber más revisa la documentación haciendo <a href='https://user-docs.spreecommerce.org/content-management/add-items-to-a-menu' target='_blank' class='alert-link'>clic aquí</a>."
+        type: Tipo
+        used_in: Usado en
+        you_have_no_menus: No tienes Menús, haz clic en el botón de Añadir nuevo Menú para crear tu primer Menú.
+        this_link_takes_you_to_your_stores_home_page: Este link te lleva a la página inicial de tu tienda.
       tab:
         configuration: Configuración
+        content: Contenido
+        customer_returns: Devoluciones de los clientes
+        navigation: Navegación
         option_types: Tipos de opción
         orders: Pedidos
         overview: Visión general
+        pages: Páginas
         products: Productos
         promotions: Promociones
         promotion_categories: Categorías de promoción
         properties: Propiedades
         prototypes: Prototipos
         reports: Informes
+        return_authorizations: Autorizaciones de devolución
         taxonomies: Taxonomías
         taxons: Taxones
         users: Usuarios
-        return_authorizations: Autorizaciones de devolución
-        customer_returns: Devoluciones de los clientes
       order:
         events:
           approve: aprobar
@@ -1232,6 +1287,7 @@ es:
     backordered_confirm_info: El ítem seleccionado está en espera por lo que tendrá demora.  ¿Agregarlo al pedido de todas formas?
     overview: Visión de conjunto
     package_from: paquete desde
+    page: Página
     page_not_found: ¡Lo sentimos! La página que buscas no pudo encontrarse.
     pagination:
       next_page: siguiente página »
@@ -1500,6 +1556,8 @@ es:
     say_yes: Si
     scope: Alcance
     search: Buscar
+    search_by: 'Buscar por:'
+    search_order_number: Número de pedido
     search_results: Buscar resultados para '%{keywords}'
     searching: Buscando
     secure_connection_type: Tipo de conexión segura

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -477,7 +477,7 @@ es:
     activate: Activar
     active: Activa
     add: Añadir
-    add_new_credit_card: Agregar tarjeta nueva
+    add_new_credit_card: Agregar nueva tarjeta
     add_action_of_type: Añadir acción del tipo
     add_country: Añadir País
     add_coupon_code: Agregar Código de Cupón

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -536,6 +536,74 @@ es:
     adjustment_total: Total del ajuste
     adjustments: Ajustes
     admin:
+      cms:
+        all_pages: Todas las páginas
+        add_new_page: Añadir nueva Página
+        add_new_section: Añadir nueva Sección
+        content: Contenido
+        click_here: clic aquí
+        draft_mode: Modo borrador
+        full_width: Ancho completo
+        link_to_taxon: Enlace a Taxón
+        link_to_product: Enlace a Producto
+        title: Título
+        fit: Ajustar a
+        info_hero_image_body: "<p>La sección <i>Hero Image</i> añade una gran imagen con un botón y un texto a tu página.</p>
+        <p>El botón puede enlazar a un Producto, Taxón o Página. Esta sección puede ser configurada para encajar dentro del contenedor central o en los bordes de la pantalla.</p>
+        <p><b>Consejo:</b> Utiliza una <i>Hero Image</i> sin botón o título, y después configura <b>Ajustar a:</b> como <b>Container</b> y <b>Columnas (Gutters)</b> como <b>Gutters</b>. Esto creará una sección que se ve genial sobre una sección <i>Side-by-Side Images</i>, o una sección <i>Image Gallery</i>.</p>
+        <p>Experimenta con las configuraciones y no temas en utilizar más de una sección <i>Hero Image</i> por página.</p>"
+        info_image_gallery_body: "<p>La sección <i>Image Gallery</i> puede ser configurada de múltiples formas. Por ejemplo, cada imagen puede enlazar con un Producto o Taxón. Si no incluyes un enlace, puedes mostrar tres imágenes. Además, también puedes usar etiquetas para añadir texto a tus imágenes.</p>
+        <p>Existen dos configuraciones para mostrar la sección <i>Image Gallery</i> según la posición de la imagen más alta, que puede estar bien a la izquierda o la derecha. También puedes indicar que esta sección se ajuste a los bordes de la pantalla o  al contenedor central para que cumpla con el estilo de tu sitio web.</p>"
+        info_product_carousel_body: "<p><i>Product Carousel</i> es una sección fácil de utilizar. Busca el Taxón que te gustaría mostrar, guarda los cambios, y esta mostrará en tu página los productos que pertenezcan a dicho taxón.</p>"
+        info_featured_article_body: "<p>La sección <i>Feature Article</i> te permite añadir texto enriquecido a tu página, además de un título, subtítulo y un botón para enlaces.</p>
+        <p>Esta sección puede configurarse para utilizarse a pantalla completa o en un contenedor, así como utilizar <i>gutters</i>.</p>"
+        info_side_by_side_images_body: "<p>La sección <i>Side-by-Side Images</i> puede ser configurada de diferentes maneras, tienes la opción de usarlas simplemente como imágenes, imágenes y texto, y cualquiera de esas opciones puede ser clicable si se configura con un enlace.</p>
+        <p><b>Consejo:</b> Puedes desplazar estas imágenes al borde de la pantalla y eliminar los <i>gutters</i> para crear un aspecto completamente diferente.</p>"
+        info_rich_text_content_body: "<p>La sección <i>Rich Text Content</i> ofrece un área con un editor de texto enriquecido que se mostrará en tu página.</p>"
+        brand_bar:
+          uses_menu: Esta sección utiliza el Menú de Spree llamado <b>%{menu}</b> para gestionar las imágenes y enlaces,
+          vist_menu_to_edit: para editar este menú.
+        full_width_on_small: Ancho completo en dispositivos pequeños
+        button_text: Texto del Botón
+        go_to_fullscreen_section_manager: Editar secciones en pantalla completa
+        page_type: Tipo de página
+        gutters: Columnas (Gutters)
+        you_have_no_pages: No tienes ninguna página, haz clic en el botón <b>+ Añadir nueva Página</b> para comenzar.
+        new_page: Nueva Página
+        toggle_page_visibility: Alternar visibilidad de la página
+        language: Idioma
+        meta_title: Meta Title
+        meta_description: Meta Description
+        preview_page: Previsualizar Página
+        full_screen_mode: '<span class="exit">Salir del </span>Modo pantalla completa'
+        hero:
+          aspect_ratio: Por favor utiliza una imagen con ratio 12:5 (2400px x 1000px)
+        select_page_type: Selecciona un tipo de página
+        section_type: Tipo de sección
+        subtitle: Subtítulo
+        set_gutters: Set Gutters
+        click_button_to_change_page_type: Haz clic en el botón <b>%{button_type}</b> para cargar las opciones disponibles para este tipo de página.
+        more_page_settings: '<span class="more">Más</span><span class="less">Menos</span> preferencias de página'
+        seo_settings: Configuración de SEO
+        no_sections_found_please_add_one: Añade la primera sección de esta página haciendo clic en el botón <b>+ Añadir nueva Sección</b> arriba.
+        click_create_to_load_new_link: 'Haz clic en el botón <b>Crear</b> debajo para guardar tu nueva sección y poder así cargar su configuración.'
+        click_update_to_load_new_link: 'Haz clic en el botón <b>Actualizar</b> debajo para guardar la nueva configuración de la sección.'
+        settings_for: 'Opciones para: <b>%{section}</b>'
+        page_sections: 'Secciones de %{page_name}'
+        page_sections_info: 'El área abajo representa tu %{page_type} mostrada en %{store}, añade secciones y arrástralas a su posición deseada'
+        visible: Visible
+        side_by_side:
+          left_image: Imagen izquierda
+          right_image: Imagen derecha
+          image_info: 'Por favor utiliza una imagen con ratio 54:35 (1468px x 952px).'
+        image_gallery:
+          display_labels: Muestra etiquetas
+          image_a: Imagen A
+          image_b: Imagen B
+          image_c: Imagen C
+          layout_style: Estilo de Layout
+          square_image: Por favor utiliza una imagen con ratio 18:13 (1080px x 780px).
+          tall_image: Por favor utiliza una imagen con ratio 27:40 (1080px x 1600px).
       linkable:
         seach_for_a_page: Busca una página
       navigation:
@@ -1383,6 +1451,7 @@ es:
     product: Producto
     product_details: Detalles del producto
     product_has_no_description: Este producto no tiene descripción
+    product_name: Nombre del producto
     product_not_available_in_this_currency: Este producto no está disponible en la moneda seleccionada.
     product_properties: Propiedades del producto
     product_rule:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -902,7 +902,7 @@ es:
     customer_returns: Retornos del cliente
     customer_search: Búsqueda del Cliente
     customer_support_email: Correo de soporte al cliente
-    new_order_notifications_email: Nuevo correo de notificación de orden
+    new_order_notifications_email: Nuevo correo de notificación de pedidos
     cut: Cortar
     cvv: CVV
     cvv_response: Respuesta de Código de Seguridad
@@ -1003,6 +1003,8 @@ es:
     extension: Extensión
     extensions_directory: Agenda de extensiones
     existing_shipments: Envíos existentes
+    favicon: Favicono
+    favicon_upload_info: "Formato de archivo: PNG o ICO. Resolución: hasta 256px x 256px. Tamaño: hasta 1MB"
     facebook: Facebook
     failed_payment_attempts: Intentos fallidos de pago
     filename: Nombre de Fichero


### PR DESCRIPTION
This patch adds Spanish translations for the new CMS and Navigation sections that were added in Spree 4.3

**Navigation**
![image](https://user-images.githubusercontent.com/671550/148655950-05b901bf-1ee3-42d7-956f-57a5f9b5f7a9.png)

**CMS**
![image](https://user-images.githubusercontent.com/671550/148655966-ccccd8a6-5ecb-474c-b12a-403510fee9a3.png)

Ideally more improvements should be added, like being able to translate dropdown field options, but those require changing Spree Frontend first to make it possible.