### PR TITLE
fix: mailer line break translation

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1187,13 +1187,13 @@ es:
       subtotal: ! 'Subtotal:'
       total: ! 'Total del pedido:'
       cancel_email:
-        dear_customer: Estimado cliente,\n
+        dear_customer: Estimado cliente, %{name}
         instructions: Tu pedido ha sido CANCELADO. Por favor conserva esta información de cancelación para tus registros.
         order_summary_canceled: Resumen de pedido [CANCELADO]
         subject: Cancelación de pedido
         thanks: Gracias por hacer negocios.
       confirm_email:
-        dear_customer: Estimado Cliente,\n
+        dear_customer: Estimado Cliente, %{name}
         instructions: Por favor, revisa y conserva la siguiente información del pedido de tus registros.
         order_summary: Resumen del pedido
         subject: Confirmación del pedido
@@ -1529,7 +1529,7 @@ es:
     shipment_details: Detalles de Envío
     shipment_mailer:
       shipped_email:
-        dear_customer: Estimado Cliente,\n
+        dear_customer: Estimado Cliente, %{name}
         instructions: Su pedido ha sido enviado
         shipment_summary: Resumen del envío
         shipping_method: "Método de envío: %{shipping_method}"


### PR DESCRIPTION
* Fix mailer translations to show name instead of \n

before: 
![image](https://github.com/spree-contrib/spree_i18n/assets/27829678/d9623ceb-2b8b-4f06-9a0d-3b8bd961dfee)

after: 
![image](https://github.com/spree-contrib/spree_i18n/assets/27829678/1ffd3e7b-0f2e-492b-b15d-0577a1c018e1)
