### PR TITLE
Fix errors in de-CH translations

### DIFF
--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -302,25 +302,25 @@ de-CH:
       refund:
       save:
       update: Aktualisieren
-    activate: Activate
+    activate: Aktivieren
     active: Aktiv
     add: Hinzufügen
-    add_action_of_type: Add action of type
+    add_action_of_type:
     add_country: Land hinzufügen
     add_coupon_code:
-    add_new_header: Add New Header
-    add_new_style: Add New Style
+    add_new_header:
+    add_new_style:
     add_one:
-    add_option_value: Option Wert hinzufügen
+    add_option_value: Wert hinzufügen
     add_product: Produkt hinzufügen
     add_product_properties: Produkteigenschaft hinzufügen
-    add_rule_of_type: Add rule of type
+    add_rule_of_type:
     add_state: Kanton hinzufügen
     add_stock:
     add_stock_management:
     add_to_cart: In den Warenkorb
     add_variant:
-    additional_item: Additional Item Cost
+    additional_item:
     address1:
     address2:
     adjustable:
@@ -328,7 +328,7 @@ de-CH:
     adjustment_amount:
     adjustment_successfully_closed:
     adjustment_successfully_opened:
-    adjustment_total: Adjustment Total
+    adjustment_total:
     adjustments: Preis-Anpassungen
     admin:
       tab:
@@ -363,11 +363,11 @@ de-CH:
     all_adjustments_opened:
     all_departments: Alle Bereiche
     all_items_have_been_returned:
-    allow_ssl_in_development_and_test: Allow SSL to be used when in development and test modes
-    allow_ssl_in_production: Allow SSL to be used in production mode
-    allow_ssl_in_staging: Allow SSL to be used in staging mode
+    allow_ssl_in_development_and_test:
+    allow_ssl_in_production:
+    allow_ssl_in_staging:
     already_signed_up_for_analytics:
-    alt_text: Alternative Text
+    alt_text: Alternativer Text
     alternative_phone: Alternative Telefonnummer
     amount: Summe
     analytics_desc_header_1:
@@ -384,7 +384,7 @@ de-CH:
     are_you_sure: Sind Sie sicher
     are_you_sure_delete: Sind sie sicher, dass Sie diesen Eintrag löschen möchten?
     associated_adjustment_closed:
-    at_symbol: '@'
+    at_symbol: "@"
     authorization_failure: Anmeldung fehlgeschlagen
     authorized:
     auto_capture:
@@ -392,7 +392,7 @@ de-CH:
     average_order_value:
     avs_response:
     back: Zurück
-    back_end: Back End
+    back_end:
     back_to_payment:
     back_to_resource_list:
     back_to_rma_reason_list:
@@ -410,15 +410,15 @@ de-CH:
     billing_address: Rechnungsadresse
     both:
     calculated_reimbursements:
-    calculator: Rechner
-    calculator_settings_warning: Wenn Sie den Rechner-Typ ändern, müssen Sie erst speichern, bevor Sie die Rechner-Einstellungen bearbeiten können
+    calculator: Kalkulator
+    calculator_settings_warning: Wenn Sie den Kalkulator-Typ ändern, müssen Sie erst speichern, bevor Sie die Kalkulator-Einstellungen bearbeiten können
     cancel: verwerfen
     canceled_at:
     canceler:
     cannot_create_customer_returns:
-    cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
-    cannot_create_returns: Cannot create returns as this order has not shipped yet.
-    cannot_perform_operation: Cannot perform requested operation
+    cannot_create_payment_without_payment_methods:
+    cannot_create_returns:
+    cannot_perform_operation:
     cannot_set_shipping_method_without_address:
     capture: stornieren
     capture_events:
@@ -443,7 +443,7 @@ de-CH:
     clear_cache_ok:
     clear_cache_warning:
     click_and_drag_on_the_products_to_sort_them:
-    clone: Klonen
+    clone: Kopieren
     close:
     close_all_adjustments:
     code:
@@ -455,7 +455,7 @@ de-CH:
     confirm_delete: Löschen bestätigen
     confirm_password: Passwort bestätigen
     continue: Weitermachen
-    continue_shopping: Weiter Einkaufen
+    continue_shopping: Weiter einkaufen
     cost_currency:
     cost_price: Einkaufspreis
     could_not_connect_to_jirafe:
@@ -486,21 +486,21 @@ de-CH:
     create_new_order:
     create_reimbursement:
     created_at:
