### PR TITLE
Fixed a wrong translation in fr.yml

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1019,7 +1019,7 @@ fr:
     destination: Destination
     destroy: Supprimer
     details: Détails
-    discontinue_on: Posté sur
+    discontinue_on: "Disponible jusqu'au"
     discontinued: Discontinué
     discontinued_variants_present: Certains éléments de campagne de cette campagne contiennent des produits qui ne sont plus disponibles.
     discount_amount: Montant de la réduction

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -153,7 +153,7 @@ fr:
         cost_price: Prix d'achat
         depth: Profondeur
         description: Description
-        discontinue_on: Posté sur
+        discontinue_on: "Disponible jusqu'au"
         height: Hauteur
         less_than: Moins que
         master_price: Prix de départ


### PR DESCRIPTION
Discontinue_on was translated as "Posté sur" which... actually doesn't mean anything for a date. 
I replaced it with "Displonible jusqu'au" which is more appropriate.