-    credit: Credit
+    credit: Kredit
     credit_card: Kreditkarte
-    credit_cards: Credit Cards
-    credit_owed: Credit Owed
+    credit_cards: Kreditkarten
+    credit_owed:
     credits:
     currency:
     currency_decimal_mark:
     currency_settings:
     currency_symbol_position:
     currency_thousands_separator:
-    current: Stand
+    current:
     current_promotion_usage:
     customer: Kunde
     customer_details: Kundenangaben
-    customer_details_updated: The customer's details have been updated.
+    customer_details_updated:
     customer_return:
     customer_returns:
     customer_search: Kundensuche
@@ -564,7 +564,7 @@ de-CH:
     empty_cart: Warenkorb leeren
     enable_mail_delivery: Mailversand einschalten
     end:
-    ending_in: Ending in
+    ending_in:
     environment: Umgebung
     error: Fehler
     errors:
@@ -629,7 +629,7 @@ de-CH:
       available_locales:
       language:
       localization_settings:
-      this_file_language: Deutsch (de-CH)
+      this_file_language: Deutsch Schweiz (de-CH)
     icon:
     identifier:
     image: Bild
@@ -732,7 +732,7 @@ de-CH:
     new_order: Neue Bestellung
     new_order_completed:
     new_payment: Neue Bezahlung
-    new_payment_method: New Payment Method
+    new_payment_method:
     new_product: Neues Produkt
     new_promotion: Neue Promotion
     new_promotion_category:
@@ -792,11 +792,11 @@ de-CH:
     option_type_placeholder:
     option_types: Optionen
     option_value:
-    option_values: Optionswalues
+    option_values: Optionswerte
     optional:
     options: Optionen
     or: oder
-    or_over_price: "%{price} or over"
+    or_over_price:
     order: Bestellung
     order_adjustments:
     order_already_updated:
@@ -827,16 +827,16 @@ de-CH:
     order_resumed:
     order_state:
       address: Adresse
-      awaiting_return: awaiting return
+      awaiting_return: Retoure erwartet
       canceled: Abgebrochen
       cart: Warenkorb
       complete: Abgeschlossen
       confirm: Bestätigt
-      considered_risky:
+      considered_risky: Riskant
       delivery: Versendet
       payment: Bezahlt
-      resumed: resumed
-      returned: returned
+      resumed: Wieder aufgenommen
+      returned: Zurückerstattet
     order_summary: Bestellübersicht
     order_sure_want_to: Sind Sie sicher, dass Sie diese Bestellung %{event} möchten?
     order_total: Gesamtsumme
@@ -863,18 +863,18 @@ de-CH:
     payment_methods: Zahlungsmethoden
     payment_processing_failed:
     payment_processor_choose_banner_text:
-    payment_processor_choose_link: our payments page
+    payment_processor_choose_link:
     payment_state: Bezahlstatus
     payment_states:
-      balance_due: fällig
+      balance_due:
       checkout:
       completed:
-      credit_owed: credit owed
-      failed: failed
-      paid: bezahlt
-      pending: ausstehend
-      processing: processing
-      void: void
+      credit_owed:
+      failed:
+      paid:
+      pending:
+      processing:
+      void:
     payment_updated:
     payments: Zahlungen
     pending:
@@ -967,7 +967,7 @@ de-CH:
     propagate_all_variants:
     properties: Eigenschaften
     property: Eigenschaft
-    prototype: Prototype
+    prototype: Prototyp
     prototypes: Prototypen
     provider:
     provider_settings_warning:
@@ -1046,7 +1046,7 @@ de-CH:
     roles: Rollen
     rules:
     safe:
-    sales_total: Umsatz Gesamt
+    sales_total: Gesamtumsatz
     sales_total_description:
     sales_totals:
     save_and_continue: Speichern und fortsetzen
@@ -1108,7 +1108,7 @@ de-CH:
     shipping_methods: Versandarten
     shipping_price_sack:
     shipping_total:
-    shop_by_taxonomy: "%{taxonomy} einkaufen"
+    shop_by_taxonomy:
     shopping_cart: Warenkorb
     show: Zeigen
     show_active:


### PR DESCRIPTION
Hey @damianlegawiec here's just a quick fix for some of the most glaring errors in the Swiss German (`de-CH`) translations. There are quite a bunch of english terms, which overwrite the correct translations in `de`.

We'd appreciate a quick merge, as we have a hard time overwriting these errors locally with the way we manage `de` vs `de-CH` in our project.